### PR TITLE
feat: expand AI import with COPE, location & tower data

### DIFF
--- a/src/policydb/email_templates.py
+++ b/src/policydb/email_templates.py
@@ -167,6 +167,15 @@ def policy_context(conn: sqlite3.Connection, policy_uid: str) -> dict:
         ctx["program_carriers"] = ""
         ctx["program_carrier_count"] = ""
 
+    # COPE data from linked location
+    cope_data: dict = {}
+    if row["project_id"]:
+        _cope_row = conn.execute(
+            "SELECT * FROM cope_data WHERE project_id = ?", (row["project_id"],)
+        ).fetchone()
+        if _cope_row:
+            cope_data = dict(_cope_row)
+
     ctx.update({
         "policy_type": row["policy_type"] or "",
         "carrier": row["carrier"] or "",
@@ -196,6 +205,16 @@ def policy_context(conn: sqlite3.Connection, policy_uid: str) -> dict:
             policy_uid=row["policy_uid"] or "",
             project_id=row["project_id"] or 0,
         ),
+        # COPE tokens
+        "construction_type": cope_data.get("construction_type", ""),
+        "year_built": str(cope_data.get("year_built", "")) if cope_data.get("year_built") else "",
+        "stories": str(cope_data.get("stories", "")) if cope_data.get("stories") else "",
+        "sq_footage": str(int(cope_data["sq_footage"])) if cope_data.get("sq_footage") else "",
+        "sprinklered": cope_data.get("sprinklered", ""),
+        "roof_type": cope_data.get("roof_type", ""),
+        "occupancy_description": cope_data.get("occupancy_description", ""),
+        "protection_class": cope_data.get("protection_class", ""),
+        "total_insurable_value": _fmt_currency(cope_data.get("total_insurable_value")),
     })
     return ctx
 
@@ -544,6 +563,17 @@ CONTEXT_TOKEN_GROUPS: dict[str, list[tuple[str, list[tuple[str, str]]]]] = {
             ("team_emails", "Team Emails (list)"),
             ("placement_colleagues", "Placement Colleagues (list)"),
             ("placement_emails", "Placement Emails (list)"),
+        ]),
+        ("COPE", [
+            ("construction_type", "Construction Type"),
+            ("year_built", "Year Built"),
+            ("stories", "Stories"),
+            ("sq_footage", "Square Footage"),
+            ("sprinklered", "Sprinklered"),
+            ("roof_type", "Roof Type"),
+            ("occupancy_description", "Occupancy"),
+            ("protection_class", "Protection Class"),
+            ("total_insurable_value", "Total Insurable Value"),
         ]),
         ("Follow-up", [
             ("subject", "Follow-Up Subject"),

--- a/src/policydb/llm_schemas.py
+++ b/src/policydb/llm_schemas.py
@@ -43,12 +43,154 @@ NORMALIZER_REGISTRY: dict[str, callable] = {
 }
 
 # ---------------------------------------------------------------------------
+# Shared Field Definitions — reused across policy and compliance schemas
+# ---------------------------------------------------------------------------
+
+COPE_FIELDS: list[dict] = [
+    {
+        "key": "construction_type",
+        "label": "Construction Type",
+        "type": "string",
+        "required": False,
+        "description": "Building construction classification",
+        "config_values": "construction_types",
+        "config_mode": "prefer",
+        "example": "Fire Resistive",
+    },
+    {
+        "key": "year_built",
+        "label": "Year Built",
+        "type": "number",
+        "required": False,
+        "description": "Year the structure was built or last renovated",
+        "example": "2005",
+    },
+    {
+        "key": "stories",
+        "label": "Number of Stories",
+        "type": "number",
+        "required": False,
+        "description": "Number of stories in the building",
+        "example": "3",
+    },
+    {
+        "key": "sq_footage",
+        "label": "Square Footage",
+        "type": "number",
+        "required": False,
+        "description": "Total square footage of the building",
+        "example": "45000",
+    },
+    {
+        "key": "sprinklered",
+        "label": "Sprinkler Status",
+        "type": "string",
+        "required": False,
+        "description": "Whether the building has sprinkler protection",
+        "config_values": "sprinkler_options",
+        "config_mode": "strict",
+        "example": "Yes",
+    },
+    {
+        "key": "roof_type",
+        "label": "Roof Type",
+        "type": "string",
+        "required": False,
+        "description": "Type or material of the roof",
+        "config_values": "roof_types",
+        "config_mode": "prefer",
+        "example": "TPO Membrane",
+    },
+    {
+        "key": "occupancy_description",
+        "label": "Occupancy Description",
+        "type": "string",
+        "required": False,
+        "description": "Description of how the building is occupied or used",
+        "example": "Office space, ground floor retail",
+    },
+    {
+        "key": "protection_class",
+        "label": "Protection Class",
+        "type": "string",
+        "required": False,
+        "description": "ISO protection class rating",
+        "config_values": "protection_classes",
+        "config_mode": "prefer",
+        "example": "3",
+    },
+    {
+        "key": "total_insurable_value",
+        "label": "Total Insurable Value",
+        "type": "number",
+        "required": False,
+        "description": "Total insurable value of the property (building + contents + BI)",
+        "normalizer": "parse_currency_with_magnitude",
+        "example": "12500000",
+    },
+]
+
+LOCATION_FIELDS: list[dict] = [
+    {
+        "key": "name",
+        "label": "Location / Building Name",
+        "type": "string",
+        "required": False,
+        "description": "Name or label for the location or building",
+        "example": "Main Office",
+    },
+    {
+        "key": "address",
+        "label": "Street Address",
+        "type": "string",
+        "required": False,
+        "description": "Street address of the location",
+        "example": "123 Main St",
+    },
+    {
+        "key": "city",
+        "label": "City",
+        "type": "string",
+        "required": False,
+        "description": "City",
+        "normalizer": "format_city",
+        "example": "Austin",
+    },
+    {
+        "key": "state",
+        "label": "State",
+        "type": "string",
+        "required": False,
+        "description": "State code",
+        "normalizer": "format_state",
+        "example": "TX",
+    },
+    {
+        "key": "zip",
+        "label": "ZIP Code",
+        "type": "string",
+        "required": False,
+        "description": "ZIP code",
+        "normalizer": "format_zip",
+        "example": "78701",
+    },
+    {
+        "key": "notes",
+        "label": "Location Notes",
+        "type": "string",
+        "required": False,
+        "description": "Special conditions, building characteristics, or other notes about this location",
+        "example": "24hr security, backup generator",
+    },
+]
+
+# ---------------------------------------------------------------------------
 # Policy Extraction Schema
 # ---------------------------------------------------------------------------
 
 POLICY_EXTRACTION_SCHEMA: dict = {
     "name": "policy_extraction",
-    "version": 1,
+    "version": 2,
     "description": (
         "Extract policy details from a certificate of insurance, "
         "declaration page, binder, or quote document"
@@ -171,8 +313,25 @@ POLICY_EXTRACTION_SCHEMA: dict = {
             "label": "Layer Position",
             "type": "string",
             "required": False,
-            "description": "Position in the tower (e.g. Primary, 1st Excess, Umbrella)",
+            "description": (
+                "Position in the insurance tower. Use 'Primary' for ground-up coverage, "
+                "'1st Excess' / '2nd Excess' etc. for layers above primary, "
+                "'Umbrella' for umbrella policies. If the document says 'excess of' "
+                "a specific limit, this is an excess layer."
+            ),
             "example": "Primary",
+        },
+        {
+            "key": "tower_group",
+            "label": "Tower / Program Group",
+            "type": "string",
+            "required": False,
+            "description": (
+                "Name of the tower or layered program this policy belongs to "
+                "(e.g. 'GL Tower', 'Property Program'). Group policies that stack "
+                "on top of each other under the same tower group name."
+            ),
+            "example": "GL Tower",
         },
         {
             "key": "commission_rate",
@@ -289,7 +448,11 @@ POLICY_EXTRACTION_SCHEMA: dict = {
             "label": "Attachment Point",
             "type": "number",
             "required": False,
-            "description": "Dollar amount where excess coverage attaches above underlying",
+            "description": (
+                "Dollar amount where excess/umbrella coverage begins (attaches above underlying). "
+                "For example, if a policy says 'excess of $1,000,000', the attachment point is 1000000. "
+                "Leave blank/omit for Primary layers."
+            ),
             "normalizer": "parse_currency_with_magnitude",
             "example": "1000000",
         },
@@ -301,6 +464,25 @@ POLICY_EXTRACTION_SCHEMA: dict = {
             "description": "Any additional notes, conditions, or remarks from the document",
         },
     ],
+    "nested_groups": {
+        "locations": {
+            "type": "array",
+            "optional": True,
+            "description": (
+                "Locations or buildings described in the document. Include if the document "
+                "contains property schedules, SOVs, building descriptions, or COPE data."
+            ),
+            "fields": LOCATION_FIELDS,
+            "nested": {
+                "cope": {
+                    "type": "object",
+                    "optional": True,
+                    "description": "COPE (Construction, Occupancy, Protection, Exposure) data for this location",
+                    "fields": COPE_FIELDS,
+                },
+            },
+        },
+    },
 }
 
 # ---------------------------------------------------------------------------
@@ -399,80 +581,7 @@ COMPLIANCE_EXTRACTION_SCHEMA: dict = {
                 "description": "Additional notes about this coverage requirement",
             },
         ],
-        "cope": [
-            {
-                "key": "construction_type",
-                "label": "Construction Type",
-                "type": "string",
-                "required": False,
-                "description": "Building construction classification",
-                "config_values": "construction_types",
-                "config_mode": "prefer",
-            },
-            {
-                "key": "year_built",
-                "label": "Year Built",
-                "type": "number",
-                "required": False,
-                "description": "Year the structure was built or last renovated",
-            },
-            {
-                "key": "stories",
-                "label": "Number of Stories",
-                "type": "number",
-                "required": False,
-                "description": "Number of stories in the building",
-            },
-            {
-                "key": "sq_footage",
-                "label": "Square Footage",
-                "type": "number",
-                "required": False,
-                "description": "Total square footage of the building",
-            },
-            {
-                "key": "sprinklered",
-                "label": "Sprinkler Status",
-                "type": "string",
-                "required": False,
-                "description": "Whether the building has sprinkler protection",
-                "config_values": "sprinkler_options",
-                "config_mode": "strict",
-            },
-            {
-                "key": "roof_type",
-                "label": "Roof Type",
-                "type": "string",
-                "required": False,
-                "description": "Type or material of the roof",
-                "config_values": "roof_types",
-                "config_mode": "prefer",
-            },
-            {
-                "key": "occupancy_description",
-                "label": "Occupancy Description",
-                "type": "string",
-                "required": False,
-                "description": "Description of how the building is occupied or used",
-            },
-            {
-                "key": "protection_class",
-                "label": "Protection Class",
-                "type": "string",
-                "required": False,
-                "description": "ISO protection class rating",
-                "config_values": "protection_classes",
-                "config_mode": "prefer",
-            },
-            {
-                "key": "total_insurable_value",
-                "label": "Total Insurable Value",
-                "type": "number",
-                "required": False,
-                "description": "Total insurable value of the property",
-                "normalizer": "parse_currency_with_magnitude",
-            },
-        ],
+        "cope": COPE_FIELDS,
     },
 }
 
@@ -533,6 +642,23 @@ def _build_json_example(schema: dict) -> dict:
         result = {}
         for f in fields:
             result[f["key"]] = f.get("example", "")
+
+        # Append nested_groups examples (e.g. locations with COPE)
+        nested_groups = schema.get("nested_groups", {})
+        for group_name, group_def in nested_groups.items():
+            group_example = {}
+            for f in group_def.get("fields", []):
+                group_example[f["key"]] = f.get("example", "")
+            # Sub-nested groups (e.g. cope inside location)
+            for sub_name, sub_def in group_def.get("nested", {}).items():
+                sub_example = {}
+                for f in sub_def.get("fields", []):
+                    sub_example[f["key"]] = f.get("example", "")
+                group_example[sub_name] = sub_example
+            if group_def.get("type") == "array":
+                result[group_name] = [group_example]
+            else:
+                result[group_name] = group_example
         return result
 
     # Nested schema (compliance) — fields is a dict of group_name -> list
@@ -598,6 +724,38 @@ def generate_extraction_prompt(schema: dict, context: dict) -> str:
             "If the document lists an aggregate limit, retention, or "
             "self-insured retention (SIR), include these values in the notes field."
         )
+
+        # Nested groups (locations + COPE)
+        nested_groups = schema.get("nested_groups", {})
+        for group_name, group_def in nested_groups.items():
+            desc = group_def.get("description", "")
+            optional = group_def.get("optional", False)
+            opt_note = " (optional — include only if data is found in the document)" if optional else ""
+            parts.append("")
+            parts.append(f"## {group_name.title()}{opt_note}")
+            if desc:
+                parts.append(f"{desc}")
+            parts.append("")
+            gtype = group_def.get("type", "object")
+            if gtype == "array":
+                parts.append(
+                    f'Return "{group_name}" as a JSON array. Each element should contain:'
+                )
+                parts.append("")
+            for f in group_def.get("fields", []):
+                parts.append(_build_field_instruction(f, config_lists))
+            # Sub-nested (e.g. cope inside location)
+            for sub_name, sub_def in group_def.get("nested", {}).items():
+                sub_desc = sub_def.get("description", "")
+                sub_opt = sub_def.get("optional", False)
+                sub_note = " (optional)" if sub_opt else ""
+                parts.append("")
+                parts.append(f"### {sub_name.upper()} Data{sub_note}")
+                if sub_desc:
+                    parts.append(f"{sub_desc}")
+                parts.append("")
+                for f in sub_def.get("fields", []):
+                    parts.append(_build_field_instruction(f, config_lists))
     else:
         # Nested field groups (compliance)
         for group_name, group_fields in fields.items():
@@ -815,6 +973,52 @@ def parse_llm_json(raw_text: str, schema: dict) -> dict:
                 "error": "No fields were extracted from the JSON.",
                 "raw_text": raw_text,
             }
+
+        # Parse nested groups (locations with COPE)
+        nested_groups = schema.get("nested_groups", {})
+        for group_name, group_def in nested_groups.items():
+            group_data = data.get(group_name)
+            if group_data is None:
+                continue  # optional group not present — backward compat
+            gtype = group_def.get("type", "object")
+            group_fields = group_def.get("fields", [])
+            sub_groups = group_def.get("nested", {})
+
+            if gtype == "array" and isinstance(group_data, list):
+                parsed_items: list[dict] = []
+                raw_items: list[dict] = []
+                for i, item in enumerate(group_data):
+                    if not isinstance(item, dict):
+                        warnings.append(f"{group_name}[{i}] is not an object, skipping.")
+                        continue
+                    p, r, w = _parse_flat_fields(item, group_fields)
+                    # Parse sub-nested groups (e.g. cope inside location)
+                    for sub_name, sub_def in sub_groups.items():
+                        sub_data = item.get(sub_name)
+                        if sub_data is not None and isinstance(sub_data, dict):
+                            sp, sr, sw = _parse_flat_fields(sub_data, sub_def.get("fields", []))
+                            p[sub_name] = sp
+                            r[sub_name] = sr
+                            warnings.extend(sw)
+                    parsed_items.append(p)
+                    raw_items.append(r)
+                    warnings.extend(w)
+                if parsed_items:
+                    parsed[group_name] = parsed_items
+                    raw[group_name] = raw_items
+            elif isinstance(group_data, dict):
+                p, r, w = _parse_flat_fields(group_data, group_fields)
+                for sub_name, sub_def in sub_groups.items():
+                    sub_data = group_data.get(sub_name)
+                    if sub_data is not None and isinstance(sub_data, dict):
+                        sp, sr, sw = _parse_flat_fields(sub_data, sub_def.get("fields", []))
+                        p[sub_name] = sp
+                        r[sub_name] = sr
+                        warnings.extend(sw)
+                parsed[group_name] = p
+                raw[group_name] = r
+                warnings.extend(w)
+
         return {"ok": True, "parsed": parsed, "warnings": warnings, "raw": raw}
 
     # --- Nested schema (compliance) — fields is a dict of groups ---

--- a/src/policydb/web/routes/policies.py
+++ b/src/policydb/web/routes/policies.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 logger = logging.getLogger("policydb.web.routes.policies")
 
@@ -965,13 +966,26 @@ def policy_ai_import_prompt(request: Request, policy_uid: str, conn=Depends(get_
         "config_lists": {},
     }
 
-    # Collect config values referenced by schema fields
+    # Collect config values referenced by schema fields (flat + nested groups)
     seen_config_keys: set[str] = set()
     for field in POLICY_EXTRACTION_SCHEMA["fields"]:
         ck = field.get("config_values")
         if ck and ck not in seen_config_keys:
             seen_config_keys.add(ck)
             context["config_lists"][ck] = cfg.get(ck, [])
+    # Walk nested_groups for additional config keys (COPE, location fields)
+    for _gname, gdef in POLICY_EXTRACTION_SCHEMA.get("nested_groups", {}).items():
+        for field in gdef.get("fields", []):
+            ck = field.get("config_values")
+            if ck and ck not in seen_config_keys:
+                seen_config_keys.add(ck)
+                context["config_lists"][ck] = cfg.get(ck, [])
+        for _sname, sdef in gdef.get("nested", {}).items():
+            for field in sdef.get("fields", []):
+                ck = field.get("config_values")
+                if ck and ck not in seen_config_keys:
+                    seen_config_keys.add(ck)
+                    context["config_lists"][ck] = cfg.get(ck, [])
 
     prompt_text = generate_extraction_prompt(POLICY_EXTRACTION_SCHEMA, context)
     json_template = generate_json_template(POLICY_EXTRACTION_SCHEMA)
@@ -980,6 +994,13 @@ def policy_ai_import_prompt(request: Request, policy_uid: str, conn=Depends(get_
     industry = client_info.get("industry_segment", "")
     if industry:
         context_display["Industry"] = industry
+    # Show location name if policy is linked to one
+    if policy_dict.get("project_id"):
+        loc_row = conn.execute(
+            "SELECT name FROM projects WHERE id = ?", (policy_dict["project_id"],)
+        ).fetchone()
+        if loc_row and loc_row["name"]:
+            context_display["Location"] = loc_row["name"]
 
     return templates.TemplateResponse("_ai_import_panel.html", {
         "request": request,
@@ -1014,10 +1035,10 @@ def policy_ai_import_parse(
     if not policy_dict:
         return HTMLResponse("Not found", status_code=404)
 
-    # Merge parsed values onto existing policy
+    # Merge parsed values onto existing policy (skip nested groups)
     merged = dict(policy_dict)
     for k, v in result["parsed"].items():
-        if v is not None:
+        if v is not None and k != "locations":
             merged[k] = v
 
     # FEIN cross-reference warning
@@ -1032,6 +1053,156 @@ def policy_ai_import_parse(
                 f"FEIN mismatch: document shows {parsed_fein}, "
                 f"client record has {client_fein['fein']}"
             )
+
+    # ── Build policy-level diffs ──
+    from policydb.llm_schemas import POLICY_EXTRACTION_SCHEMA as _SCHEMA, LOCATION_FIELDS, COPE_FIELDS
+    _field_labels = {f["key"]: f["label"] for f in _SCHEMA["fields"]}
+    ai_policy_diffs: list[dict] = []
+    for k, v in result["parsed"].items():
+        if k == "locations" or v is None:
+            continue
+        current = policy_dict.get(k)
+        current_str = str(current) if current is not None else ""
+        extracted_str = str(v) if v is not None else ""
+        if current_str != extracted_str:
+            ai_policy_diffs.append({
+                "field": k,
+                "label": _field_labels.get(k, k),
+                "current": current,
+                "extracted": v,
+                "is_fill": not current_str,  # empty→filled = pre-check
+            })
+
+    # ── Build location & COPE diffs ──
+    locations_parsed = result["parsed"].get("locations", [])
+    ai_location_data: list[dict] = []
+    if locations_parsed:
+        from rapidfuzz import fuzz
+
+        _loc_labels = {f["key"]: f["label"] for f in LOCATION_FIELDS}
+        _cope_labels = {f["key"]: f["label"] for f in COPE_FIELDS}
+
+        # Load client's existing locations for fuzzy matching
+        existing_locations = [dict(r) for r in conn.execute(
+            """SELECT id, name, address, city, state, zip, notes
+               FROM projects WHERE client_id = ? AND (project_type = 'Location' OR project_type IS NULL)""",
+            (policy_dict["client_id"],),
+        ).fetchall()]
+
+        for loc_idx, loc in enumerate(locations_parsed):
+            cope_extracted = loc.get("cope", {})
+            loc_entry: dict = {
+                "index": loc_idx,
+                "extracted": {k: v for k, v in loc.items() if k != "cope"},
+                "cope_extracted": cope_extracted,
+                "existing": None,
+                "cope_existing": None,
+                "diffs": [],
+                "cope_diffs": [],
+                "match_score": 0,
+                "project_id": None,
+                "match_type": "new",
+            }
+
+            # Try to match: policy's project_id first, then fuzzy
+            matched_project = None
+            if policy_dict.get("project_id") and len(locations_parsed) == 1:
+                matched_project = conn.execute(
+                    "SELECT id, name, address, city, state, zip, notes FROM projects WHERE id = ?",
+                    (policy_dict["project_id"],),
+                ).fetchone()
+                if matched_project:
+                    loc_entry["match_type"] = "linked"
+                    loc_entry["match_score"] = 100
+            if not matched_project and existing_locations:
+                # Fuzzy match on name + address
+                loc_name = loc.get("name", "")
+                loc_addr = loc.get("address", "")
+                best_score = 0
+                best_match = None
+                for eloc in existing_locations:
+                    name_score = fuzz.ratio(
+                        (loc_name or "").lower(), (eloc.get("name") or "").lower()
+                    ) if loc_name else 0
+                    addr_score = fuzz.ratio(
+                        (loc_addr or "").lower(), (eloc.get("address") or "").lower()
+                    ) if loc_addr else 0
+                    combined = max(name_score, addr_score)
+                    if combined > best_score and combined >= 60:
+                        best_score = combined
+                        best_match = eloc
+                if best_match:
+                    matched_project = best_match
+                    loc_entry["match_type"] = "fuzzy"
+                    loc_entry["match_score"] = int(best_score)
+
+            if matched_project:
+                mp = dict(matched_project) if not isinstance(matched_project, dict) else matched_project
+                loc_entry["project_id"] = mp["id"]
+                loc_entry["existing"] = {k: mp.get(k) for k in ["name", "address", "city", "state", "zip", "notes"]}
+
+                # Location field diffs
+                for fkey in ["name", "address", "city", "state", "zip", "notes"]:
+                    ext_val = loc.get(fkey)
+                    cur_val = mp.get(fkey)
+                    if ext_val is not None:
+                        cur_str = str(cur_val) if cur_val else ""
+                        ext_str = str(ext_val) if ext_val else ""
+                        if cur_str != ext_str:
+                            loc_entry["diffs"].append({
+                                "field": fkey,
+                                "label": _loc_labels.get(fkey, fkey),
+                                "current": cur_val,
+                                "extracted": ext_val,
+                                "is_fill": not cur_str,
+                            })
+
+                # COPE diffs
+                if cope_extracted:
+                    cope_row = conn.execute(
+                        "SELECT * FROM cope_data WHERE project_id = ?", (mp["id"],)
+                    ).fetchone()
+                    cope_current = dict(cope_row) if cope_row else {}
+                    loc_entry["cope_existing"] = cope_current
+                    for fkey in [f["key"] for f in COPE_FIELDS]:
+                        ext_val = cope_extracted.get(fkey)
+                        cur_val = cope_current.get(fkey)
+                        if ext_val is not None:
+                            cur_str = str(cur_val) if cur_val else ""
+                            ext_str = str(ext_val) if ext_val else ""
+                            if cur_str != ext_str:
+                                loc_entry["cope_diffs"].append({
+                                    "field": fkey,
+                                    "label": _cope_labels.get(fkey, fkey),
+                                    "current": cur_val,
+                                    "extracted": ext_val,
+                                    "is_fill": not cur_str,
+                                })
+            else:
+                # New location — all extracted fields are "diffs" (fills)
+                for fkey in ["name", "address", "city", "state", "zip", "notes"]:
+                    ext_val = loc.get(fkey)
+                    if ext_val:
+                        loc_entry["diffs"].append({
+                            "field": fkey,
+                            "label": _loc_labels.get(fkey, fkey),
+                            "current": None,
+                            "extracted": ext_val,
+                            "is_fill": True,
+                        })
+                if cope_extracted:
+                    for fkey in [f["key"] for f in COPE_FIELDS]:
+                        ext_val = cope_extracted.get(fkey)
+                        if ext_val is not None:
+                            loc_entry["cope_diffs"].append({
+                                "field": fkey,
+                                "label": _cope_labels.get(fkey, fkey),
+                                "current": None,
+                                "extracted": ext_val,
+                                "is_fill": True,
+                            })
+
+            ai_location_data.append(loc_entry)
 
     # Build the same context as policy_tab_details
     from policydb.queries import REVIEW_CYCLE_LABELS as _RCL
@@ -1101,6 +1272,9 @@ def policy_ai_import_parse(
             (merged["id"],),
         ).fetchall()] if merged.get("is_program") else [],
         "ai_warnings": ai_warnings,
+        "ai_policy_diffs": ai_policy_diffs,
+        "ai_location_data": ai_location_data,
+        "ai_parsed_json": json.dumps(result["parsed"], default=str),
     })
 
     # Append OOB warnings div if there are warnings
@@ -1118,6 +1292,132 @@ def policy_ai_import_parse(
         html.body += oob_html.encode()
 
     return html
+
+
+@router.post("/{policy_uid}/ai-import/apply-location")
+async def policy_ai_import_apply_location(
+    request: Request,
+    policy_uid: str,
+    conn=Depends(get_db),
+):
+    """Apply extracted location and COPE data from AI import."""
+    uid = policy_uid.upper()
+    body = await request.json()
+    project_id = body.get("project_id")
+    create_new = body.get("create_new", False)
+    location_fields = body.get("location_fields", {})
+    cope_fields = body.get("cope_fields", {})
+    location_name = body.get("location_name", "")
+
+    policy = get_policy_by_uid(conn, uid)
+    if not policy:
+        return JSONResponse({"ok": False, "error": "Policy not found"}, status_code=404)
+
+    created = False
+    # Create new location if requested
+    if create_new:
+        conn.execute(
+            """INSERT INTO projects (client_id, name, address, city, state, zip, notes, project_type, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, 'Location', datetime('now'), datetime('now'))""",
+            (
+                policy["client_id"],
+                location_fields.get("name", location_name or "Imported Location"),
+                location_fields.get("address", ""),
+                location_fields.get("city", ""),
+                location_fields.get("state", ""),
+                location_fields.get("zip", ""),
+                location_fields.get("notes", ""),
+            ),
+        )
+        project_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+        # Link policy to new location
+        conn.execute(
+            "UPDATE policies SET project_id = ?, updated_at = datetime('now') WHERE policy_uid = ?",
+            (project_id, uid),
+        )
+        created = True
+        logger.info("AI import: created location %s for policy %s", project_id, uid)
+    elif project_id and location_fields:
+        # Update existing location fields
+        update_parts = []
+        update_vals = []
+        for fkey in ["name", "address", "city", "state", "zip"]:
+            if fkey in location_fields:
+                update_parts.append(f"{fkey} = ?")
+                update_vals.append(location_fields[fkey])
+        # Notes: append if existing, set if empty
+        if "notes" in location_fields and location_fields["notes"]:
+            existing_notes = conn.execute(
+                "SELECT notes FROM projects WHERE id = ?", (project_id,)
+            ).fetchone()
+            if existing_notes and existing_notes["notes"]:
+                update_parts.append("notes = ?")
+                update_vals.append(
+                    existing_notes["notes"] + "\n\n--- Imported ---\n" + location_fields["notes"]
+                )
+            else:
+                update_parts.append("notes = ?")
+                update_vals.append(location_fields["notes"])
+        if update_parts:
+            update_parts.append("updated_at = datetime('now')")
+            update_vals.append(project_id)
+            conn.execute(
+                f"UPDATE projects SET {', '.join(update_parts)} WHERE id = ?",
+                update_vals,
+            )
+        # Link policy to location if not already linked
+        if not policy["project_id"]:
+            conn.execute(
+                "UPDATE policies SET project_id = ?, updated_at = datetime('now') WHERE policy_uid = ?",
+                (project_id, uid),
+            )
+        logger.info("AI import: updated location %s for policy %s", project_id, uid)
+
+    # Apply COPE data
+    if project_id and cope_fields:
+        # Check if cope_data row exists
+        cope_row = conn.execute(
+            "SELECT id FROM cope_data WHERE project_id = ?", (project_id,)
+        ).fetchone()
+        if cope_row:
+            # Update existing COPE row
+            cope_updates = []
+            cope_vals = []
+            for fkey, fval in cope_fields.items():
+                cope_updates.append(f"{fkey} = ?")
+                cope_vals.append(fval)
+            if cope_updates:
+                cope_updates.append("updated_at = datetime('now')")
+                cope_vals.append(project_id)
+                conn.execute(
+                    f"UPDATE cope_data SET {', '.join(cope_updates)} WHERE project_id = ?",
+                    cope_vals,
+                )
+        else:
+            # Insert new COPE row
+            cols = ["project_id"]
+            vals = [project_id]
+            for fkey, fval in cope_fields.items():
+                cols.append(fkey)
+                vals.append(fval)
+            placeholders = ", ".join("?" for _ in cols)
+            conn.execute(
+                f"INSERT INTO cope_data ({', '.join(cols)}, created_at, updated_at) "
+                f"VALUES ({placeholders}, datetime('now'), datetime('now'))",
+                vals,
+            )
+        logger.info("AI import: saved COPE data for location %s", project_id)
+
+    conn.commit()
+
+    # Get location name for response
+    loc_name = location_name
+    if project_id:
+        loc_row = conn.execute("SELECT name FROM projects WHERE id = ?", (project_id,)).fetchone()
+        if loc_row:
+            loc_name = loc_row["name"] or loc_name
+
+    return JSONResponse({"ok": True, "location_name": loc_name, "created": created, "project_id": project_id})
 
 
 @router.get("/{policy_uid}/tab/details", response_class=HTMLResponse)

--- a/src/policydb/web/templates/_ai_import_panel.html
+++ b/src/policydb/web/templates/_ai_import_panel.html
@@ -260,6 +260,12 @@ function submitAiImport() {
                 if (target) {
                     target.innerHTML = temp.innerHTML;
                     htmx.process(target);
+                    /* Execute <script> blocks that innerHTML doesn't run */
+                    target.querySelectorAll('script').forEach(function(oldScript) {
+                        var newScript = document.createElement('script');
+                        newScript.textContent = oldScript.textContent;
+                        oldScript.parentNode.replaceChild(newScript, oldScript);
+                    });
                 }
 
                 /* Open parent <details> if collapsed (compliance review mode) */

--- a/src/policydb/web/templates/policies/_ai_review_panel.html
+++ b/src/policydb/web/templates/policies/_ai_review_panel.html
@@ -1,0 +1,250 @@
+{# AI Import Review Panel — shows diffs for policy fields, locations, and COPE data.
+   Rendered inside _tab_details.html when ai_policy_diffs or ai_location_data are present.
+   Context:
+     ai_policy_diffs   — list of {field, label, current, extracted, is_fill}
+     ai_location_data   — list of location dicts with diffs, cope_diffs, match info
+     ai_parsed_json     — JSON string of all parsed data (for apply endpoints)
+     policy             — current policy dict
+#}
+<div id="ai-review-panel" class="mb-6" data-parsed='{{ ai_parsed_json }}'>
+
+  {# ══ Header ══ #}
+  <div class="flex items-center gap-3 mb-4">
+    <div class="flex items-center gap-2">
+      <svg class="w-5 h-5 text-indigo-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
+      </svg>
+      <h3 class="text-sm font-semibold text-gray-900">AI Import Review</h3>
+    </div>
+    <span class="text-xs text-gray-400">Select fields to apply, then confirm</span>
+    <button onclick="document.getElementById('ai-review-panel').remove()"
+            class="ml-auto text-xs text-gray-400 hover:text-gray-600 transition-colors">Dismiss</button>
+  </div>
+
+  {# ══════════════════════════════════════════════════════════════════════════
+     SECTION A — Policy Field Diffs
+     ══════════════════════════════════════════════════════════════════════════ #}
+  {% if ai_policy_diffs %}
+  <div class="card border-indigo-200 bg-indigo-50/20 mb-4" id="ai-policy-diffs-card">
+    <div class="px-5 py-3 border-b border-indigo-100 flex items-center justify-between">
+      <span class="text-xs font-semibold text-indigo-600 uppercase tracking-wide">Policy Fields</span>
+      <span class="text-xs text-gray-400">{{ ai_policy_diffs | length }} change{{ 's' if ai_policy_diffs | length != 1 }}</span>
+    </div>
+    <div class="divide-y divide-indigo-50">
+      {% for d in ai_policy_diffs %}
+      <label class="flex items-center gap-4 px-5 py-2.5 hover:bg-indigo-50/40 cursor-pointer transition-colors">
+        <input type="checkbox" name="apply_field" value="{{ d.field }}"
+               class="ai-field-cb rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+               {% if d.is_fill %}checked{% endif %}>
+        <span class="text-xs font-medium text-gray-500 w-36 shrink-0">{{ d.label }}</span>
+        <span class="text-xs text-gray-400 flex-1 truncate" title="{{ d.current or '(empty)' }}">
+          {% if d.current %}{{ d.current }}{% else %}<em class="text-gray-300">empty</em>{% endif %}
+        </span>
+        <svg class="w-4 h-4 text-indigo-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+        </svg>
+        <span class="text-xs font-medium text-indigo-700 flex-1 truncate" title="{{ d.extracted }}">
+          {{ d.extracted }}
+        </span>
+      </label>
+      {% endfor %}
+    </div>
+    <div class="px-5 py-3 border-t border-indigo-100 flex items-center gap-3">
+      <button type="button" onclick="applyPolicyFields()"
+              class="px-4 py-1.5 rounded-lg text-xs font-medium bg-indigo-600 text-white hover:bg-indigo-700 transition-colors">
+        Apply Selected Fields
+      </button>
+      <button type="button" onclick="toggleAllFieldCbs(true)" class="text-xs text-indigo-500 hover:text-indigo-700">Select All</button>
+      <button type="button" onclick="toggleAllFieldCbs(false)" class="text-xs text-gray-400 hover:text-gray-600">Clear All</button>
+    </div>
+  </div>
+  {% endif %}
+
+  {# ══════════════════════════════════════════════════════════════════════════
+     SECTION B — Location & COPE Review (per location)
+     ══════════════════════════════════════════════════════════════════════════ #}
+  {% if ai_location_data %}
+  {% for loc in ai_location_data %}
+  <div class="card border-emerald-200 bg-emerald-50/20 mb-4" id="ai-loc-card-{{ loc.index }}">
+    <div class="px-5 py-3 border-b border-emerald-100 flex items-center gap-3">
+      <svg class="w-4 h-4 text-emerald-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"/>
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"/>
+      </svg>
+      <span class="text-xs font-semibold text-emerald-700 uppercase tracking-wide">
+        {% if loc.match_type == 'linked' %}
+          Linked Location: {{ loc.existing.name or 'Unnamed' }}
+        {% elif loc.match_type == 'fuzzy' %}
+          Matched Location: {{ loc.existing.name or 'Unnamed' }}
+        {% else %}
+          New Location: {{ loc.extracted.name or 'Location ' ~ (loc.index + 1) }}
+        {% endif %}
+      </span>
+      {% if loc.match_type == 'fuzzy' %}
+      <span class="px-2 py-0.5 rounded-full text-[10px] font-bold
+        {% if loc.match_score >= 75 %}bg-green-100 text-green-700
+        {% elif loc.match_score >= 60 %}bg-amber-100 text-amber-700
+        {% else %}bg-gray-100 text-gray-500{% endif %}">
+        {{ loc.match_score }}% match
+      </span>
+      {% endif %}
+      {% if loc.diffs or loc.cope_diffs %}
+      <span class="text-xs text-gray-400 ml-auto">
+        {{ (loc.diffs | length) + (loc.cope_diffs | length) }} field{{ 's' if (loc.diffs | length) + (loc.cope_diffs | length) != 1 }}
+      </span>
+      {% endif %}
+    </div>
+
+    {# Location field diffs #}
+    {% if loc.diffs %}
+    <div class="divide-y divide-emerald-50">
+      {% for d in loc.diffs %}
+      <label class="flex items-center gap-4 px-5 py-2.5 hover:bg-emerald-50/40 cursor-pointer transition-colors">
+        <input type="checkbox" name="apply_loc_{{ loc.index }}" value="{{ d.field }}"
+               class="ai-loc-cb-{{ loc.index }} rounded border-gray-300 text-emerald-600 focus:ring-emerald-500"
+               {% if d.is_fill %}checked{% endif %}>
+        <span class="text-xs font-medium text-gray-500 w-36 shrink-0">{{ d.label }}</span>
+        <span class="text-xs text-gray-400 flex-1 truncate">
+          {% if d.current %}{{ d.current }}{% else %}<em class="text-gray-300">empty</em>{% endif %}
+        </span>
+        <svg class="w-4 h-4 text-emerald-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+        </svg>
+        <span class="text-xs font-medium text-emerald-700 flex-1 truncate">{{ d.extracted }}</span>
+      </label>
+      {% endfor %}
+    </div>
+    {% endif %}
+
+    {# COPE field diffs #}
+    {% if loc.cope_diffs %}
+    <div class="px-5 py-2 border-t border-emerald-100">
+      <span class="text-[10px] font-semibold text-emerald-500 uppercase tracking-wider">COPE Data</span>
+    </div>
+    <div class="divide-y divide-emerald-50">
+      {% for d in loc.cope_diffs %}
+      <label class="flex items-center gap-4 px-5 py-2.5 hover:bg-emerald-50/40 cursor-pointer transition-colors">
+        <input type="checkbox" name="apply_cope_{{ loc.index }}" value="{{ d.field }}"
+               class="ai-cope-cb-{{ loc.index }} rounded border-gray-300 text-teal-600 focus:ring-teal-500"
+               {% if d.is_fill %}checked{% endif %}>
+        <span class="text-xs font-medium text-gray-500 w-36 shrink-0">{{ d.label }}</span>
+        <span class="text-xs text-gray-400 flex-1 truncate">
+          {% if d.current is not none and d.current != '' %}{{ d.current }}{% else %}<em class="text-gray-300">empty</em>{% endif %}
+        </span>
+        <svg class="w-4 h-4 text-teal-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+        </svg>
+        <span class="text-xs font-medium text-teal-700 flex-1 truncate">{{ d.extracted }}</span>
+      </label>
+      {% endfor %}
+    </div>
+    {% endif %}
+
+    {# Actions #}
+    <div class="px-5 py-3 border-t border-emerald-100 flex items-center gap-3">
+      {% if loc.match_type == 'new' %}
+      <button type="button" onclick="applyLocation({{ loc.index }}, null, true)"
+              class="px-4 py-1.5 rounded-lg text-xs font-medium bg-emerald-600 text-white hover:bg-emerald-700 transition-colors">
+        Create Location &amp; Apply
+      </button>
+      {% else %}
+      <button type="button" onclick="applyLocation({{ loc.index }}, {{ loc.project_id }}, false)"
+              class="px-4 py-1.5 rounded-lg text-xs font-medium bg-emerald-600 text-white hover:bg-emerald-700 transition-colors">
+        Apply to {{ loc.existing.name or 'Location' }}
+      </button>
+      {% endif %}
+      <button type="button" onclick="document.getElementById('ai-loc-card-{{ loc.index }}').remove()"
+              class="text-xs text-gray-400 hover:text-gray-600 transition-colors">Skip</button>
+    </div>
+  </div>
+  {% endfor %}
+  {% endif %}
+
+</div>
+
+<script>
+/* ── AI Review Panel helpers ── */
+function toggleAllFieldCbs(checked) {
+  document.querySelectorAll('.ai-field-cb').forEach(function(cb) { cb.checked = checked; });
+}
+
+function applyPolicyFields() {
+  var panel = document.getElementById('ai-review-panel');
+  var parsed = JSON.parse(panel.dataset.parsed);
+  var checked = [];
+  document.querySelectorAll('.ai-field-cb:checked').forEach(function(cb) {
+    checked.push(cb.value);
+  });
+  if (!checked.length) return;
+
+  /* Build updates — one PATCH per field using existing cell-save endpoint */
+  var uid = '{{ policy.policy_uid }}';
+  var promises = checked.map(function(field) {
+    var value = parsed[field];
+    if (value === null || value === undefined) value = '';
+    return fetch('/policies/' + uid + '/cell', {
+      method: 'PATCH',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({field: field, value: String(value)})
+    });
+  });
+
+  Promise.all(promises).then(function() {
+    var card = document.getElementById('ai-policy-diffs-card');
+    if (card) {
+      card.innerHTML = '<div class="px-5 py-4 text-sm text-emerald-600 font-medium flex items-center gap-2">' +
+        '<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>' +
+        checked.length + ' field' + (checked.length !== 1 ? 's' : '') + ' applied</div>';
+      card.className = 'card border-emerald-200 bg-emerald-50/20 mb-4';
+    }
+  });
+}
+
+function applyLocation(locIndex, projectId, createNew) {
+  var panel = document.getElementById('ai-review-panel');
+  var parsed = JSON.parse(panel.dataset.parsed);
+  var locData = parsed.locations ? parsed.locations[locIndex] : null;
+  if (!locData) return;
+
+  /* Collect selected location fields */
+  var locFields = {};
+  document.querySelectorAll('.ai-loc-cb-' + locIndex + ':checked').forEach(function(cb) {
+    locFields[cb.value] = locData[cb.value] || '';
+  });
+
+  /* Collect selected COPE fields */
+  var copeFields = {};
+  document.querySelectorAll('.ai-cope-cb-' + locIndex + ':checked').forEach(function(cb) {
+    var copeData = locData.cope || {};
+    copeFields[cb.value] = copeData[cb.value];
+    if (copeFields[cb.value] === undefined) copeFields[cb.value] = '';
+  });
+
+  var uid = '{{ policy.policy_uid }}';
+  fetch('/policies/' + uid + '/ai-import/apply-location', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({
+      loc_index: locIndex,
+      project_id: projectId,
+      create_new: createNew,
+      location_fields: locFields,
+      cope_fields: copeFields,
+      location_name: locData.name || ''
+    })
+  }).then(function(resp) {
+    return resp.json();
+  }).then(function(data) {
+    var card = document.getElementById('ai-loc-card-' + locIndex);
+    if (card && data.ok) {
+      var label = data.location_name || ('Location ' + (locIndex + 1));
+      var count = Object.keys(locFields).length + Object.keys(copeFields).length;
+      card.innerHTML = '<div class="px-5 py-4 text-sm text-emerald-600 font-medium flex items-center gap-2">' +
+        '<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>' +
+        label + ' — ' + count + ' field' + (count !== 1 ? 's' : '') + ' applied' +
+        (data.created ? ' (new location created)' : '') + '</div>';
+      card.className = 'card border-emerald-200 bg-emerald-50/20 mb-4';
+    }
+  });
+}
+</script>

--- a/src/policydb/web/templates/policies/_tab_details.html
+++ b/src/policydb/web/templates/policies/_tab_details.html
@@ -1,6 +1,10 @@
 {# Policy Details Tab — per-field PATCH on blur, no form wrapper #}
 <div id="tab-details-content">
 
+{% if ai_policy_diffs is defined and (ai_policy_diffs or ai_location_data) %}
+{% include 'policies/_ai_review_panel.html' %}
+{% endif %}
+
 {% if policy.is_opportunity %}
 <!-- Opportunity banner -->
 <div class="bg-amber-50 border border-amber-200 rounded-xl px-5 py-4 mb-4 flex items-start justify-between gap-4">


### PR DESCRIPTION
## Summary
- Expands the AI-assisted JSON import to extract **COPE data**, **location details**, and **tower/program structure** from policy documents — not just flat policy fields
- Adds a **diff/review panel** with per-field checkboxes so the user controls what gets applied vs skipped
- Locations are matched to existing records via fuzzy matching (RapidFuzz) or linked via the policy's project_id
- COPE fields (construction type, year built, sprinklers, TIV, etc.) save to the existing `cope_data` table
- Tower fields (`tower_group`, `layer_position`, `attachment_point`) now have improved LLM extraction prompts
- COPE tokens added to email template system for use in compose workflows

Closes #32

## Test plan
- [x] Backward compat: JSON without `locations` key parses identically to before
- [x] Single location + COPE: review panel shows diffs, apply saves to DB
- [x] Location matching: linked location detected, fuzzy match with score badge
- [x] Policy field diffs: pre-checked for empty→filled, unchecked for value→value changes
- [x] Apply endpoints: policy fields via existing cell-save, location+COPE via new endpoint
- [x] COPE tokens registered in email template system
- [x] Visual QA in browser — full flow tested end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)