### PR TITLE
fix: always-visible date/note on disposition pill bar

### DIFF
--- a/src/policydb/web/templates/action_center/_followup_sections.html
+++ b/src/policydb/web/templates/action_center/_followup_sections.html
@@ -133,20 +133,18 @@
   {% if not (item.is_milestone is defined and item.is_milestone) %}
   <div id="disp-bar-{{ row_id }}" class="hidden">
     <div class="disp-pill-bar bg-white border border-gray-200 rounded-lg p-2 mx-4 mb-2 mt-1">
-      <div class="flex flex-wrap gap-1">
-        {% for d in dispositions %}
-        <button type="button"
-          onclick="quickSaveDisp(this, '{{ d.label }}', {{ d.default_days }}, '{{ row_id }}', '{{ item.source }}-{{ item.id }}', 'action_center')"
-          class="disp-pill-inline text-[10px] px-2 py-0.5 rounded border border-gray-200 text-gray-500 hover:border-[#003865] hover:text-[#003865] transition-colors cursor-pointer{% if item.disposition == d.label %} bg-[#003865] text-white{% endif %}">{{ d.label }}</button>
-        {% endfor %}
-        <button type="button" onclick="expandDispBar('{{ row_id }}')"
-          class="text-[10px] px-2 py-0.5 rounded border border-gray-200 text-gray-400 hover:text-[#003865] transition-colors cursor-pointer" title="Date/note override">&#8943;</button>
-      </div>
-      <div id="disp-expand-{{ row_id }}" class="hidden mt-2 pt-2 border-t border-dashed border-gray-200">
-        <form hx-post="/activities/update-disposition" hx-target="#ac-tab-content" hx-swap="innerHTML" class="flex gap-3 items-end flex-wrap">
-          <input type="hidden" name="composite_id" value="{{ item.source }}-{{ item.id }}">
-          <input type="hidden" name="disposition" id="disp-val-{{ row_id }}" value="{{ item.disposition or '' }}">
-          <input type="hidden" name="context" value="action_center">
+      <form hx-post="/activities/update-disposition" hx-target="#ac-tab-content" hx-swap="innerHTML">
+        <input type="hidden" name="composite_id" value="{{ item.source }}-{{ item.id }}">
+        <input type="hidden" name="disposition" id="disp-val-{{ row_id }}" value="{{ item.disposition or '' }}">
+        <input type="hidden" name="context" value="action_center">
+        <div class="flex flex-wrap gap-1 mb-2">
+          {% for d in dispositions %}
+          <button type="button"
+            onclick="quickSaveDisp(this, '{{ d.label }}', {{ d.default_days }}, '{{ row_id }}', '{{ item.source }}-{{ item.id }}', 'action_center')"
+            class="disp-pill-inline text-[10px] px-2 py-0.5 rounded border border-gray-200 text-gray-500 hover:border-[#003865] hover:text-[#003865] transition-colors cursor-pointer{% if item.disposition == d.label %} bg-[#003865] text-white{% endif %}">{{ d.label }}</button>
+          {% endfor %}
+        </div>
+        <div class="flex gap-3 items-end flex-wrap">
           <div>
             <div class="text-[9px] text-gray-400">Follow-up date</div>
             <div class="flex gap-1 items-center">
@@ -163,8 +161,8 @@
           </div>
           <button type="submit" class="text-xs bg-[#003865] text-white px-3 py-1.5 rounded hover:bg-[#004a80]">Save</button>
           <button type="button" onclick="toggleDispBar('{{ row_id }}')" class="text-xs text-gray-400">Cancel</button>
-        </form>
-      </div>
+        </div>
+      </form>
     </div>
   </div>
   {% endif %}
@@ -287,17 +285,40 @@
     </div>
   </div>
 
-  {# ── Inline triage disposition pills ── #}
+  {# ── Inline triage disposition pills + date/note ── #}
   <div id="disp-bar-{{ row_id }}" class="hidden">
     <div class="disp-pill-bar bg-white border border-gray-200 rounded-lg p-2 mx-4 mb-2 mt-1">
-      <div class="text-[10px] text-gray-500 mb-1">Pick a disposition to classify this item:</div>
-      <div class="flex flex-wrap gap-1.5">
-        {% for d in dispositions %}
-        <button type="button"
-          onclick="quickSaveDisp(this, '{{ d.label }}', {{ d.default_days }}, '{{ row_id }}', '{{ item.source }}-{{ item.id }}', 'action_center')"
-          class="text-[11px] px-2.5 py-1 rounded border border-gray-200 text-gray-600 hover:border-[#003865] hover:text-[#003865] hover:bg-blue-50 transition-colors cursor-pointer">{{ d.label }}</button>
-        {% endfor %}
-      </div>
+      <form hx-post="/activities/update-disposition" hx-target="#ac-tab-content" hx-swap="innerHTML">
+        <input type="hidden" name="composite_id" value="{{ item.source }}-{{ item.id }}">
+        <input type="hidden" name="disposition" id="disp-val-{{ row_id }}" value="">
+        <input type="hidden" name="context" value="action_center">
+        <div class="text-[10px] text-gray-500 mb-1">Pick a disposition to classify this item:</div>
+        <div class="flex flex-wrap gap-1.5 mb-2">
+          {% for d in dispositions %}
+          <button type="button"
+            onclick="quickSaveDisp(this, '{{ d.label }}', {{ d.default_days }}, '{{ row_id }}', '{{ item.source }}-{{ item.id }}', 'action_center')"
+            class="disp-pill-inline text-[11px] px-2.5 py-1 rounded border border-gray-200 text-gray-600 hover:border-[#003865] hover:text-[#003865] hover:bg-blue-50 transition-colors cursor-pointer">{{ d.label }}</button>
+          {% endfor %}
+        </div>
+        <div class="flex gap-3 items-end flex-wrap">
+          <div>
+            <div class="text-[9px] text-gray-400">Follow-up date</div>
+            <div class="flex gap-1 items-center">
+              <input type="date" name="follow_up_date" id="disp-date-{{ row_id }}" value="{{ item.follow_up_date }}"
+                class="text-xs border border-gray-200 rounded px-2 py-1 focus:ring-1 focus:ring-[#003865]">
+              <button type="button" onclick="var d=new Date();d.setDate(d.getDate()+1);document.getElementById('disp-date-{{ row_id }}').value=d.toISOString().split('T')[0]" class="text-[9px] border border-gray-200 rounded px-1 py-0.5 text-gray-400 hover:text-[#003865]">+1d</button>
+              <button type="button" onclick="var d=new Date();d.setDate(d.getDate()+3);document.getElementById('disp-date-{{ row_id }}').value=d.toISOString().split('T')[0]" class="text-[9px] border border-gray-200 rounded px-1 py-0.5 text-gray-400 hover:text-[#003865]">+3d</button>
+              <button type="button" onclick="var d=new Date();d.setDate(d.getDate()+7);document.getElementById('disp-date-{{ row_id }}').value=d.toISOString().split('T')[0]" class="text-[9px] border border-gray-200 rounded px-1 py-0.5 text-gray-400 hover:text-[#003865]">+7d</button>
+            </div>
+          </div>
+          <div class="flex-1 min-w-32">
+            <div class="text-[9px] text-gray-400">Note</div>
+            <input type="text" name="note" placeholder="Optional..." class="w-full text-xs border border-gray-200 rounded px-2 py-1 focus:ring-1 focus:ring-[#003865]">
+          </div>
+          <button type="submit" class="text-xs bg-[#003865] text-white px-3 py-1.5 rounded hover:bg-[#004a80]">Save</button>
+          <button type="button" onclick="toggleDispBar('{{ row_id }}')" class="text-xs text-gray-400">Cancel</button>
+        </div>
+      </form>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary

- Remove hidden expand (...) pattern from disposition pill bar
- Date field, +1d/+3d/+7d shortcuts, and note input are now always visible when the pill bar is open
- Picking a pill auto-fills the date per disposition rules, but user can always override manually
- Applied to both fu_row and triage_row macros

🤖 Generated with [Claude Code](https://claude.com/claude-code)