### PR TITLE
feat: project-level activity logging — single row instead of N-row fan-out

### DIFF
--- a/src/policydb/db.py
+++ b/src/policydb/db.py
@@ -1027,6 +1027,15 @@ def init_db(path: Path | None = None) -> None:
         )
         conn.commit()
 
+    if 74 not in applied:
+        sql = (_MIGRATIONS_DIR / "074_activity_project_id.sql").read_text()
+        conn.executescript(sql)
+        conn.execute(
+            "INSERT INTO schema_version (version, description) VALUES (?, ?)",
+            (74, "Add project_id to activity_log for project-level activities"),
+        )
+        conn.commit()
+
     # Data hygiene: fix 'None' string corruption in text fields (runs every startup, fast no-op if clean)
     conn.execute("UPDATE clients SET cn_number = NULL WHERE cn_number = 'None'")
 

--- a/src/policydb/migrations/074_activity_project_id.sql
+++ b/src/policydb/migrations/074_activity_project_id.sql
@@ -1,0 +1,9 @@
+-- Migration 074: Add project_id to activity_log for project-level activities.
+--
+-- Previously, logging an activity against a project created N rows (one per policy).
+-- This adds a project_id FK so a single row can represent a project-level activity
+-- with policy_id NULL.
+
+ALTER TABLE activity_log ADD COLUMN project_id INTEGER REFERENCES projects(id);
+
+CREATE INDEX IF NOT EXISTS idx_activity_log_project_id ON activity_log(project_id);

--- a/src/policydb/queries.py
+++ b/src/policydb/queries.py
@@ -396,10 +396,13 @@ def get_activities(
     activity_type: Optional[str] = None,
     client_ids: list[int] | None = None,
 ) -> list[sqlite3.Row]:
-    sql = """SELECT a.*, c.name AS client_name, c.cn_number, p.policy_uid, p.project_id
+    sql = """SELECT a.*, c.name AS client_name, c.cn_number, p.policy_uid,
+                    COALESCE(a.project_id, p.project_id) AS project_id,
+                    pr.name AS project_name
              FROM activity_log a
              JOIN clients c ON a.client_id = c.id
              LEFT JOIN policies p ON a.policy_id = p.id
+             LEFT JOIN projects pr ON COALESCE(a.project_id, p.project_id) = pr.id
              WHERE 1=1"""
     params: list = []
     if client_ids:
@@ -563,6 +566,34 @@ def get_all_followups(
     LEFT JOIN policies p ON a.policy_id = p.id
     LEFT JOIN contacts co_a ON a.contact_id = co_a.id
     WHERE a.follow_up_done = 0 AND a.follow_up_date IS NOT NULL
+      AND (a.project_id IS NULL OR a.policy_id IS NOT NULL)
+
+    UNION ALL
+
+    SELECT 'project' AS source,
+           a.id, a.subject, a.follow_up_date, a.activity_type,
+           a.contact_person, a.disposition, a.thread_id,
+           c.name AS client_name, c.id AS client_id, c.cn_number,
+           NULL AS policy_uid, NULL AS policy_type, NULL AS carrier,
+           pr.name AS project_name, a.project_id,
+           0 AS is_opportunity,
+           CAST(julianday('now') - julianday(a.follow_up_date) AS INTEGER) AS days_overdue,
+           co_a2.email AS contact_email,
+           (SELECT GROUP_CONCAT(co_i4.email, ',')
+            FROM contact_client_assignments cca_i4
+            JOIN contacts co_i4 ON cca_i4.contact_id = co_i4.id
+            WHERE cca_i4.client_id = c.id AND cca_i4.contact_type = 'internal'
+              AND co_i4.email IS NOT NULL
+           ) AS internal_cc,
+           a.details AS note_details,
+           NULL AS note_subject,
+           a.activity_date AS note_date
+    FROM activity_log a
+    JOIN clients c ON a.client_id = c.id
+    LEFT JOIN projects pr ON a.project_id = pr.id
+    LEFT JOIN contacts co_a2 ON a.contact_id = co_a2.id
+    WHERE a.follow_up_done = 0 AND a.follow_up_date IS NOT NULL
+      AND a.project_id IS NOT NULL AND a.policy_id IS NULL
 
     UNION ALL
 
@@ -680,6 +711,8 @@ def get_all_followups(
             r["source_label"] = "Renewal"
         elif src == "client":
             r["source_label"] = "Client"
+        elif src == "project":
+            r["source_label"] = "Project"
         else:
             r["source_label"] = ""
 
@@ -687,7 +720,7 @@ def get_all_followups(
     _today = date.today()
     for r in all_rows:
         src = r.get("source")
-        if src == "activity":
+        if src in ("activity", "project"):
             disp = r.get("disposition")
             if disp:
                 days_over = r.get("days_overdue") or 0
@@ -724,7 +757,7 @@ def get_all_followups(
             r["reason_line"] = ""
 
     # Enrich activity-sourced items with prev_disposition and prev_days_ago
-    activity_items = [r for r in all_rows if r.get("source") == "activity" and r.get("id")]
+    activity_items = [r for r in all_rows if r.get("source") in ("activity", "project") and r.get("id")]
     if activity_items:
         act_ids = [r["id"] for r in activity_items]
         placeholders = ",".join("?" * len(act_ids))

--- a/src/policydb/web/routes/action_center.py
+++ b/src/policydb/web/routes/action_center.py
@@ -68,7 +68,7 @@ def _classify_item(item: dict, today: date, stale_threshold: int, dispositions: 
     fu_date_str = item.get("follow_up_date", "")
 
     # Step 1: Triage — activity items with no disposition
-    if source == "activity" and not disposition.strip():
+    if source in ("activity", "project") and not disposition.strip():
         return "triage"
 
     # Step 2: Map disposition → accountability

--- a/src/policydb/web/routes/activities.py
+++ b/src/policydb/web/routes/activities.py
@@ -199,10 +199,13 @@ def activity_complete(
 def _activity_row_dict(conn, activity_id: int) -> dict | None:
     """Fetch a single activity row with client_name and policy_uid for template rendering."""
     row = conn.execute(
-        """SELECT a.*, c.name AS client_name, c.id AS client_id, c.cn_number, p.policy_uid, p.project_id
+        """SELECT a.*, c.name AS client_name, c.id AS client_id, c.cn_number, p.policy_uid,
+                  COALESCE(a.project_id, p.project_id) AS project_id,
+                  pr.name AS project_name
            FROM activity_log a
            JOIN clients c ON a.client_id = c.id
            LEFT JOIN policies p ON a.policy_id = p.id
+           LEFT JOIN projects pr ON COALESCE(a.project_id, p.project_id) = pr.id
            WHERE a.id = ?""",
         (activity_id,),
     ).fetchone()
@@ -394,11 +397,12 @@ def activity_followup(
 
     cursor = conn.execute(
         """INSERT INTO activity_log
-           (activity_date, client_id, policy_id, activity_type, contact_person,
+           (activity_date, client_id, policy_id, project_id, activity_type, contact_person,
             subject, details, follow_up_date, account_exec, duration_hours)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (date.today().isoformat(), original["client_id"],
          original.get("policy_id") or None,
+         original.get("project_id") or None,
          original.get("activity_type", "Call"),
          original.get("contact_person") or None,
          subject, notes or None,
@@ -435,19 +439,23 @@ def activity_followup(
         new_id = cursor.lastrowid
         frow = conn.execute(
             """SELECT a.*, c.name AS client_name, c.cn_number, c.id AS client_id,
-                      p.policy_uid, p.project_id, p.policy_type, p.carrier, p.project_name,
+                      p.policy_uid, COALESCE(a.project_id, p.project_id) AS project_id,
+                      p.policy_type, p.carrier,
+                      COALESCE(pr.name, p.project_name) AS project_name,
                       CAST(julianday('now') - julianday(a.follow_up_date) AS INTEGER) AS days_overdue,
                       NULL AS contact_email, NULL AS internal_cc
                FROM activity_log a
                JOIN clients c ON a.client_id = c.id
                LEFT JOIN policies p ON a.policy_id = p.id
+               LEFT JOIN projects pr ON COALESCE(a.project_id, p.project_id) = pr.id
                WHERE a.id = ?""",
             (new_id,),
         ).fetchone()
         if not frow:
             return HTMLResponse("")
         r = dict(frow)
-        r["source"] = "activity"
+        # Set source based on whether this is project-level or policy-level
+        r["source"] = "project" if (r.get("project_id") and not r.get("policy_id")) else "activity"
         today_str = date.today().isoformat()
         r["_is_overdue"] = (r.get("follow_up_date") or "") < today_str
         r["note_details"] = r.get("details")

--- a/src/policydb/web/routes/clients.py
+++ b/src/policydb/web/routes/clients.py
@@ -3182,10 +3182,20 @@ def _project_contacts(conn, client_id: int, project: str) -> list[dict]:
 
 @router.get("/{client_id}/project/log-form", response_class=HTMLResponse)
 def project_log_form(request: Request, client_id: int, project: str, conn=Depends(get_db)):
-    """HTMX partial: inline activity log form for all policies in a project."""
+    """HTMX partial: inline activity log form for a project."""
     ctx = _project_note_ctx(conn, client_id, project)
     ctx["activity_types"] = cfg.get("activity_types")
     ctx["contacts"] = _project_contacts(conn, client_id, project)
+    # Policies list for "Specific policy" scope dropdown
+    if ctx.get("project_id"):
+        policies = conn.execute(
+            """SELECT id, policy_uid, policy_type, carrier FROM policies
+               WHERE project_id = ? AND archived = 0 ORDER BY policy_type""",
+            (ctx["project_id"],),
+        ).fetchall()
+        ctx["policies"] = [dict(p) for p in policies]
+    else:
+        ctx["policies"] = []
     return templates.TemplateResponse("clients/_project_log_form.html", {"request": request, **ctx})
 
 
@@ -3199,19 +3209,13 @@ def project_log_save(
     subject: str = Form(...),
     details: str = Form(""),
     follow_up_date: str = Form(""),
-    follow_up_scope: str = Form("all"),
+    scope: str = Form("project"),
+    specific_policy_id: int = Form(0),
     duration_hours: str = Form(""),
     conn=Depends(get_db),
 ):
-    """Create an activity log entry for every active policy in a project."""
+    """Create a single activity log entry at project or specific-policy level."""
     from datetime import date
-    policies = conn.execute(
-        """SELECT id FROM policies
-           WHERE client_id = ? AND LOWER(TRIM(COALESCE(project_name,''))) = LOWER(TRIM(?))
-             AND archived = 0
-           ORDER BY id""",
-        (client_id, project_name),
-    ).fetchall()
     account_exec = cfg.get("default_account_exec", "")
     dur = None
     if duration_hours and duration_hours.strip():
@@ -3231,33 +3235,59 @@ def project_log_save(
         if _row:
             _contact_id = _row["id"]
 
-    # follow_up_scope: "all" = set follow-up on every policy, "lead" = only the first
-    _fu_date_for = follow_up_date if follow_up_date else None
-    count = 0
-    for i, p in enumerate(policies):
-        # Only set follow-up on first policy if scope is "lead"
-        row_fu = _fu_date_for if (follow_up_scope == "all" or i == 0) else None
+    # Resolve project_id from projects table
+    proj_row = conn.execute(
+        "SELECT id FROM projects WHERE client_id = ? AND LOWER(TRIM(name)) = LOWER(TRIM(?))",
+        (client_id, project_name),
+    ).fetchone()
+    _project_id = proj_row["id"] if proj_row else None
+
+    _fu_date = follow_up_date if follow_up_date else None
+
+    if scope == "policy" and specific_policy_id:
+        # Specific policy scope: one row with policy_id set
         conn.execute(
             """INSERT INTO activity_log
-               (activity_date, client_id, policy_id, activity_type, contact_person,
+               (activity_date, client_id, policy_id, project_id, activity_type, contact_person,
                 contact_id, subject, details, follow_up_date, duration_hours, account_exec)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-            (today, client_id, p["id"], activity_type, contact_person or None,
-             _contact_id, subject, details or None, row_fu, dur, account_exec),
+               VALUES (?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (today, client_id, specific_policy_id, activity_type, contact_person or None,
+             _contact_id, subject, details or None, _fu_date, dur, account_exec),
         )
-        if row_fu:
+        if _fu_date:
             from policydb.queries import supersede_followups
-            supersede_followups(conn, p["id"], row_fu)
-        count += 1
+            supersede_followups(conn, specific_policy_id, _fu_date)
+        # Look up policy_uid for success message
+        pol = conn.execute("SELECT policy_uid FROM policies WHERE id=?", (specific_policy_id,)).fetchone()
+        log_msg = f"Logged activity to {pol['policy_uid']}" if pol else "Logged activity to policy"
+    else:
+        # Project-level scope: one row with project_id set, policy_id NULL
+        conn.execute(
+            """INSERT INTO activity_log
+               (activity_date, client_id, policy_id, project_id, activity_type, contact_person,
+                contact_id, subject, details, follow_up_date, duration_hours, account_exec)
+               VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (today, client_id, _project_id, activity_type, contact_person or None,
+             _contact_id, subject, details or None, _fu_date, dur, account_exec),
+        )
+        # No supersede_followups for project-level activities (no policy_id to chain)
+        log_msg = f"Logged project activity to {project_name}"
+
     conn.commit()
     # Return the log form again with a success banner
     ctx = _project_note_ctx(conn, client_id, project_name)
     ctx["activity_types"] = cfg.get("activity_types")
     ctx["contacts"] = _project_contacts(conn, client_id, project_name)
-    fu_note = ""
-    if _fu_date_for and follow_up_scope == "lead":
-        fu_note = " (follow-up on lead policy only)"
-    ctx["log_success"] = f'Logged to {count} polic{"y" if count == 1 else "ies"} in {project_name}{fu_note}'
+    if _project_id:
+        policies = conn.execute(
+            """SELECT id, policy_uid, policy_type, carrier FROM policies
+               WHERE project_id = ? AND archived = 0 ORDER BY policy_type""",
+            (_project_id,),
+        ).fetchall()
+        ctx["policies"] = [dict(p) for p in policies]
+    else:
+        ctx["policies"] = []
+    ctx["log_success"] = log_msg
     return templates.TemplateResponse("clients/_project_log_form.html", {"request": request, **ctx})
 
 

--- a/src/policydb/web/routes/policies.py
+++ b/src/policydb/web/routes/policies.py
@@ -1536,10 +1536,13 @@ def policy_tab_activity(request: Request, policy_uid: str, conn=Depends(get_db))
         return HTMLResponse("Not found", status_code=404)
 
     activities = [dict(r) for r in conn.execute(
-        """SELECT a.*, c.name AS client_name, c.cn_number, p.policy_uid, p.project_id
+        """SELECT a.*, c.name AS client_name, c.cn_number, p.policy_uid,
+                  COALESCE(a.project_id, p.project_id) AS project_id,
+                  pr.name AS project_name
            FROM activity_log a
            JOIN clients c ON a.client_id = c.id
            LEFT JOIN policies p ON a.policy_id = p.id
+           LEFT JOIN projects pr ON COALESCE(a.project_id, p.project_id) = pr.id
            WHERE a.policy_id = ? AND a.activity_date >= date('now', '-90 days')
            ORDER BY
              CASE WHEN a.follow_up_date IS NOT NULL AND (a.follow_up_done IS NULL OR a.follow_up_done = 0) THEN 0 ELSE 1 END,
@@ -1547,6 +1550,39 @@ def policy_tab_activity(request: Request, policy_uid: str, conn=Depends(get_db))
              a.activity_date DESC, a.id DESC""",
         (policy_dict["id"],),
     ).fetchall()]
+
+    # Cross-reference: project-level activities for the same project
+    _proj_id = policy_dict.get("project_id")
+    if _proj_id:
+        xrefs = [dict(r) for r in conn.execute(
+            """SELECT a.*, c.name AS client_name, c.cn_number, NULL AS policy_uid,
+                      a.project_id, pr.name AS project_name
+               FROM activity_log a
+               JOIN clients c ON a.client_id = c.id
+               LEFT JOIN projects pr ON a.project_id = pr.id
+               WHERE a.project_id = ? AND a.policy_id IS NULL
+                 AND a.activity_date >= date('now', '-90 days')
+               ORDER BY a.activity_date DESC, a.id DESC""",
+            (_proj_id,),
+        ).fetchall()]
+        for xa in xrefs:
+            xa["is_project_xref"] = True
+        activities.extend(xrefs)
+        # Re-sort to match original order: open follow-ups first (by fu date asc), then by activity_date desc
+        def _sort_key(x):
+            has_open_fu = bool(x.get("follow_up_date") and not x.get("follow_up_done"))
+            return (
+                0 if has_open_fu else 1,
+                x.get("follow_up_date", "9999") if has_open_fu else "9999",
+                "9999-99-99" if has_open_fu else (x.get("activity_date") or ""),  # secondary: date desc for non-fu
+            )
+        activities.sort(key=_sort_key)
+        # Within same sort group, reverse activity_date for non-fu items
+        # Simpler: just stable-sort non-fu items by date desc
+        fu_items = [a for a in activities if a.get("follow_up_date") and not a.get("follow_up_done")]
+        other_items = [a for a in activities if not (a.get("follow_up_date") and not a.get("follow_up_done"))]
+        other_items.sort(key=lambda x: (x.get("activity_date", ""), x.get("id", 0)), reverse=True)
+        activities = fu_items + other_items
 
     all_contact_names = [r[0] for r in conn.execute(
         "SELECT DISTINCT name FROM contacts WHERE name IS NOT NULL AND name != '' ORDER BY name"

--- a/src/policydb/web/templates/action_center/_followup_sections.html
+++ b/src/policydb/web/templates/action_center/_followup_sections.html
@@ -21,6 +21,7 @@
       {% elif item.source_label == 'Renewal' %}bg-amber-100 text-amber-700
       {% elif item.source_label == 'Opportunity' %}bg-emerald-100 text-emerald-700
       {% elif item.source_label == 'Client' %}bg-gray-100 text-gray-600
+      {% elif item.source_label == 'Project' %}bg-purple-100 text-purple-700
       {% endif %}">{{ item.source_label }}</span>
     {% endif %}
 
@@ -53,6 +54,10 @@
           {{ item.milestone_name }} &middot; {{ item.policy_type }}
         {% elif item.policy_uid %}
           <a href="/policies/{{ item.policy_uid }}/edit" class="hover:text-[#003865] hover:underline">{{ item.policy_type }}{% if item.carrier %} <span class="text-gray-400">&middot; {{ item.carrier }}</span>{% endif %}</a>
+        {% elif item.source == 'project' %}
+          <span class="text-[10px] bg-purple-50 text-purple-600 font-medium px-1.5 py-0.5 rounded inline-flex items-center gap-0.5"><span>&#128205;</span> {{ item.project_name or 'Project' }}</span>
+          <span class="text-gray-400">&middot;</span>
+          {{ item.subject }}
         {% elif item.source == 'policy' %}
           {{ item.policy_type }}{% if item.carrier %} <span class="text-gray-400">&middot; {{ item.carrier }}</span>{% endif %}
         {% else %}
@@ -189,7 +194,11 @@
         {% with ref_tag=_fu_ref %}{% include "_ref_tag_pill.html" %}{% endwith %}
       </div>
       <div class="text-xs text-gray-600 truncate mt-0.5">
-        {% if item.source == 'policy' %}
+        {% if item.source == 'project' %}
+          <span class="text-[10px] bg-purple-50 text-purple-600 font-medium px-1.5 py-0.5 rounded inline-flex items-center gap-0.5"><span>&#128205;</span> {{ item.project_name or 'Project' }}</span>
+          <span class="text-gray-400">&middot;</span>
+          {{ item.subject }}
+        {% elif item.source == 'policy' %}
           {{ item.policy_type }}{% if item.carrier %} <span class="text-gray-400">&middot; {{ item.carrier }}</span>{% endif %}
         {% else %}
           {{ item.subject }}

--- a/src/policydb/web/templates/activities/_activity_row.html
+++ b/src/policydb/web/templates/activities/_activity_row.html
@@ -1,3 +1,22 @@
+{% if a.get('is_project_xref') %}
+{# ── Project cross-reference: lighter purple, read-only ── #}
+<li class="activity-item px-5 py-3 bg-purple-50/50 border-l-2 border-purple-200 italic" data-has-followup="0" data-followup-date="" data-activity-date="{{ a.activity_date }}" data-activity-id="{{ a.id }}">
+  <div class="flex-1 min-w-0">
+    <div class="flex items-center gap-2 flex-wrap">
+      <span class="text-[10px] bg-purple-100 text-purple-600 font-medium px-1.5 py-0.5 rounded inline-flex items-center gap-0.5"><span>&#128205;</span> {{ a.project_name or 'Project' }}</span>
+      <span class="text-xs font-medium bg-gray-100 text-gray-600 px-2 py-0.5 rounded">{{ a.activity_type }}</span>
+      <span class="text-sm text-gray-600">{{ a.subject }}</span>
+      {% if a.duration_hours %}<span class="text-xs bg-blue-50 text-blue-600 px-1.5 py-0.5 rounded">{{ a.duration_hours }}h</span>{% endif %}
+    </div>
+    {% if a.details %}<p class="text-xs text-gray-400 mt-1 line-clamp-2">{{ a.details }}</p>{% endif %}
+    <p class="text-xs text-gray-400 mt-1">
+      {{ a.activity_date }}
+      {% if a.contact_person %} &middot; {{ a.contact_person }}{% endif %}
+      {% if a.follow_up_date %} &middot; <span class="{% if not a.follow_up_done %}text-purple-500{% else %}line-through text-gray-300{% endif %}">Follow-up {{ a.follow_up_date }}</span>{% endif %}
+    </p>
+  </div>
+</li>
+{% else %}
 <li id="activity-{{ a.id }}" class="activity-item px-5 py-3 flex items-start justify-between gap-4" data-has-followup="{{ '1' if a.follow_up_date and not a.follow_up_done else '0' }}" data-followup-date="{{ a.follow_up_date if a.follow_up_date and not a.follow_up_done else '' }}" data-activity-date="{{ a.activity_date }}" data-activity-id="{{ a.id }}">
   {% set _a_rfi_uid = a.subject.split('Send RFI: ')[1].split(' ', 1)[0] if a.subject and a.subject.startswith('Send RFI: ') else '' %}
   {% set _a_ref = build_ref_tag(cn_number=a.cn_number|default(''), client_id=a.client_id, policy_uid=a.policy_uid|default(''), project_id=a.project_id|default(0), activity_id=a.id, rfi_uid=_a_rfi_uid) %}
@@ -160,3 +179,4 @@ function actMarkDoneOnly(btn, actId) {
   btn.closest('li').classList.add('hidden');
 }
 </script>
+{% endif %}

--- a/src/policydb/web/templates/clients/_project_log_form.html
+++ b/src/policydb/web/templates/clients/_project_log_form.html
@@ -10,7 +10,30 @@
     <p class="text-xs text-green-700 font-medium bg-green-100 rounded px-2 py-1">{{ log_success }}</p>
     {% endif %}
 
-    <p class="text-xs font-medium text-gray-600">Log activity to all {{ policy_count }} polic{{ 'y' if policy_count == 1 else 'ies' }} in <span class="font-semibold">{{ project_name }}</span></p>
+    <p class="text-xs font-medium text-gray-600">Log activity for <span class="font-semibold">{{ project_name }}</span></p>
+
+    {# Scope selector: project-level (default) or specific policy #}
+    <div class="flex items-center gap-4 text-xs text-gray-600">
+      <span class="text-gray-500 font-medium">Scope:</span>
+      <label class="flex items-center gap-1 cursor-pointer">
+        <input type="radio" name="scope" value="project" checked class="accent-green-600"
+          onchange="document.getElementById('policy-picker-{{ project_id }}').style.display='none'">
+        Project-level
+      </label>
+      <label class="flex items-center gap-1 cursor-pointer">
+        <input type="radio" name="scope" value="policy" class="accent-green-600"
+          onchange="document.getElementById('policy-picker-{{ project_id }}').style.display=''">
+        Specific policy
+      </label>
+    </div>
+    <div id="policy-picker-{{ project_id }}" style="display:none" class="ml-4">
+      <select name="specific_policy_id" class="border border-gray-300 rounded px-2 py-1 text-xs w-full bg-white focus:outline-none focus:ring-1 focus:ring-marsh">
+        <option value="">Select policy...</option>
+        {% for p in policies %}
+        <option value="{{ p.id }}">{{ p.policy_uid }} &mdash; {{ p.policy_type }}{% if p.carrier %} &middot; {{ p.carrier }}{% endif %}</option>
+        {% endfor %}
+      </select>
+    </div>
 
     <div class="grid grid-cols-4 gap-2">
       <div>
@@ -22,9 +45,9 @@
       </div>
       <div>
         <p class="text-xs text-gray-500 mb-0.5">Contact Person</p>
-        <input type="text" name="contact_person" list="proj-log-contacts" autocomplete="off"
+        <input type="text" name="contact_person" list="proj-log-contacts-{{ project_id }}" autocomplete="off"
           class="border border-gray-300 rounded px-2 py-1 text-xs w-full focus:outline-none focus:ring-1 focus:ring-marsh">
-        <datalist id="proj-log-contacts">
+        <datalist id="proj-log-contacts-{{ project_id }}">
           {% for c in contacts %}<option value="{{ c.name }}">{% endfor %}
         </datalist>
       </div>
@@ -35,23 +58,9 @@
       </div>
       <div>
         <p class="text-xs text-gray-500 mb-0.5">Follow-Up Date</p>
-        <input type="date" name="follow_up_date" id="proj-fu-date"
-          class="border border-gray-300 rounded px-2 py-1 text-xs w-full focus:outline-none focus:ring-1 focus:ring-marsh"
-          onchange="document.getElementById('fu-scope-row').style.display = this.value ? '' : 'none'">
+        <input type="date" name="follow_up_date"
+          class="border border-gray-300 rounded px-2 py-1 text-xs w-full focus:outline-none focus:ring-1 focus:ring-marsh">
       </div>
-    </div>
-
-    {# Follow-up scope — only visible when a follow-up date is set #}
-    <div id="fu-scope-row" class="flex items-center gap-4 text-xs text-gray-600" style="display:none">
-      <span class="text-gray-500 font-medium">Follow-up applies to:</span>
-      <label class="flex items-center gap-1 cursor-pointer">
-        <input type="radio" name="follow_up_scope" value="lead" checked class="accent-green-600">
-        Lead policy only
-      </label>
-      <label class="flex items-center gap-1 cursor-pointer">
-        <input type="radio" name="follow_up_scope" value="all" class="accent-green-600">
-        All {{ policy_count }} policies
-      </label>
     </div>
 
     <div class="grid grid-cols-4 gap-2">
@@ -69,7 +78,7 @@
 
     <div class="flex items-center gap-3">
       <button type="submit"
-        class="bg-green-600 hover:bg-green-700 text-white text-xs font-medium px-3 py-1.5 rounded">Log to All</button>
+        class="bg-green-600 hover:bg-green-700 text-white text-xs font-medium px-3 py-1.5 rounded">Log Activity</button>
       <button type="button"
         hx-get="/clients/{{ client.id }}/project-note?project={{ project_name | urlencode }}"
         hx-target="closest .proj-hdr-wrap"


### PR DESCRIPTION
## Summary
- **Fixes #26** — project-level activity logging now creates a single `activity_log` row with `project_id` set, instead of N identical rows (one per policy in the project)
- Fixes contact picker datalist ID collision when multiple project sections are on the same client page
- Replaces "Lead policy only" / "All N policies" radio with "Project-level" (default) / "Specific policy" scope selector
- Project follow-ups appear in Action Center with purple location badge
- Policy Activity tab shows project-level activities as lighter purple cross-references

## Test plan
- [ ] Start server — migration 074 runs, `activity_log` has `project_id` column
- [ ] Log a project-level activity — exactly 1 row in DB with `project_id` set, `policy_id` NULL
- [ ] Switch to "Specific policy" scope, log — 1 row with `policy_id` set
- [ ] Action Center shows project follow-up with purple "Project" badge
- [ ] Re-diary a project follow-up — new activity inherits `project_id`, `supersede_followups()` NOT called
- [ ] Policy Activity tab shows project cross-references with purple styling
- [ ] Multiple project log forms on same page have independent contact pickers

🤖 Generated with [Claude Code](https://claude.com/claude-code)