### PR TITLE
Fix: pulse follow-up date, project log contacts, reconcile programs

### DIFF
--- a/src/policydb/web/routes/clients.py
+++ b/src/policydb/web/routes/clients.py
@@ -452,6 +452,18 @@ def client_tab_overview(request: Request, client_id: int, conn=Depends(get_db)):
                AND follow_up_date IS NOT NULL AND follow_up_date < date('now')
            )""", (client_id, client_id)
     ).fetchone()[0]
+    # Next upcoming follow-up date (earliest pending across activities + policies)
+    pulse_next_followup = conn.execute(
+        """SELECT MIN(fu) FROM (
+             SELECT MIN(follow_up_date) AS fu FROM activity_log
+             WHERE client_id=? AND follow_up_done=0 AND follow_up_date >= date('now')
+             UNION ALL
+             SELECT MIN(follow_up_date) AS fu FROM policies
+             WHERE client_id=? AND archived=0 AND (is_opportunity=0 OR is_opportunity IS NULL)
+               AND follow_up_date IS NOT NULL AND follow_up_date >= date('now')
+           )""", (client_id, client_id)
+    ).fetchone()[0]
+
     _risks_for_pulse = conn.execute("SELECT severity FROM client_risks WHERE client_id=?", (client_id,)).fetchall()
     pulse_high_risks = sum(1 for r in _risks_for_pulse if r["severity"] in ("High", "Critical"))
 
@@ -478,6 +490,7 @@ def client_tab_overview(request: Request, client_id: int, conn=Depends(get_db)):
         "client_scratchpad_updated": _scratch["updated_at"] if _scratch else "",
         "client_saved_notes": get_saved_notes(conn, "client", client_id),
         "pulse_overdue": pulse_overdue,
+        "pulse_next_followup": pulse_next_followup,
         "pulse_milestone_done": pulse_milestone_done,
         "pulse_milestone_total": pulse_milestone_total,
         "pulse_high_risks": pulse_high_risks,
@@ -1350,6 +1363,7 @@ def client_detail(request: Request, client_id: int, add_contact: str = "", conn=
         "linked_group": linked_group,
         "linked_relationships": cfg.get("linked_account_relationships", []),
         "pulse_overdue": pulse_overdue,
+        "pulse_next_followup": next_followup_date,
         "pulse_milestone_done": pulse_milestone_done,
         "pulse_milestone_total": pulse_milestone_total,
         "pulse_high_risks": pulse_high_risks,
@@ -3134,22 +3148,31 @@ def project_delete(
     return HTMLResponse("", headers={"HX-Redirect": f"/clients/{client_id}"})
 
 
+def _project_contacts(conn, client_id: int, project: str) -> list[dict]:
+    """Get all contacts relevant to a project: policy-assigned + client-level."""
+    rows = conn.execute(
+        """SELECT DISTINCT co.id, co.name FROM (
+             SELECT co2.id, co2.name FROM contact_policy_assignments cpa
+               JOIN contacts co2 ON cpa.contact_id = co2.id
+               JOIN policies p ON cpa.policy_id = p.id
+               WHERE p.client_id = ? AND LOWER(TRIM(COALESCE(p.project_name,''))) = LOWER(TRIM(?))
+                 AND co2.name IS NOT NULL AND TRIM(co2.name) != '' AND p.archived = 0
+             UNION
+             SELECT co3.id, co3.name FROM contact_client_assignments cca
+               JOIN contacts co3 ON cca.contact_id = co3.id
+               WHERE cca.client_id = ? AND co3.name IS NOT NULL AND TRIM(co3.name) != ''
+           ) co ORDER BY co.name""",
+        (client_id, project, client_id),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
 @router.get("/{client_id}/project/log-form", response_class=HTMLResponse)
 def project_log_form(request: Request, client_id: int, project: str, conn=Depends(get_db)):
     """HTMX partial: inline activity log form for all policies in a project."""
     ctx = _project_note_ctx(conn, client_id, project)
     ctx["activity_types"] = cfg.get("activity_types")
-    # Get contacts for datalist
-    contacts = conn.execute(
-        """SELECT DISTINCT co.name FROM contact_policy_assignments cpa
-           JOIN contacts co ON cpa.contact_id = co.id
-           JOIN policies p ON cpa.policy_id = p.id
-           WHERE p.client_id = ? AND LOWER(TRIM(COALESCE(p.project_name,''))) = LOWER(TRIM(?))
-             AND co.name IS NOT NULL AND TRIM(co.name) != '' AND p.archived = 0
-           ORDER BY co.name""",
-        (client_id, project),
-    ).fetchall()
-    ctx["contacts"] = [dict(r) for r in contacts]
+    ctx["contacts"] = _project_contacts(conn, client_id, project)
     return templates.TemplateResponse("clients/_project_log_form.html", {"request": request, **ctx})
 
 
@@ -3163,6 +3186,7 @@ def project_log_save(
     subject: str = Form(...),
     details: str = Form(""),
     follow_up_date: str = Form(""),
+    follow_up_scope: str = Form("all"),
     duration_hours: str = Form(""),
     conn=Depends(get_db),
 ):
@@ -3171,7 +3195,8 @@ def project_log_save(
     policies = conn.execute(
         """SELECT id FROM policies
            WHERE client_id = ? AND LOWER(TRIM(COALESCE(project_name,''))) = LOWER(TRIM(?))
-             AND archived = 0""",
+             AND archived = 0
+           ORDER BY id""",
         (client_id, project_name),
     ).fetchall()
     account_exec = cfg.get("default_account_exec", "")
@@ -3182,35 +3207,44 @@ def project_log_save(
         except ValueError:
             dur = None
     today = date.today().isoformat()
+
+    # Resolve contact_person → contact_id
+    _contact_id = None
+    if contact_person and contact_person.strip():
+        _row = conn.execute(
+            "SELECT id FROM contacts WHERE LOWER(TRIM(name))=LOWER(TRIM(?))",
+            (contact_person.strip(),),
+        ).fetchone()
+        if _row:
+            _contact_id = _row["id"]
+
+    # follow_up_scope: "all" = set follow-up on every policy, "lead" = only the first
+    _fu_date_for = follow_up_date if follow_up_date else None
     count = 0
-    for p in policies:
+    for i, p in enumerate(policies):
+        # Only set follow-up on first policy if scope is "lead"
+        row_fu = _fu_date_for if (follow_up_scope == "all" or i == 0) else None
         conn.execute(
             """INSERT INTO activity_log
                (activity_date, client_id, policy_id, activity_type, contact_person,
-                subject, details, follow_up_date, duration_hours, account_exec)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                contact_id, subject, details, follow_up_date, duration_hours, account_exec)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (today, client_id, p["id"], activity_type, contact_person or None,
-             subject, details or None, follow_up_date or None, dur, account_exec),
+             _contact_id, subject, details or None, row_fu, dur, account_exec),
         )
-        if follow_up_date:
+        if row_fu:
             from policydb.queries import supersede_followups
-            supersede_followups(conn, p["id"], follow_up_date)
+            supersede_followups(conn, p["id"], row_fu)
         count += 1
     conn.commit()
-    # Return the log form again with a success banner so user can continue editing
+    # Return the log form again with a success banner
     ctx = _project_note_ctx(conn, client_id, project_name)
     ctx["activity_types"] = cfg.get("activity_types")
-    contacts = conn.execute(
-        """SELECT DISTINCT co.name FROM contact_policy_assignments cpa
-           JOIN contacts co ON cpa.contact_id = co.id
-           JOIN policies p ON cpa.policy_id = p.id
-           WHERE p.client_id = ? AND LOWER(TRIM(COALESCE(p.project_name,''))) = LOWER(TRIM(?))
-             AND co.name IS NOT NULL AND TRIM(co.name) != '' AND p.archived = 0
-           ORDER BY co.name""",
-        (client_id, project_name),
-    ).fetchall()
-    ctx["contacts"] = [dict(r) for r in contacts]
-    ctx["log_success"] = f'Logged to {count} polic{"y" if count == 1 else "ies"} in {project_name}'
+    ctx["contacts"] = _project_contacts(conn, client_id, project_name)
+    fu_note = ""
+    if _fu_date_for and follow_up_scope == "lead":
+        fu_note = " (follow-up on lead policy only)"
+    ctx["log_success"] = f'Logged to {count} polic{"y" if count == 1 else "ies"} in {project_name}{fu_note}'
     return templates.TemplateResponse("clients/_project_log_form.html", {"request": request, **ctx})
 
 

--- a/src/policydb/web/routes/reconcile.py
+++ b/src/policydb/web/routes/reconcile.py
@@ -65,6 +65,19 @@ def _cache_cleanup():
             del _PARSED_CACHE[k]
 
 
+def _get_program_summary(token: str) -> dict:
+    """Reconstruct program_summary from cached board state."""
+    cache = _BOARD_CACHE.get(token)
+    if not cache:
+        return {}
+    results, extras, db_rows, ts = cache
+    carrier_map = {}
+    for r in db_rows:
+        if r.get("is_program") and r.get("_program_carrier_rows"):
+            carrier_map[r["id"]] = r["_program_carrier_rows"]
+    return program_reconcile_summary(results + extras, carrier_map=carrier_map)
+
+
 def _render_counters(summary: dict) -> str:
     """Build OOB counter HTML matching the board-counters div in _pairing_board.html."""
     return (
@@ -879,6 +892,33 @@ def reconcile_confirm_all(request: Request, token: str = Form("")):
         "today": date.today().isoformat(),
         "field_display": _FIELD_DISPLAY,
         "policy_types": cfg.get("policy_types", []),
+        "program_summary": _get_program_summary(token),
+    })
+
+
+@router.post("/confirm-all-programs", response_class=HTMLResponse)
+def reconcile_confirm_all_programs(request: Request, token: str = Form("")):
+    """Confirm all program-matched paired rows regardless of score. Re-renders entire board."""
+    cache = _BOARD_CACHE.get(token)
+    if not cache:
+        return HTMLResponse('<div class="text-xs text-red-500 p-2">Session expired. Please re-run reconciliation.</div>')
+    results, extras, db_rows, ts = cache
+    confirmed_count = 0
+    for row in results:
+        if row.status == "PAIRED" and not row.confirmed and row.is_program_match:
+            row.confirmed = True
+            confirmed_count += 1
+    summary = summarize(results + extras)
+    return templates.TemplateResponse("reconcile/_pairing_board.html", {
+        "request": request,
+        "results": results,
+        "extras": extras,
+        "token": token,
+        "summary": summary,
+        "today": date.today().isoformat(),
+        "field_display": _FIELD_DISPLAY,
+        "policy_types": cfg.get("policy_types", []),
+        "program_summary": _get_program_summary(token),
     })
 
 
@@ -1628,6 +1668,7 @@ def reconcile_all(request: Request, token: str = Form(""), conn=Depends(get_db))
         "today": date.today().isoformat(),
         "field_display": _FIELD_DISPLAY,
         "policy_types": cfg.get("policy_types", []),
+        "program_summary": _get_program_summary(token),
     }).body.decode()
 
     return HTMLResponse(learn_banner + board_html)

--- a/src/policydb/web/templates/clients/_account_pulse.html
+++ b/src/policydb/web/templates/clients/_account_pulse.html
@@ -34,6 +34,15 @@
           {% endif %}
         </li>
         <li class="flex items-center gap-2">
+          {% if pulse_next_followup %}
+          <span class="w-1.5 h-1.5 rounded-full bg-blue-500"></span>
+          <span class="text-gray-600">Next follow-up <span class="font-medium text-blue-700">{{ pulse_next_followup }}</span></span>
+          {% else %}
+          <span class="w-1.5 h-1.5 rounded-full bg-gray-300"></span>
+          <span class="text-gray-400">No upcoming follow-ups</span>
+          {% endif %}
+        </li>
+        <li class="flex items-center gap-2">
           {% if summary.next_renewal_days is not none %}
             {% if summary.next_renewal_days <= 30 %}
             <span class="w-1.5 h-1.5 rounded-full bg-red-500"></span>

--- a/src/policydb/web/templates/clients/_project_log_form.html
+++ b/src/policydb/web/templates/clients/_project_log_form.html
@@ -35,9 +35,23 @@
       </div>
       <div>
         <p class="text-xs text-gray-500 mb-0.5">Follow-Up Date</p>
-        <input type="date" name="follow_up_date"
-          class="border border-gray-300 rounded px-2 py-1 text-xs w-full focus:outline-none focus:ring-1 focus:ring-marsh">
+        <input type="date" name="follow_up_date" id="proj-fu-date"
+          class="border border-gray-300 rounded px-2 py-1 text-xs w-full focus:outline-none focus:ring-1 focus:ring-marsh"
+          onchange="document.getElementById('fu-scope-row').style.display = this.value ? '' : 'none'">
       </div>
+    </div>
+
+    {# Follow-up scope — only visible when a follow-up date is set #}
+    <div id="fu-scope-row" class="flex items-center gap-4 text-xs text-gray-600" style="display:none">
+      <span class="text-gray-500 font-medium">Follow-up applies to:</span>
+      <label class="flex items-center gap-1 cursor-pointer">
+        <input type="radio" name="follow_up_scope" value="lead" checked class="accent-green-600">
+        Lead policy only
+      </label>
+      <label class="flex items-center gap-1 cursor-pointer">
+        <input type="radio" name="follow_up_scope" value="all" class="accent-green-600">
+        All {{ policy_count }} policies
+      </label>
     </div>
 
     <div class="grid grid-cols-4 gap-2">

--- a/src/policydb/web/templates/reconcile/_pairing_board.html
+++ b/src/policydb/web/templates/reconcile/_pairing_board.html
@@ -33,6 +33,51 @@
   <span class="text-xs text-gray-400">{{ summary.total }} total rows</span>
 </div>
 
+{# ── Program Summary (if any programs were matched) ────────────────────────── #}
+{% if program_summary %}
+<div class="mb-4 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3">
+  <div class="flex items-center justify-between mb-2">
+    <h3 class="text-xs font-semibold text-blue-800 uppercase tracking-wide">Program Reconciliation</h3>
+    {# Count unconfirmed program rows #}
+    {% set ns = namespace(unconfirmed_pgm=0) %}
+    {% for r in results if r.is_program_match and r.status == 'PAIRED' and not r.confirmed %}
+      {% set ns.unconfirmed_pgm = ns.unconfirmed_pgm + 1 %}
+    {% endfor %}
+    {% if ns.unconfirmed_pgm > 0 %}
+    <button type="button"
+      hx-post="/reconcile/confirm-all-programs"
+      hx-include="[name=token]"
+      hx-target="#pairing-board"
+      hx-swap="innerHTML"
+      class="text-xs bg-blue-600 hover:bg-blue-700 text-white font-medium px-3 py-1.5 rounded-lg transition-colors">
+      Okay All Program Matches ({{ ns.unconfirmed_pgm }})
+    </button>
+    {% else %}
+    <span class="text-xs text-green-600 font-medium">All program matches confirmed</span>
+    {% endif %}
+  </div>
+  <div class="space-y-2">
+    {% for uid, pgm in program_summary.items() %}
+    <div class="flex items-center gap-3 text-xs">
+      <span class="font-medium text-blue-900">{{ pgm.policy_type or 'Program' }}</span>
+      <span class="text-blue-500">&middot;</span>
+      <span class="text-blue-700">{{ pgm.matched_count }}/{{ pgm.carrier_count }} carriers matched</span>
+      <span class="text-blue-500">&middot;</span>
+      <span class="tabular-nums {% if pgm.fully_reconciled %}text-green-700{% else %}text-amber-700{% endif %}">
+        {{ pgm.matched_premium | currency }} of {{ pgm.total_premium | currency }}
+      </span>
+      {% if pgm.fully_reconciled %}
+      <span class="text-green-600 font-medium">&#10003; Reconciled</span>
+      {% elif pgm.new_carriers %}
+      <span class="text-amber-600 font-medium">{{ pgm.new_carriers | length }} new carrier{{ 's' if pgm.new_carriers | length != 1 else '' }}</span>
+      {% endif %}
+      <a href="/policies/{{ uid }}/edit" class="text-blue-500 hover:underline ml-auto font-mono">{{ uid }}</a>
+    </div>
+    {% endfor %}
+  </div>
+</div>
+{% endif %}
+
 {# ── Toolbar ────────────────────────────────────────────────────────────────── #}
 <div class="flex flex-wrap items-center gap-3 mb-4 no-print">
   {# Confirm All #}


### PR DESCRIPTION
## Summary
- **#36** — Account Pulse now shows the next upcoming follow-up date (earliest pending across activities + policies)
- **#26** — Project/location activity logging: expanded contact query to include client-level contacts, resolves `contact_id`, added follow-up scope toggle (lead policy only vs all)
- **#37** — Reconciliation pairing board displays program summary panel with carrier match counts + premium status, added "Okay All Program Matches" bulk confirm button

## Test plan
- [ ] Open a client detail page → verify Account Pulse shows "Next follow-up" date or "No upcoming follow-ups"
- [ ] Open a client with a project → click "+ Log" → verify Contact Person datalist includes client-level contacts
- [ ] Set a follow-up date in project log form → verify scope toggle appears (Lead policy only / All policies)
- [ ] Run a reconciliation with program policies → verify program summary panel appears above toolbar
- [ ] Click "Okay All Program Matches" → verify all program-matched rows are confirmed

Closes #36, closes #26, closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)