### PR TITLE
fix: disposition save failure + sidebar duplication on Action Center

### DIFF
--- a/src/policydb/web/routes/activities.py
+++ b/src/policydb/web/routes/activities.py
@@ -720,10 +720,17 @@ def update_disposition(
 
     elif source == "policy":
         # Auto-create activity_log row, then supersede old follow-ups
-        pol = conn.execute(
-            "SELECT id, client_id, policy_type FROM policies WHERE policy_uid = ?",
-            (item_id,),
-        ).fetchone()
+        # item_id may be policy_uid (string like "POL-003") or integer PK
+        if item_id.isdigit():
+            pol = conn.execute(
+                "SELECT id, client_id, policy_type FROM policies WHERE id = ?",
+                (int(item_id),),
+            ).fetchone()
+        else:
+            pol = conn.execute(
+                "SELECT id, client_id, policy_type FROM policies WHERE policy_uid = ?",
+                (item_id,),
+            ).fetchone()
         if pol:
             conn.execute(
                 """INSERT INTO activity_log
@@ -833,10 +840,16 @@ def bulk_action(
                     f"UPDATE activity_log SET {', '.join(updates)} WHERE id = ?", params
                 )
             elif source == "policy":
-                pol = conn.execute(
-                    "SELECT id, client_id, policy_type FROM policies WHERE policy_uid = ?",
-                    (item_id,),
-                ).fetchone()
+                if item_id.isdigit():
+                    pol = conn.execute(
+                        "SELECT id, client_id, policy_type FROM policies WHERE id = ?",
+                        (int(item_id),),
+                    ).fetchone()
+                else:
+                    pol = conn.execute(
+                        "SELECT id, client_id, policy_type FROM policies WHERE policy_uid = ?",
+                        (item_id,),
+                    ).fetchone()
                 if pol:
                     conn.execute(
                         """INSERT INTO activity_log
@@ -878,10 +891,11 @@ def bulk_action(
                     (new_date, int(item_id)),
                 )
             elif source == "policy":
-                conn.execute(
-                    "UPDATE policies SET follow_up_date = ? WHERE policy_uid = ?",
-                    (new_date, item_id),
-                )
+                _pk = int(item_id) if item_id.isdigit() else None
+                if _pk:
+                    conn.execute("UPDATE policies SET follow_up_date = ? WHERE id = ?", (new_date, _pk))
+                else:
+                    conn.execute("UPDATE policies SET follow_up_date = ? WHERE policy_uid = ?", (new_date, item_id))
             elif source == "client":
                 conn.execute(
                     "UPDATE clients SET follow_up_date = ? WHERE id = ?",
@@ -896,10 +910,11 @@ def bulk_action(
                 )
                 _auto_send_rfi_bundle(conn, int(item_id))
             elif source == "policy":
-                conn.execute(
-                    "UPDATE policies SET follow_up_date = NULL WHERE policy_uid = ?",
-                    (item_id,),
-                )
+                _pk = int(item_id) if item_id.isdigit() else None
+                if _pk:
+                    conn.execute("UPDATE policies SET follow_up_date = NULL WHERE id = ?", (_pk,))
+                else:
+                    conn.execute("UPDATE policies SET follow_up_date = NULL WHERE policy_uid = ?", (item_id,))
             elif source == "client":
                 conn.execute(
                     "UPDATE clients SET follow_up_date = NULL WHERE id = ?",

--- a/src/policydb/web/templates/base.html
+++ b/src/policydb/web/templates/base.html
@@ -886,12 +886,13 @@ window.quickSaveDisp = function(btn, label, days, rowId, compositeId, context) {
   fd.append('context', context || '');
   fetch('/activities/update-disposition', { method: 'POST', body: fd })
     .then(function() {
-      if (typeof htmx !== 'undefined') {
-        var target = context === 'action_center'
-          ? document.getElementById('ac-tab-content')
-          : btn.closest('.fu-section') || btn.closest('[data-section]');
-        if (target) htmx.ajax('GET', target.getAttribute('hx-get') || window.location.pathname, {target: target, swap: 'innerHTML'});
-        else window.location.reload();
+      if (context === 'action_center') {
+        var target = document.getElementById('ac-tab-content');
+        if (target && typeof htmx !== 'undefined') {
+          htmx.ajax('GET', '/action-center/followups', {target: target, swap: 'innerHTML'});
+        } else {
+          window.location.reload();
+        }
       } else {
         window.location.reload();
       }


### PR DESCRIPTION
## Summary

- Fix policy lookup in `update-disposition` and `bulk-action` endpoints to handle both integer PK (from template `item.id`) and string `policy_uid` formats
- Fix `quickSaveDisp` JS to refresh via `/action-center/followups` partial URL instead of full `/action-center` page URL (was loading full page into tab content, duplicating sidebar)

## Test plan

- [x] `curl` POST to `/activities/update-disposition` with `policy-3` composite ID returns OK and creates activity_log entry with correct disposition
- [x] No server errors
- [x] App compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)