### PR TITLE
fix: new follow-ups immediately marked done by supersede_followups

### DIFF
--- a/src/policydb/web/routes/activities.py
+++ b/src/policydb/web/routes/activities.py
@@ -92,6 +92,11 @@ def activity_log(
         if _row:
             _contact_id = _row["id"]
 
+    # Supersede old follow-ups BEFORE inserting the new one
+    if follow_up_date and policy_id:
+        from policydb.queries import supersede_followups
+        supersede_followups(conn, policy_id, follow_up_date)
+
     account_exec = cfg.get("default_account_exec", "Grant")
     cursor = conn.execute(
         """INSERT INTO activity_log
@@ -102,10 +107,6 @@ def activity_log(
          follow_up_date or None, account_exec, round_duration(duration_hours),
          disposition.strip() or None),
     )
-
-    if follow_up_date and policy_id:
-        from policydb.queries import supersede_followups
-        supersede_followups(conn, policy_id, follow_up_date)
     conn.commit()
     logger.info("Activity created for client %d: %s", client_id, activity_type)
     # Return the new activity row as HTMX partial
@@ -438,6 +439,12 @@ def activity_followup(
             (disposition.strip(), activity_id),
         )
 
+    # Supersede old follow-ups BEFORE inserting the new one — otherwise the
+    # blanket UPDATE in supersede_followups marks the just-created activity as done.
+    if new_follow_up_date and original.get("policy_id"):
+        from policydb.queries import supersede_followups
+        supersede_followups(conn, original["policy_id"], new_follow_up_date)
+
     # Create new activity (re-diary)
     account_exec = cfg.get("default_account_exec", "Grant")
     dur = round_duration(duration_hours)
@@ -458,9 +465,6 @@ def activity_followup(
          subject, notes or None,
          new_follow_up_date or None, account_exec, dur),
     )
-    if new_follow_up_date and original.get("policy_id"):
-        from policydb.queries import supersede_followups
-        supersede_followups(conn, original["policy_id"], new_follow_up_date)
     conn.commit()
 
     # If this follow-up is for a policy with a disposition, update the timeline

--- a/src/policydb/web/routes/policies.py
+++ b/src/policydb/web/routes/policies.py
@@ -276,6 +276,11 @@ def policy_row_log_post(
         except ValueError:
             return None
 
+    # Supersede old follow-ups BEFORE inserting the new one
+    if follow_up_date:
+        from policydb.queries import supersede_followups
+        supersede_followups(conn, policy_id, follow_up_date)
+
     account_exec = cfg.get("default_account_exec", "Grant")
     conn.execute(
         """INSERT INTO activity_log
@@ -287,9 +292,6 @@ def policy_row_log_post(
             follow_up_date or None, account_exec, round_duration(duration_hours),
         ),
     )
-    if follow_up_date:
-        from policydb.queries import supersede_followups
-        supersede_followups(conn, policy_id, follow_up_date)
     conn.commit()
 
     uid = policy_uid.upper()
@@ -356,6 +358,11 @@ def policy_dash_log_post(
         except ValueError:
             return None
 
+    # Supersede old follow-ups BEFORE inserting the new one
+    if follow_up_date:
+        from policydb.queries import supersede_followups
+        supersede_followups(conn, policy_id, follow_up_date)
+
     account_exec = cfg.get("default_account_exec", "Grant")
     conn.execute(
         """INSERT INTO activity_log
@@ -367,9 +374,6 @@ def policy_dash_log_post(
             follow_up_date or None, account_exec, round_duration(duration_hours),
         ),
     )
-    if follow_up_date:
-        from policydb.queries import supersede_followups
-        supersede_followups(conn, policy_id, follow_up_date)
     conn.commit()
 
     uid = policy_uid.upper()
@@ -446,6 +450,11 @@ def policy_renew_log_post(
         except ValueError:
             return None
 
+    # Supersede old follow-ups BEFORE inserting the new one
+    if follow_up_date:
+        from policydb.queries import supersede_followups
+        supersede_followups(conn, policy_id, follow_up_date)
+
     account_exec = cfg.get("default_account_exec", "Grant")
     conn.execute(
         """INSERT INTO activity_log
@@ -457,9 +466,6 @@ def policy_renew_log_post(
             follow_up_date or None, account_exec, round_duration(duration_hours),
         ),
     )
-    if follow_up_date:
-        from policydb.queries import supersede_followups
-        supersede_followups(conn, policy_id, follow_up_date)
     conn.commit()
 
     uid = policy_uid.upper()
@@ -543,6 +549,11 @@ def opp_log_post(
             return float(v) if str(v).strip() else None
         except ValueError:
             return None
+    # Supersede old follow-ups BEFORE inserting the new one
+    if follow_up_date and policy_id:
+        from policydb.queries import supersede_followups
+        supersede_followups(conn, policy_id, follow_up_date)
+
     account_exec = cfg.get("default_account_exec", "Grant")
     conn.execute(
         """INSERT INTO activity_log
@@ -554,9 +565,6 @@ def opp_log_post(
             follow_up_date or None, account_exec, round_duration(duration_hours),
         ),
     )
-    if follow_up_date and policy_id:
-        from policydb.queries import supersede_followups
-        supersede_followups(conn, policy_id, follow_up_date)
     conn.commit()
     return _opp_row_response(request, policy_uid.upper(), conn)
 


### PR DESCRIPTION
## Summary

`supersede_followups()` runs `UPDATE activity_log SET follow_up_done=1 WHERE policy_id=? AND follow_up_done=0` to clear old follow-ups. It was being called AFTER inserting the new activity, which immediately marked the new follow-up as done (strikethrough on the date).

Fix: move `supersede_followups()` BEFORE the INSERT in all 6 affected endpoints across `activities.py` and `policies.py`.

## Test plan

- [x] All tests pass (55 in focused suite, 266 in full suite)
- [x] App compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)