### PR TITLE
fix: AI import swap targets + OOB handling for policy and compliance …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -502,3 +502,20 @@ This is not optional — UI changes without visual verification have repeatedly 
 **20. `thread_id` column is legacy — do not write to it:** The `activity_log.thread_id` column exists for backwards compatibility but is no longer written to. New activities get `NULL` thread_id. The auto-clustered activity timeline (grouped by `activity_cluster_days` time gap) replaces the old manual COR correspondence threading. COR search in ref_lookup still works for old data.
 
 **21. NEVER force-remove worktrees without checking for uncommitted work:** Before removing ANY worktree, run `git -C <worktree-path> status` to check for uncommitted changes. If there are uncommitted changes, STOP and ask the user. Never batch-remove worktrees. When user says "clean up" or "merge all", explicitly ask which branches are still actively being worked on. Assume worktrees have active work unless confirmed otherwise. This rule exists because force-removing an active worktree destroyed in-progress uncommitted work with no recovery path.
+
+**22. Worktree edits require `pip install -e .` for server visibility:** When working in a git worktree, template/code edits are NOT visible to the running `policydb serve` unless the package is installed in editable mode (`pip install -e .`) from the worktree directory. The server uses the installed package — if it was installed from the main repo, it reads templates from there, not the worktree. Always run `pip install -e .` from the worktree before starting the dev server.
+
+**23. `fetch()` bypasses HTMX OOB swap processing:** When using `fetch()` + `innerHTML` instead of `htmx.ajax()` (e.g. to inspect HTTP status codes for error handling), `hx-swap-oob` attributes in the response HTML are NOT processed. You must manually extract OOB elements from the response, find their targets by ID, and swap their innerHTML before setting the main target content. Pattern:
+```javascript
+var temp = document.createElement('div');
+temp.innerHTML = html;
+temp.querySelectorAll('[hx-swap-oob]').forEach(function(el) {
+    var target = document.getElementById(el.id);
+    if (target) target.innerHTML = el.innerHTML;
+    el.remove();
+});
+mainTarget.innerHTML = temp.innerHTML;
+htmx.process(mainTarget);
+```
+
+**24. HTMX swap targets must exist before the response arrives:** When a slideover/panel triggers a `fetch()` that swaps content into a page element (e.g. `#ai-import-target`), the target element must have a stable ID in the page template. If the swap target is dynamically created or inside lazy-loaded content, verify it exists at swap time. Missing targets silently fail — the response HTML is fetched but never displayed.

--- a/src/policydb/web/routes/compliance.py
+++ b/src/policydb/web/routes/compliance.py
@@ -153,6 +153,7 @@ def ai_import_prompt(
         "json_template": json_template,
         "context_display": context_display,
         "parse_url": parse_url,
+        "import_target": "#review-mode-container",
     })
 
 

--- a/src/policydb/web/templates/_ai_import_panel.html
+++ b/src/policydb/web/templates/_ai_import_panel.html
@@ -243,10 +243,31 @@ function submitAiImport() {
                 errorDiv.innerHTML = html;
                 errorDiv.style.display = '';
             } else {
-                /* Success — swap into target and close panel */
+                /* Success — extract OOB elements first, then swap main content */
+                var temp = document.createElement('div');
+                temp.innerHTML = html;
+
+                /* Process hx-swap-oob elements manually (fetch bypasses HTMX OOB) */
+                var oobEls = temp.querySelectorAll('[hx-swap-oob]');
+                oobEls.forEach(function(el) {
+                    var targetEl = document.getElementById(el.id);
+                    if (targetEl) targetEl.innerHTML = el.innerHTML;
+                    el.remove();
+                });
+
+                /* Swap remaining content into target */
                 var target = document.querySelector(importTarget);
-                if (target) target.innerHTML = html;
-                htmx.process(target);
+                if (target) {
+                    target.innerHTML = temp.innerHTML;
+                    htmx.process(target);
+                }
+
+                /* Open parent <details> if collapsed (compliance review mode) */
+                if (target) {
+                    var details = target.closest('details');
+                    if (details && !details.open) details.open = true;
+                }
+
                 closeAiImport();
             }
         });

--- a/src/policydb/web/templates/policies/edit.html
+++ b/src/policydb/web/templates/policies/edit.html
@@ -87,7 +87,7 @@
       {% if total %}<span class="tab-badge">{{ done }}/{{ total }}</span>{% endif %}
     </button>
   </div>
-  <div class="tab-content">
+  <div class="tab-content" id="ai-import-target">
     <div class="py-4 text-sm text-gray-400 text-center">Loading…</div>
   </div>
 </div>


### PR DESCRIPTION
…flows

- Add id="ai-import-target" to policy edit tab-content div so parse response can swap into it
- Set import_target="#review-mode-container" on compliance prompt route so compliance parse swaps into the correct container
- Rewrite submitAiImport() JS to manually extract hx-swap-oob elements before innerHTML swap (fetch() bypasses HTMX OOB processing)
- Auto-open parent <details> after compliance import swap
- Add lessons learned #22-24 to CLAUDE.md (worktree pip install, fetch vs htmx OOB, swap target existence)