### PR TITLE
Fix compose slideover leaving page unscrollable after dismiss

### DIFF
--- a/src/policydb/web/templates/_compose_slideover.html
+++ b/src/policydb/web/templates/_compose_slideover.html
@@ -258,6 +258,7 @@
     var panel = document.getElementById('compose-panel');
     if (backdrop) backdrop.remove();
     if (panel) panel.remove();
+    document.body.style.overflow = '';
   };
 
   // Initialize preview on load


### PR DESCRIPTION
## Changes

- Restore `document.body.overflow` style when closing the compose slideover panel
- Ensures the page remains scrollable after dismissing the compose dialog

## Details

When the compose slideover is dismissed, the backdrop and panel elements are removed from the DOM. However, the `overflow` style property on the body was not being reset, leaving the page in an unscrollable state. This fix restores the overflow style to its default value.