### PR TITLE
feat: audit log activity review (#34)

### DIFF
--- a/src/policydb/activity_review.py
+++ b/src/policydb/activity_review.py
@@ -1,0 +1,407 @@
+"""Activity Review Engine — detect unlogged work sessions from audit trail.
+
+Scans audit_log entries, clusters them into per-client work sessions,
+identifies sessions with no corresponding activity_log entry, and writes
+them to the suggested_activities table for user review.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import sqlite3
+from collections import defaultdict
+from datetime import date, datetime, timedelta
+
+import policydb.config as cfg
+
+logger = logging.getLogger(__name__)
+
+# Tables we scan for client-attributable work
+_TRACKED_TABLES = {"clients", "policies", "contacts", "policy_milestones"}
+
+# Summary text templates: (table, operation) -> verb
+_SUMMARY_VERBS: dict[tuple[str, str], str] = {
+    ("clients", "INSERT"): "Created client",
+    ("clients", "UPDATE"): "Updated client info",
+    ("clients", "DELETE"): "Deleted client",
+    ("policies", "INSERT"): "Created policy",
+    ("policies", "UPDATE"): "Updated policy",
+    ("policies", "DELETE"): "Deleted policy",
+    ("contacts", "INSERT"): "Added contact",
+    ("contacts", "UPDATE"): "Edited contact",
+    ("contacts", "DELETE"): "Removed contact",
+    ("policy_milestones", "INSERT"): "Added milestone",
+    ("policy_milestones", "UPDATE"): "Updated milestone",
+    ("policy_milestones", "DELETE"): "Removed milestone",
+}
+
+
+def _resolve_client_ids(conn: sqlite3.Connection, entries: list[dict]) -> list[dict]:
+    """Resolve each audit entry to one or more client_ids.
+
+    Returns a flat list of entries, each with a 'client_id' key.
+    Entries that can't be resolved are dropped.
+    """
+    resolved = []
+
+    for entry in entries:
+        table = entry["table_name"]
+        row_id = entry["row_id"]
+
+        if table == "clients":
+            # row_id IS the client id
+            try:
+                entry["client_id"] = int(row_id)
+                resolved.append(entry)
+            except (ValueError, TypeError):
+                pass
+
+        elif table == "policies":
+            # row_id is policy_uid -> policies.client_id
+            row = conn.execute(
+                "SELECT client_id FROM policies WHERE policy_uid = ?", (row_id,)
+            ).fetchone()
+            if row:
+                entry["client_id"] = row[0]
+                entry["_policy_uid"] = row_id
+                resolved.append(entry)
+
+        elif table == "contacts":
+            # row_id -> contacts.id -> contact_client_assignments.client_id
+            try:
+                contact_id = int(row_id)
+            except (ValueError, TypeError):
+                continue
+            rows = conn.execute(
+                "SELECT client_id FROM contact_client_assignments WHERE contact_id = ?",
+                (contact_id,),
+            ).fetchall()
+            for r in rows:
+                copy = dict(entry)
+                copy["client_id"] = r[0]
+                resolved.append(copy)
+
+        elif table == "policy_milestones":
+            # row_id -> policy_milestones.id -> policy_uid -> policies.client_id
+            try:
+                ms_id = int(row_id)
+            except (ValueError, TypeError):
+                continue
+            row = conn.execute(
+                """SELECT p.client_id, pm.policy_uid
+                   FROM policy_milestones pm
+                   JOIN policies p ON p.policy_uid = pm.policy_uid
+                   WHERE pm.id = ?""",
+                (ms_id,),
+            ).fetchone()
+            if row:
+                entry["client_id"] = row[0]
+                entry["_policy_uid"] = row[1]
+                resolved.append(entry)
+
+    return resolved
+
+
+def _cluster_sessions(
+    entries: list[dict], gap_minutes: int
+) -> dict[int, list[list[dict]]]:
+    """Cluster entries by client_id and time gap.
+
+    Returns {client_id: [session_list, session_list, ...]}.
+    Each session_list is a list of entries within the gap window.
+    """
+    by_client: dict[int, list[dict]] = defaultdict(list)
+    for e in entries:
+        by_client[e["client_id"]].append(e)
+
+    gap = timedelta(minutes=gap_minutes)
+    result: dict[int, list[list[dict]]] = {}
+
+    for client_id, client_entries in by_client.items():
+        client_entries.sort(key=lambda e: e["changed_at"])
+        sessions: list[list[dict]] = []
+        current: list[dict] = []
+
+        for e in client_entries:
+            if current:
+                prev_time = datetime.fromisoformat(current[-1]["changed_at"])
+                this_time = datetime.fromisoformat(e["changed_at"])
+                if this_time - prev_time > gap:
+                    sessions.append(current)
+                    current = []
+            current.append(e)
+
+        if current:
+            sessions.append(current)
+
+        result[client_id] = sessions
+
+    return result
+
+
+def _is_bulk_operation(session: list[dict]) -> bool:
+    """Detect bulk operations: >20 changes within 60 seconds."""
+    if len(session) <= 20:
+        return False
+    first = datetime.fromisoformat(session[0]["changed_at"])
+    last = datetime.fromisoformat(session[-1]["changed_at"])
+    return (last - first).total_seconds() <= 60
+
+
+def _build_summary(session: list[dict]) -> tuple[str, str, str]:
+    """Build summary text, tables_touched, and policy_uids from a session.
+
+    Returns (summary, tables_touched, policy_uids).
+    """
+    # Count changes by (table, operation)
+    counts: dict[tuple[str, str], int] = defaultdict(int)
+    policy_uids: set[str] = set()
+    tables: set[str] = set()
+
+    for e in session:
+        key = (e["table_name"], e["operation"])
+        counts[key] += 1
+        tables.add(e["table_name"])
+        uid = e.get("_policy_uid")
+        if uid:
+            policy_uids.add(uid)
+
+    # Build summary parts
+    parts = []
+    for (table, op), count in sorted(counts.items()):
+        verb = _SUMMARY_VERBS.get((table, op), f"{op.lower()} {table}")
+        if table == "policies" and policy_uids:
+            uid_str = ", ".join(sorted(policy_uids)[:5])
+            if count > 1:
+                parts.append(f"{verb} x{count} ({uid_str})")
+            else:
+                parts.append(f"{verb} {uid_str}")
+        elif count > 1:
+            parts.append(f"{verb} x{count}")
+        else:
+            parts.append(verb)
+
+    summary = "; ".join(parts) if parts else "Data changes"
+    tables_touched = ", ".join(sorted(tables))
+    policy_uids_str = ", ".join(sorted(policy_uids))
+
+    return summary, tables_touched, policy_uids_str
+
+
+def _has_covering_activity(
+    conn: sqlite3.Connection,
+    client_id: int,
+    session_date: str,
+    session_start: datetime,
+    session_end: datetime,
+) -> bool:
+    """Check if an activity_log entry exists covering this session window.
+
+    Uses ±30 minute tolerance on the activity_date matching the session date.
+    """
+    rows = conn.execute(
+        """SELECT activity_date, created_at FROM activity_log
+           WHERE client_id = ? AND activity_date = ?
+           AND follow_up_done = 0""",
+        (client_id, session_date),
+    ).fetchall()
+
+    if rows:
+        return True
+
+    # Also check if any activity was created within the session window (±30 min)
+    window_start = (session_start - timedelta(minutes=30)).isoformat()
+    window_end = (session_end + timedelta(minutes=30)).isoformat()
+
+    count = conn.execute(
+        """SELECT COUNT(*) FROM activity_log
+           WHERE client_id = ?
+           AND created_at >= ? AND created_at <= ?""",
+        (client_id, window_start, window_end),
+    ).fetchone()[0]
+
+    return count > 0
+
+
+def scan_for_unlogged_sessions(
+    conn: sqlite3.Connection, start_date: str, end_date: str
+) -> int:
+    """Scan audit log and write unlogged sessions to suggested_activities.
+
+    Args:
+        conn: Database connection
+        start_date: ISO date string (inclusive)
+        end_date: ISO date string (inclusive)
+
+    Returns:
+        Number of new suggestions created.
+    """
+    gap_minutes = cfg.get("review_session_gap_minutes", 30)
+    dismiss_days = cfg.get("review_dismiss_days", 7)
+
+    # Expire old dismissals first
+    expire_dismissed_suggestions(conn)
+
+    # 1. Query audit log for tracked tables
+    placeholders = ",".join("?" * len(_TRACKED_TABLES))
+    rows = conn.execute(
+        f"""SELECT table_name, row_id, operation, old_values, new_values, changed_at
+            FROM audit_log
+            WHERE table_name IN ({placeholders})
+              AND date(changed_at) >= ? AND date(changed_at) <= ?
+            ORDER BY changed_at""",
+        list(_TRACKED_TABLES) + [start_date, end_date],
+    ).fetchall()
+
+    if not rows:
+        return 0
+
+    entries = [
+        {
+            "table_name": r[0],
+            "row_id": r[1],
+            "operation": r[2],
+            "old_values": r[3],
+            "new_values": r[4],
+            "changed_at": r[5],
+        }
+        for r in rows
+    ]
+
+    # 2. Resolve to client_ids
+    resolved = _resolve_client_ids(conn, entries)
+    if not resolved:
+        return 0
+
+    # 3. Cluster into sessions
+    client_sessions = _cluster_sessions(resolved, gap_minutes)
+
+    # 4. Process each session
+    created = 0
+    for client_id, sessions in client_sessions.items():
+        # Get client name for logging
+        client_row = conn.execute(
+            "SELECT name FROM clients WHERE id = ?", (client_id,)
+        ).fetchone()
+        client_name = client_row[0] if client_row else f"Client #{client_id}"
+
+        for session in sessions:
+            start_dt = datetime.fromisoformat(session[0]["changed_at"])
+            end_dt = datetime.fromisoformat(session[-1]["changed_at"])
+            session_date_str = start_dt.date().isoformat()
+
+            # Duration: round up to 0.1h, minimum 0.1
+            raw_hours = (end_dt - start_dt).total_seconds() / 3600
+            duration = max(0.1, math.ceil(raw_hours * 10) / 10)
+
+            # Check for bulk operation
+            is_bulk = _is_bulk_operation(session)
+
+            # Check for existing activity coverage
+            if _has_covering_activity(conn, client_id, session_date_str, start_dt, end_dt):
+                continue
+
+            # Build summary
+            summary, tables_touched, policy_uids = _build_summary(session)
+            if is_bulk:
+                summary = f"[Bulk Import] {summary}"
+
+            # Determine status (bulk = auto-dismissed)
+            status = "dismissed" if is_bulk else "pending"
+            dismissed_at = datetime.now().isoformat() if is_bulk else None
+            dismiss_expires = (
+                (datetime.now() + timedelta(days=dismiss_days)).isoformat()
+                if is_bulk
+                else None
+            )
+
+            # INSERT OR IGNORE (unique constraint on client_id + session_start)
+            try:
+                conn.execute(
+                    """INSERT OR IGNORE INTO suggested_activities
+                       (client_id, session_date, session_start, session_end,
+                        estimated_duration_hours, tables_touched, change_count,
+                        policy_uids, summary, status, dismissed_at, dismiss_expires_at)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        client_id,
+                        session_date_str,
+                        start_dt.isoformat(),
+                        end_dt.isoformat(),
+                        duration,
+                        tables_touched,
+                        len(session),
+                        policy_uids,
+                        summary,
+                        status,
+                        dismissed_at,
+                        dismiss_expires,
+                    ),
+                )
+                if conn.total_changes:
+                    created += 1
+            except Exception as e:
+                logger.warning("Failed to insert suggested activity: %s", e)
+
+    if created:
+        conn.commit()
+        logger.info("Activity review scan: %d new suggestions for %s to %s", created, start_date, end_date)
+
+    return created
+
+
+def get_pending_review_count(conn: sqlite3.Connection) -> int:
+    """Get count of pending suggested activities."""
+    try:
+        return conn.execute(
+            "SELECT COUNT(*) FROM suggested_activities WHERE status = 'pending'"
+        ).fetchone()[0]
+    except Exception:
+        return 0
+
+
+def get_pending_suggestions(conn: sqlite3.Connection) -> list[dict]:
+    """Get all pending suggestions with client names, ordered by session_start."""
+    try:
+        rows = conn.execute(
+            """SELECT sa.*, c.name as client_name
+               FROM suggested_activities sa
+               JOIN clients c ON c.id = sa.client_id
+               WHERE sa.status = 'pending'
+               ORDER BY sa.session_start DESC"""
+        ).fetchall()
+        cols = [d[0] for d in conn.execute(
+            """SELECT sa.*, c.name as client_name
+               FROM suggested_activities sa
+               JOIN clients c ON c.id = sa.client_id
+               LIMIT 0"""
+        ).description]
+        return [dict(zip(cols, r)) for r in rows]
+    except Exception:
+        return []
+
+
+def expire_dismissed_suggestions(conn: sqlite3.Connection) -> int:
+    """Reset expired dismissals back to pending.
+
+    Returns number of suggestions reset.
+    """
+    try:
+        now = datetime.now().isoformat()
+        conn.execute(
+            """UPDATE suggested_activities
+               SET status = 'pending', dismissed_at = NULL, dismiss_expires_at = NULL
+               WHERE status = 'dismissed'
+                 AND dismiss_expires_at IS NOT NULL
+                 AND dismiss_expires_at < ?""",
+            (now,),
+        )
+        count = conn.total_changes
+        if count:
+            conn.commit()
+            logger.info("Activity review: %d expired dismissals reset to pending", count)
+        return count
+    except Exception:
+        return 0

--- a/src/policydb/config.py
+++ b/src/policydb/config.py
@@ -507,6 +507,9 @@ _DEFAULTS: dict[str, Any] = {
     "migration_backup_retention_count": 10,
     "log_level": "INFO",
     "log_retention_days": 730,
+    "default_review_activity_type": "Other",
+    "review_session_gap_minutes": 30,
+    "review_dismiss_days": 7,
     "milestone_profiles": [
         {
             "name": "Full Renewal",

--- a/src/policydb/db.py
+++ b/src/policydb/db.py
@@ -359,7 +359,7 @@ def init_db(path: Path | None = None) -> None:
 
     # Back up the database once before running any pending migrations.
     # This gives a clean restore point regardless of which migration fails.
-    _KNOWN_MIGRATIONS = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72}
+    _KNOWN_MIGRATIONS = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73}
     if _KNOWN_MIGRATIONS - applied:
         _backup_db(conn, db_path)
 
@@ -1018,6 +1018,15 @@ def init_db(path: Path | None = None) -> None:
         )
         conn.commit()
 
+    if 73 not in applied:
+        sql = (_MIGRATIONS_DIR / "073_suggested_activities.sql").read_text()
+        conn.executescript(sql)
+        conn.execute(
+            "INSERT INTO schema_version (version, description) VALUES (?, ?)",
+            (73, "Suggested activities table for audit log review"),
+        )
+        conn.commit()
+
     # Data hygiene: fix 'None' string corruption in text fields (runs every startup, fast no-op if clean)
     conn.execute("UPDATE clients SET cn_number = NULL WHERE cn_number = 'None'")
 
@@ -1198,17 +1207,28 @@ def _purge_old_logs(conn: sqlite3.Connection) -> None:
     except Exception:
         pass  # Table may not exist yet
 
-    if audit_deleted or app_deleted:
+    suggested_deleted = 0
+    try:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM suggested_activities WHERE created_at < ?", (cutoff,)
+        ).fetchone()[0]
+        if count > 0:
+            conn.execute("DELETE FROM suggested_activities WHERE created_at < ?", (cutoff,))
+            suggested_deleted = count
+    except Exception:
+        pass  # Table may not exist yet
+
+    if audit_deleted or app_deleted or suggested_deleted:
         conn.commit()
         logger.info(
-            "Log purge: %d audit + %d app rows older than %d days deleted",
-            audit_deleted, app_deleted, retention_days,
+            "Log purge: %d audit + %d app + %d suggested rows older than %d days deleted",
+            audit_deleted, app_deleted, suggested_deleted, retention_days,
         )
         _HEALTH_STATUS["last_purge_audit"] = audit_deleted
         _HEALTH_STATUS["last_purge_app"] = app_deleted
 
         # VACUUM only on large purges — rewrites entire DB, expensive
-        total = audit_deleted + app_deleted
+        total = audit_deleted + app_deleted + suggested_deleted
         if total > 10_000:
             try:
                 conn.execute("VACUUM")

--- a/src/policydb/migrations/073_suggested_activities.sql
+++ b/src/policydb/migrations/073_suggested_activities.sql
@@ -1,0 +1,30 @@
+-- Migration 073: Suggested activities table for audit log review
+-- Stores detected work sessions that have no corresponding activity_log entry.
+
+CREATE TABLE IF NOT EXISTS suggested_activities (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    client_id INTEGER NOT NULL,
+    session_date DATE NOT NULL,
+    session_start DATETIME NOT NULL,
+    session_end DATETIME NOT NULL,
+    estimated_duration_hours REAL NOT NULL,
+    tables_touched TEXT,
+    change_count INTEGER NOT NULL,
+    policy_uids TEXT,
+    summary TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    dismissed_at DATETIME,
+    dismiss_expires_at DATETIME,
+    logged_activity_id INTEGER,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (client_id) REFERENCES clients(id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_suggested_activities_unique
+    ON suggested_activities(client_id, session_start);
+CREATE INDEX IF NOT EXISTS idx_suggested_activities_status
+    ON suggested_activities(status);
+CREATE INDEX IF NOT EXISTS idx_suggested_activities_date
+    ON suggested_activities(session_date);
+CREATE INDEX IF NOT EXISTS idx_suggested_activities_client
+    ON suggested_activities(client_id);

--- a/src/policydb/web/routes/action_center.py
+++ b/src/policydb/web/routes/action_center.py
@@ -9,6 +9,12 @@ from fastapi.responses import HTMLResponse
 
 from policydb.web.app import get_db, templates
 import policydb.config as cfg
+from policydb.activity_review import (
+    expire_dismissed_suggestions,
+    get_pending_review_count,
+    get_pending_suggestions,
+    scan_for_unlogged_sessions,
+)
 from policydb.queries import (
     get_activities,
     get_all_followups,
@@ -486,6 +492,8 @@ def action_center_page(request: Request, tab: str = "", conn=Depends(get_db)):
         tab_ctx = _activities_ctx(conn)
     elif initial_tab == "scratchpads":
         tab_ctx = _scratchpads_ctx(conn)
+    elif initial_tab == "activity-review":
+        tab_ctx = _activity_review_ctx(conn)
     # Always compute scratchpad count for tab badge
     scratchpad_count = 0
     if "scratchpads" not in tab_ctx:
@@ -509,6 +517,7 @@ def action_center_page(request: Request, tab: str = "", conn=Depends(get_db)):
         + len(tab_ctx.get("stale", []))
     )
     nudge_due_count = len(tab_ctx.get("nudge_due", []))
+    review_pending_count = get_pending_review_count(conn)
     ctx = {
         "request": request,
         "active": "action-center",
@@ -516,6 +525,7 @@ def action_center_page(request: Request, tab: str = "", conn=Depends(get_db)):
         "scratchpad_count": scratchpad_count,
         "act_now_count": act_now_count,
         "nudge_due_count": nudge_due_count,
+        "review_pending_count": review_pending_count,
         **sidebar,
         **tab_ctx,
         **health_ctx,
@@ -666,3 +676,146 @@ def set_disposition(
     ctx = _followups_ctx(conn, window=30, activity_type="", q="")
     ctx["request"] = request
     return templates.TemplateResponse("action_center/_followups.html", ctx)
+
+
+# ── Activity Review ──────────────────────────────────────────────────────────
+
+# Track last scan date in memory (resets on server restart)
+_last_scan_date: str | None = None
+
+
+def _activity_review_ctx(conn, scan_date: str = "") -> dict:
+    """Build context for the Activity Review tab."""
+    global _last_scan_date
+    today = date.today().isoformat()
+    target_date = scan_date or today
+
+    # Auto-scan for today if we haven't yet
+    if _last_scan_date != today and not scan_date:
+        scan_for_unlogged_sessions(conn, today, today)
+        _last_scan_date = today
+
+    suggestions = get_pending_suggestions(conn)
+    activity_types = cfg.get("activity_types", [])
+    default_activity_type = cfg.get("default_review_activity_type", "Other")
+
+    return {
+        "suggestions": suggestions,
+        "review_count": len(suggestions),
+        "scan_date": target_date,
+        "activity_types": activity_types,
+        "default_activity_type": default_activity_type,
+    }
+
+
+@router.get("/action-center/activity-review", response_class=HTMLResponse)
+def ac_activity_review(request: Request, conn=Depends(get_db)):
+    """Activity Review tab partial — lazy loaded."""
+    ctx = _activity_review_ctx(conn)
+    ctx["request"] = request
+    return templates.TemplateResponse("action_center/_activity_review.html", ctx)
+
+
+@router.post("/action-center/activity-review/scan", response_class=HTMLResponse)
+def ac_activity_review_scan(
+    request: Request,
+    scan_date: str = Form(""),
+    conn=Depends(get_db),
+):
+    """Run activity review scan for a specific date."""
+    global _last_scan_date
+    target = scan_date or date.today().isoformat()
+    scan_for_unlogged_sessions(conn, target, target)
+    _last_scan_date = target
+
+    ctx = _activity_review_ctx(conn, scan_date=target)
+    ctx["request"] = request
+    return templates.TemplateResponse("action_center/_activity_review.html", ctx)
+
+
+@router.post("/action-center/activity-review/{suggestion_id}/dismiss", response_class=HTMLResponse)
+def ac_dismiss_suggestion(
+    request: Request,
+    suggestion_id: int,
+    conn=Depends(get_db),
+):
+    """Soft-dismiss a suggested activity (resurfaces after configured days)."""
+    dismiss_days = cfg.get("review_dismiss_days", 7)
+    now = datetime.now()
+    expires = (now + timedelta(days=dismiss_days)).isoformat()
+    conn.execute(
+        """UPDATE suggested_activities
+           SET status = 'dismissed', dismissed_at = ?, dismiss_expires_at = ?
+           WHERE id = ?""",
+        (now.isoformat(), expires, suggestion_id),
+    )
+    conn.commit()
+
+    # Return empty string to remove the card + OOB badge update
+    count = get_pending_review_count(conn)
+    badge_html = f'<span id="review-badge" hx-swap-oob="true">'
+    if count:
+        badge_html += f'<span class="tab-badge" style="background:#f59e0b;color:white">{count}</span>'
+    badge_html += '</span>'
+    return HTMLResponse(badge_html)
+
+
+@router.post("/action-center/activity-review/{suggestion_id}/log", response_class=HTMLResponse)
+def ac_log_suggestion(
+    request: Request,
+    suggestion_id: int,
+    activity_type: str = Form(""),
+    subject: str = Form(""),
+    details: str = Form(""),
+    duration_hours: float = Form(0.1),
+    activity_date: str = Form(""),
+    policy_uid: str = Form(""),
+    conn=Depends(get_db),
+):
+    """Log a suggested activity as a real activity_log entry."""
+    # Look up the suggestion to get client_id
+    suggestion = conn.execute(
+        "SELECT * FROM suggested_activities WHERE id = ?", (suggestion_id,)
+    ).fetchone()
+    if not suggestion:
+        return HTMLResponse("")
+
+    client_id = suggestion["client_id"]
+    act_date = activity_date or suggestion["session_date"]
+
+    # Resolve policy_id from policy_uid if provided
+    policy_id = None
+    if policy_uid:
+        prow = conn.execute(
+            "SELECT id FROM policies WHERE policy_uid = ?", (policy_uid,)
+        ).fetchone()
+        if prow:
+            policy_id = prow["id"]
+
+    # Insert activity
+    cursor = conn.execute(
+        """INSERT INTO activity_log
+           (activity_date, client_id, policy_id, activity_type, subject,
+            details, duration_hours, account_exec, follow_up_done)
+           VALUES (?, ?, ?, ?, ?, ?, ?, 'Grant', 0)""",
+        (act_date, client_id, policy_id, activity_type or "Other",
+         subject or "Account work (from review)", details, duration_hours),
+    )
+    activity_id = cursor.lastrowid
+
+    # Mark suggestion as logged
+    conn.execute(
+        """UPDATE suggested_activities
+           SET status = 'logged', logged_activity_id = ?
+           WHERE id = ?""",
+        (activity_id, suggestion_id),
+    )
+    conn.commit()
+
+    # Return empty + OOB badge update
+    count = get_pending_review_count(conn)
+    badge_html = f'<span id="review-badge" hx-swap-oob="true">'
+    if count:
+        badge_html += f'<span class="tab-badge" style="background:#f59e0b;color:white">{count}</span>'
+    badge_html += '</span>'
+    return HTMLResponse(badge_html)

--- a/src/policydb/web/templates/action_center/_activity_review.html
+++ b/src/policydb/web/templates/action_center/_activity_review.html
@@ -1,0 +1,54 @@
+{# Action Center — Activity Review Tab (HTMX partial, no base inheritance) #}
+<div id="ac-activity-review-panel">
+
+  {# ── Header bar ── #}
+  <div class="flex items-center justify-between mb-4">
+    <div class="flex items-center gap-3">
+      <h2 class="text-sm font-semibold text-gray-700">Activity Review</h2>
+      <span class="text-xs text-gray-400">
+        {% if review_count %}
+          {{ review_count }} unlogged session{{ 's' if review_count != 1 else '' }}
+        {% else %}
+          All caught up
+        {% endif %}
+      </span>
+    </div>
+
+    <form hx-post="/action-center/activity-review/scan"
+          hx-target="#ac-activity-review-panel"
+          hx-swap="outerHTML"
+          class="flex items-center gap-2">
+      <input type="date" name="scan_date" value="{{ scan_date }}"
+             class="text-xs border border-gray-200 rounded px-2 py-1 text-gray-600">
+      <button type="submit"
+              class="text-xs font-medium px-3 py-1.5 rounded bg-gray-100 text-gray-700 hover:bg-gray-200 transition-colors">
+        Scan
+      </button>
+    </form>
+  </div>
+
+  {# ── Session cards ── #}
+  {% if suggestions %}
+  <div class="space-y-3">
+    {% for s in suggestions %}
+    {% include "action_center/_review_card.html" %}
+    {% endfor %}
+  </div>
+  <script>
+  function toggleLogForm(id) {
+    var el = document.getElementById('log-form-' + id);
+    if (el) el.classList.toggle('hidden');
+  }
+  </script>
+  {% else %}
+  <div class="text-center py-12 text-gray-400">
+    <svg class="w-10 h-10 mx-auto mb-3 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+            d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    <p class="text-sm font-medium">No unlogged sessions found</p>
+    <p class="text-xs mt-1">Use the date picker and Scan button to check other days</p>
+  </div>
+  {% endif %}
+
+</div>

--- a/src/policydb/web/templates/action_center/_review_card.html
+++ b/src/policydb/web/templates/action_center/_review_card.html
@@ -1,0 +1,131 @@
+{# Single session card for Activity Review — used in loop and OOB swaps #}
+<div id="review-card-{{ s.id }}" class="bg-white border border-gray-200 rounded-lg p-4 hover:border-gray-300 transition-colors">
+
+  {# ── Header row: client + time ── #}
+  <div class="flex items-center justify-between mb-2">
+    <a href="/clients/{{ s.client_id }}" class="text-sm font-semibold text-marsh hover:underline">
+      {{ s.client_name }}
+    </a>
+    <span class="text-xs text-gray-400">
+      {{ s.session_start[11:16] }} – {{ s.session_end[11:16] }}
+    </span>
+  </div>
+
+  {# ── Stats row ── #}
+  <div class="flex items-center gap-3 mb-2 text-xs text-gray-500">
+    <span>~{{ s.estimated_duration_hours }} hrs</span>
+    <span class="text-gray-300">·</span>
+    <span>{{ s.change_count }} change{{ 's' if s.change_count != 1 else '' }}</span>
+    {% if s.session_date %}
+    <span class="text-gray-300">·</span>
+    <span>{{ s.session_date }}</span>
+    {% endif %}
+  </div>
+
+  {# ── Summary ── #}
+  <p class="text-xs text-gray-600 mb-2">{{ s.summary }}</p>
+
+  {# ── Policy pills ── #}
+  {% if s.policy_uids %}
+  <div class="flex flex-wrap gap-1 mb-3">
+    {% for uid in s.policy_uids.split(', ') %}
+    {% if uid %}
+    <a href="/policies/{{ uid }}"
+       class="inline-block text-[10px] font-mono px-1.5 py-0.5 rounded bg-indigo-50 text-indigo-600 hover:bg-indigo-100">
+      {{ uid }}
+    </a>
+    {% endif %}
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  {# ── Actions ── #}
+  <div class="flex items-center justify-end gap-2">
+    <button hx-post="/action-center/activity-review/{{ s.id }}/dismiss"
+            hx-target="#review-card-{{ s.id }}"
+            hx-swap="outerHTML"
+            class="text-xs text-gray-400 hover:text-gray-600 px-2 py-1 rounded hover:bg-gray-50 transition-colors">
+      Dismiss
+    </button>
+    <button onclick="toggleLogForm({{ s.id }})"
+            class="text-xs font-medium text-marsh hover:text-marsh/80 px-3 py-1.5 rounded bg-marsh/5 hover:bg-marsh/10 transition-colors">
+      Log Activity →
+    </button>
+  </div>
+
+  {# ── Inline log form (hidden by default) ── #}
+  <div id="log-form-{{ s.id }}" class="hidden mt-3 pt-3 border-t border-gray-100">
+    <form hx-post="/action-center/activity-review/{{ s.id }}/log"
+          hx-target="#review-card-{{ s.id }}"
+          hx-swap="outerHTML"
+          class="space-y-3">
+
+      <div class="grid grid-cols-2 gap-3">
+        {# Activity type #}
+        <div>
+          <label class="block text-[10px] font-medium text-gray-500 mb-1">Type</label>
+          <select name="activity_type"
+                  class="w-full text-xs border border-gray-200 rounded px-2 py-1.5 text-gray-700">
+            {% for at in activity_types %}
+            <option value="{{ at }}" {{ 'selected' if at == default_activity_type else '' }}>{{ at }}</option>
+            {% endfor %}
+          </select>
+        </div>
+
+        {# Duration #}
+        <div>
+          <label class="block text-[10px] font-medium text-gray-500 mb-1">Duration (hrs)</label>
+          <input type="number" name="duration_hours" value="{{ s.estimated_duration_hours }}"
+                 step="0.1" min="0.1"
+                 class="w-full text-xs border border-gray-200 rounded px-2 py-1.5 text-gray-700">
+        </div>
+      </div>
+
+      <div class="grid grid-cols-2 gap-3">
+        {# Date #}
+        <div>
+          <label class="block text-[10px] font-medium text-gray-500 mb-1">Date</label>
+          <input type="date" name="activity_date" value="{{ s.session_date }}"
+                 class="w-full text-xs border border-gray-200 rounded px-2 py-1.5 text-gray-700">
+        </div>
+
+        {# Policy UID #}
+        <div>
+          <label class="block text-[10px] font-medium text-gray-500 mb-1">Policy</label>
+          <input type="text" name="policy_uid"
+                 value="{{ s.policy_uids.split(', ')[0] if s.policy_uids else '' }}"
+                 placeholder="e.g. POL-042"
+                 class="w-full text-xs border border-gray-200 rounded px-2 py-1.5 text-gray-700">
+        </div>
+      </div>
+
+      {# Subject #}
+      <div>
+        <label class="block text-[10px] font-medium text-gray-500 mb-1">Subject</label>
+        <input type="text" name="subject" value="{{ s.summary }}"
+               class="w-full text-xs border border-gray-200 rounded px-2 py-1.5 text-gray-700">
+      </div>
+
+      {# Details #}
+      <div>
+        <label class="block text-[10px] font-medium text-gray-500 mb-1">Details</label>
+        <textarea name="details" rows="2"
+                  class="w-full text-xs border border-gray-200 rounded px-2 py-1.5 text-gray-700 resize-y"
+                  placeholder="Additional notes..."></textarea>
+      </div>
+
+      <div class="flex justify-end gap-2">
+        <button type="button" onclick="toggleLogForm({{ s.id }})"
+                class="text-xs text-gray-400 hover:text-gray-600 px-2 py-1">
+          Cancel
+        </button>
+        <button type="submit"
+                class="text-xs font-medium text-white bg-marsh hover:bg-marsh/90 px-3 py-1.5 rounded transition-colors">
+          Save Activity
+        </button>
+      </div>
+    </form>
+  </div>
+
+</div>
+

--- a/src/policydb/web/templates/action_center/page.html
+++ b/src/policydb/web/templates/action_center/page.html
@@ -37,6 +37,15 @@
             <span class="tab-badge" style="background:#ef4444;color:white">{{ _sp_count }}</span>
           {% endif %}
         </button>
+        <button class="tab-btn" data-tab="activity-review" data-tab-url="/action-center/activity-review">
+          Activity Review
+          <span id="review-badge">
+          {% set _rev_count = review_pending_count if review_pending_count is defined else 0 %}
+          {% if _rev_count %}
+            <span class="tab-badge" style="background:#f59e0b;color:white">{{ _rev_count }}</span>
+          {% endif %}
+          </span>
+        </button>
       </div>
 
       {# Tab content area #}
@@ -50,6 +59,8 @@
           {% include "action_center/_activities.html" %}
         {% elif initial_tab == 'scratchpads' %}
           {% include "action_center/_scratchpads.html" %}
+        {% elif initial_tab == 'activity-review' %}
+          {% include "action_center/_activity_review.html" %}
         {% endif %}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Adds a session detection engine that scans the audit log, clusters changes into per-client work sessions, and identifies sessions with no corresponding activity entry
- New "Activity Review" tab in Action Center with session cards, pre-filled log forms, and soft dismiss (7-day expiry)
- Passive badge on the tab for unlogged session count
- Bulk import detection auto-dismisses reconciler/importer noise
- New migration 073 (suggested_activities table), 3 config keys

## Test plan
- [x] Tab renders with correct badge count
- [x] Auto-scan detects sessions from audit log on first tab load
- [x] Session cards show client name, policies, time range, change count
- [x] "Log Activity" opens pre-filled form, saves to activity_log, removes card, updates badge
- [x] "Dismiss" soft-dismisses card, updates badge
- [x] No regressions on existing Action Center tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)