### PR TITLE
fix: sidebar map geocoding + address autocomplete

### DIFF
--- a/src/policydb/db.py
+++ b/src/policydb/db.py
@@ -1055,6 +1055,15 @@ def init_db(path: Path | None = None) -> None:
             conn.executescript(sql)
             conn.commit()
 
+    if 76 not in applied:
+        sql = (_MIGRATIONS_DIR / "076_add_client_geocoding.sql").read_text()
+        conn.executescript(sql)
+        conn.execute(
+            "INSERT INTO schema_version (version, description) VALUES (?, ?)",
+            (76, "Add latitude/longitude columns to clients for map geocoding cache"),
+        )
+        conn.commit()
+
     # Data hygiene: fix 'None' string corruption in text fields (runs every startup, fast no-op if clean)
     conn.execute("UPDATE clients SET cn_number = NULL WHERE cn_number = 'None'")
 

--- a/src/policydb/migrations/076_add_client_geocoding.sql
+++ b/src/policydb/migrations/076_add_client_geocoding.sql
@@ -1,0 +1,2 @@
+ALTER TABLE clients ADD COLUMN latitude REAL;
+ALTER TABLE clients ADD COLUMN longitude REAL;

--- a/src/policydb/web/routes/clients.py
+++ b/src/policydb/web/routes/clients.py
@@ -96,6 +96,11 @@ def _sort_clients(clients, sort="name", dir="asc"):
     return clients
 
 
+def _get_us_states():
+    from policydb.web.routes.policies import US_STATES
+    return US_STATES
+
+
 def _get_project_locations(conn, client_id: int) -> list[dict]:
     """Load all location-type projects with policy/opportunity counts, premium, and revenue."""
     rows = conn.execute("""
@@ -355,6 +360,8 @@ def client_new_post(
     client_since: str = Form(""),
     preferred_contact_method: str = Form(""),
     referral_source: str = Form(""),
+    latitude: str = Form(""),
+    longitude: str = Form(""),
     conn=Depends(get_db),
 ):
     def _float(v):
@@ -402,21 +409,25 @@ def client_new_post(
                     "client_since": client_since,
                     "preferred_contact_method": preferred_contact_method,
                     "referral_source": referral_source,
+                    "latitude": latitude,
+                    "longitude": longitude,
                 },
             })
 
     cursor = conn.execute(
         """INSERT INTO clients (name, industry_segment, cn_number, is_prospect, primary_contact, contact_email,
            contact_phone, contact_mobile, address, notes, account_exec, broker_fee, business_description,
-           website, renewal_month, client_since, preferred_contact_method, referral_source)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+           website, renewal_month, client_since, preferred_contact_method, referral_source,
+           latitude, longitude)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (name, industry_segment, cn_number.strip() or None, 1 if is_prospect else 0,
          primary_contact or None, clean_email(contact_email) or None,
          format_phone(contact_phone) or None, format_phone(contact_mobile) or None,
          address or None, notes or None, account_exec,
          _float(broker_fee), business_description or None,
          website or None, _int(renewal_month), client_since or None,
-         preferred_contact_method or None, referral_source or None),
+         preferred_contact_method or None, referral_source or None,
+         _float(latitude), _float(longitude)),
     )
     conn.commit()
     logger.info("Client %d created: %s", cursor.lastrowid, name)
@@ -735,6 +746,7 @@ def client_tab_policies(request: Request, client_id: int, conn=Depends(get_db)):
         "project_stages": cfg.get("project_stages", []),
         "project_types": cfg.get("project_types", []),
         "timeline_data": _build_timeline_data(_get_project_pipeline(conn, client_id)),
+        "us_states": _get_us_states(),
     })
 
 
@@ -2259,6 +2271,8 @@ def client_edit_post(
     referral_source: str = Form(""),
     fein: str = Form(""),
     hourly_rate: str = Form(""),
+    latitude: str = Form(""),
+    longitude: str = Form(""),
     conn=Depends(get_db),
 ):
     def _float(v):
@@ -2281,7 +2295,7 @@ def client_edit_post(
            contact_email=?, contact_phone=?, contact_mobile=?, address=?, notes=?,
            broker_fee=?, business_description=?,
            website=?, renewal_month=?, client_since=?, preferred_contact_method=?, referral_source=?,
-           fein=?, hourly_rate=?
+           fein=?, hourly_rate=?, latitude=?, longitude=?
            WHERE id=?""",
         (name, industry_segment, cn_number.strip() or None, 1 if is_prospect else 0,
          primary_contact or None, clean_email(contact_email) or None,
@@ -2291,6 +2305,7 @@ def client_edit_post(
          website or None, _int(renewal_month), client_since or None,
          preferred_contact_method or None, referral_source or None,
          format_fein(fein) or None, _float(hourly_rate),
+         _float(latitude), _float(longitude),
          client_id),
     )
     conn.commit()

--- a/src/policydb/web/templates/clients/_project_locations.html
+++ b/src/policydb/web/templates/clients/_project_locations.html
@@ -117,6 +117,8 @@ window.addLocation = function(clientId) {
   </div>
 </details>
 
+<div id="loc-address-suggestions" class="fixed z-50 bg-white border border-gray-200 rounded-b-lg shadow-lg max-h-48 overflow-y-auto hidden" style="min-width:200px"></div>
+
 <script>
 (function() {
   function flashCell(el) {
@@ -124,6 +126,108 @@ window.addLocation = function(clientId) {
     el.style.backgroundColor = '#d1fae5';
     setTimeout(function() { el.style.backgroundColor = ''; setTimeout(function() { el.style.transition = ''; }, 300); }, 800);
   }
+
+  function patchLocField(endpoint, field, value) {
+    return fetch(endpoint, {
+      method: 'PATCH',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({field: field, value: value})
+    }).then(function(r) { return r.json(); });
+  }
+
+  /* ── Nominatim autocomplete for location address cells ── */
+  var stateMap = {};
+  {% for abbr, name in us_states %}
+  stateMap[{{ name | tojson }}.toLowerCase()] = {{ abbr | tojson }};
+  {% endfor %}
+
+  function stateToAbbr(s) {
+    if (!s) return '';
+    var lower = s.trim().toLowerCase();
+    if (stateMap[lower]) return stateMap[lower];
+    var upper = s.trim().toUpperCase();
+    return upper.length === 2 ? upper : s.trim();
+  }
+
+  var locAddrDropdown = document.getElementById('loc-address-suggestions');
+  var locAddrTimer = null;
+  var locAddrActiveCell = null;
+
+  document.addEventListener('input', function(e) {
+    if (!e.target.matches('.loc-cell[data-field="address"]')) return;
+    locAddrActiveCell = e.target;
+    clearTimeout(locAddrTimer);
+    var q = e.target.textContent.trim();
+    if (q.length < 4) { locAddrDropdown.classList.add('hidden'); return; }
+    locAddrTimer = setTimeout(function() {
+      fetch('https://nominatim.openstreetmap.org/search?format=json&q=' + encodeURIComponent(q) + '&limit=5&addressdetails=1&countrycodes=us,gb,ca')
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+          if (!data || !data.length) { locAddrDropdown.classList.add('hidden'); return; }
+          var rect = locAddrActiveCell.getBoundingClientRect();
+          locAddrDropdown.style.left = rect.left + 'px';
+          locAddrDropdown.style.top = rect.bottom + 'px';
+          locAddrDropdown.style.width = Math.max(rect.width, 300) + 'px';
+          locAddrDropdown.innerHTML = '';
+          data.forEach(function(item) {
+            var div = document.createElement('div');
+            div.className = 'px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 cursor-pointer border-b border-gray-50';
+            div.textContent = item.display_name;
+            div.addEventListener('mousedown', function(ev) {
+              ev.preventDefault();
+              if (!locAddrActiveCell) return;
+              var row = locAddrActiveCell.closest('tr');
+              if (!row) return;
+              var a = item.address || {};
+              var street = (a.house_number ? a.house_number + ' ' : '') + (a.road || '');
+              var endpoint = locAddrActiveCell.dataset.endpoint;
+
+              locAddrActiveCell.textContent = street || item.display_name;
+              patchLocField(endpoint, 'address', locAddrActiveCell.textContent).then(function(d) {
+                if (d.ok && d.formatted) { locAddrActiveCell.textContent = d.formatted; flashCell(locAddrActiveCell); }
+              });
+
+              var cityCell = row.querySelector('.loc-cell[data-field="city"]');
+              var city = a.city || a.town || a.village || a.hamlet || '';
+              if (cityCell && city) {
+                cityCell.textContent = city;
+                patchLocField(cityCell.dataset.endpoint, 'city', city).then(function(d) {
+                  if (d.ok && d.formatted) { cityCell.textContent = d.formatted; flashCell(cityCell); }
+                });
+              }
+
+              var stateCell = row.querySelector('.loc-cell[data-field="state"]');
+              var state = stateToAbbr(a.state || '');
+              if (stateCell && state) {
+                stateCell.textContent = state;
+                patchLocField(stateCell.dataset.endpoint, 'state', state).then(function(d) {
+                  if (d.ok && d.formatted) { stateCell.textContent = d.formatted; flashCell(stateCell); }
+                });
+              }
+
+              var zipCell = row.querySelector('.loc-cell[data-field="zip"]');
+              var zip = a.postcode || '';
+              if (zipCell && zip) {
+                zipCell.textContent = zip;
+                patchLocField(zipCell.dataset.endpoint, 'zip', zip).then(function(d) {
+                  if (d.ok && d.formatted) { zipCell.textContent = d.formatted; flashCell(zipCell); }
+                });
+              }
+
+              locAddrDropdown.classList.add('hidden');
+            });
+            locAddrDropdown.appendChild(div);
+          });
+          locAddrDropdown.classList.remove('hidden');
+        }).catch(function() { locAddrDropdown.classList.add('hidden'); });
+    }, 400);
+  }, true);
+
+  document.addEventListener('blur', function(e) {
+    if (e.target.matches('.loc-cell[data-field="address"]')) {
+      setTimeout(function() { locAddrDropdown.classList.add('hidden'); }, 200);
+    }
+  }, true);
 
   // Blur-save for contenteditable cells
   document.addEventListener('blur', function(e) {

--- a/src/policydb/web/templates/clients/_sticky_sidebar.html
+++ b/src/policydb/web/templates/clients/_sticky_sidebar.html
@@ -162,23 +162,32 @@
        class="text-xs text-marsh hover:underline mt-1 block">Open full map →</a>
     <script>
     (function() {
-      var addr = {{ client.address | tojson }};
       var container = document.getElementById('sidebar-map-container');
-      if (!addr || !container) return;
-      fetch('https://nominatim.openstreetmap.org/search?format=json&q=' + encodeURIComponent(addr) + '&limit=1')
+      if (!container) return;
+
+      function showMap(lat, lon) {
+        var d = 0.01;
+        var bbox = (lon - d) + ',' + (lat - d) + ',' + (lon + d) + ',' + (lat + d);
+        container.innerHTML = '<iframe src="https://www.openstreetmap.org/export/embed.html?bbox=' + bbox + '&layer=mapnik&marker=' + lat + ',' + lon + '" style="width:100%;height:120px;border:0;border-radius:6px" loading="lazy"></iframe>';
+      }
+
+      {% if client.latitude and client.longitude %}
+      showMap({{ client.latitude }}, {{ client.longitude }});
+      {% else %}
+      var addr = {{ client.address | tojson }};
+      if (!addr) return;
+      fetch('https://nominatim.openstreetmap.org/search?format=json&q=' + encodeURIComponent(addr) + '&limit=1&countrycodes=us,gb,ca')
         .then(function(r) { return r.json(); })
         .then(function(data) {
           if (data && data.length > 0) {
-            var lat = parseFloat(data[0].lat), lon = parseFloat(data[0].lon);
-            var d = 0.01;
-            var bbox = (lon - d) + ',' + (lat - d) + ',' + (lon + d) + ',' + (lat + d);
-            container.innerHTML = '<iframe src="https://www.openstreetmap.org/export/embed.html?bbox=' + bbox + '&layer=mapnik&marker=' + lat + ',' + lon + '" style="width:100%;height:120px;border:0;border-radius:6px" loading="lazy"></iframe>';
+            showMap(parseFloat(data[0].lat), parseFloat(data[0].lon));
           } else {
             container.innerHTML = '<span class="text-xs text-gray-400">Address not found on map</span>';
           }
         }).catch(function() {
           container.innerHTML = '<span class="text-xs text-gray-400">Map unavailable</span>';
         });
+      {% endif %}
     })();
     </script>
   </div>

--- a/src/policydb/web/templates/clients/edit.html
+++ b/src/policydb/web/templates/clients/edit.html
@@ -100,16 +100,23 @@
         <label class="field-label">Address</label>
         <input type="text" name="address" id="address-input" value="{{ client.address if client else '' }}" class="form-input w-full"
           data-1p-ignore data-lpignore="true" autocomplete="off" placeholder="Start typing an address...">
+        <input type="hidden" name="latitude" id="address-lat" value="{{ client.latitude if client and client.latitude else '' }}">
+        <input type="hidden" name="longitude" id="address-lon" value="{{ client.longitude if client and client.longitude else '' }}">
         <div id="address-suggestions" class="absolute left-0 right-0 top-full z-50 bg-white border border-gray-200 rounded-b-lg shadow-lg max-h-48 overflow-y-auto hidden"></div>
       </div>
       <script>
       (function() {
         var input = document.getElementById('address-input');
         var dropdown = document.getElementById('address-suggestions');
+        var latField = document.getElementById('address-lat');
+        var lonField = document.getElementById('address-lon');
         if (!input || !dropdown) return;
         var timer = null;
         input.addEventListener('input', function() {
           clearTimeout(timer);
+          // Clear stored coordinates when user types manually
+          if (latField) latField.value = '';
+          if (lonField) lonField.value = '';
           var q = input.value.trim();
           if (q.length < 4) { dropdown.classList.add('hidden'); return; }
           timer = setTimeout(function() {
@@ -125,6 +132,8 @@
                   div.addEventListener('mousedown', function(e) {
                     e.preventDefault();
                     input.value = item.display_name;
+                    if (latField) latField.value = item.lat || '';
+                    if (lonField) lonField.value = item.lon || '';
                     dropdown.classList.add('hidden');
                   });
                   dropdown.appendChild(div);

--- a/src/policydb/web/templates/policies/_tab_details.html
+++ b/src/policydb/web/templates/policies/_tab_details.html
@@ -465,10 +465,12 @@
     <div>
       <p class="text-xs font-medium text-gray-500 uppercase tracking-wide mb-3">Primary Exposure Address / Location</p>
       <div class="grid grid-cols-1 sm:grid-cols-6 gap-4">
-        <div class="sm:col-span-6">
+        <div class="sm:col-span-6 relative">
           <label class="field-label">Street Address</label>
-          <input type="text" data-field="exposure_address" value="{{ policy.exposure_address or '' }}"
-            placeholder="123 Main St, Suite 100" class="form-input w-full">
+          <input type="text" data-field="exposure_address" id="exposure-address-input" value="{{ policy.exposure_address or '' }}"
+            placeholder="123 Main St, Suite 100" class="form-input w-full"
+            data-1p-ignore data-lpignore="true" autocomplete="off">
+          <div id="exposure-address-suggestions" class="absolute left-0 right-0 top-full z-50 bg-white border border-gray-200 rounded-b-lg shadow-lg max-h-48 overflow-y-auto hidden"></div>
         </div>
         <div class="sm:col-span-3">
           <label class="field-label">City</label>
@@ -634,6 +636,72 @@
       });
   }
   AC_FIELDS.forEach(loadList);
+
+  /* ── Nominatim autocomplete for exposure address ── */
+  (function() {
+    var addrInput = document.getElementById('exposure-address-input');
+    var addrDropdown = document.getElementById('exposure-address-suggestions');
+    if (!addrInput || !addrDropdown) return;
+
+    var stateMap = {};
+    {% for abbr, name in us_states %}
+    stateMap[{{ name | tojson }}.toLowerCase()] = {{ abbr | tojson }};
+    {% endfor %}
+
+    function stateToAbbr(s) {
+      if (!s) return '';
+      var lower = s.trim().toLowerCase();
+      if (stateMap[lower]) return stateMap[lower];
+      var upper = s.trim().toUpperCase();
+      return upper.length === 2 ? upper : s.trim();
+    }
+
+    var timer = null;
+    addrInput.addEventListener('input', function() {
+      clearTimeout(timer);
+      var q = addrInput.value.trim();
+      if (q.length < 4) { addrDropdown.classList.add('hidden'); return; }
+      timer = setTimeout(function() {
+        fetch('https://nominatim.openstreetmap.org/search?format=json&q=' + encodeURIComponent(q) + '&limit=5&addressdetails=1&countrycodes=us,gb,ca')
+          .then(function(r) { return r.json(); })
+          .then(function(data) {
+            if (!data || !data.length) { addrDropdown.classList.add('hidden'); return; }
+            addrDropdown.innerHTML = '';
+            data.forEach(function(item) {
+              var div = document.createElement('div');
+              div.className = 'px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 cursor-pointer border-b border-gray-50';
+              div.textContent = item.display_name;
+              div.addEventListener('mousedown', function(e) {
+                e.preventDefault();
+                var a = item.address || {};
+                var street = (a.house_number ? a.house_number + ' ' : '') + (a.road || '');
+                addrInput.value = street || item.display_name;
+                patchField('exposure_address', addrInput.value, addrInput);
+
+                var city = a.city || a.town || a.village || a.hamlet || '';
+                var cityEl = container.querySelector('[data-field="exposure_city"]');
+                if (cityEl && city) { cityEl.value = city; patchField('exposure_city', city, cityEl); }
+
+                var state = stateToAbbr(a.state || '');
+                var stateEl = container.querySelector('[data-field="exposure_state"]');
+                if (stateEl && state) { stateEl.value = state; patchField('exposure_state', state, stateEl); }
+
+                var zip = a.postcode || '';
+                var zipEl = container.querySelector('[data-field="exposure_zip"]');
+                if (zipEl && zip) { zipEl.value = zip; patchField('exposure_zip', zip, zipEl); }
+
+                addrDropdown.classList.add('hidden');
+              });
+              addrDropdown.appendChild(div);
+            });
+            addrDropdown.classList.remove('hidden');
+          }).catch(function() { addrDropdown.classList.add('hidden'); });
+      }, 400);
+    });
+    addrInput.addEventListener('blur', function() {
+      setTimeout(function() { addrDropdown.classList.add('hidden'); }, 200);
+    });
+  })();
 
   /* ── Live layer notation preview ── */
   (function () {


### PR DESCRIPTION
## Summary
- **Sidebar map fix**: Store lat/lon when client address is picked from Nominatim autocomplete, so the map renders instantly from cached coordinates instead of re-geocoding every page load (which frequently returned "Address not found")
- **Policy address autocomplete**: Added Nominatim autocomplete to the exposure_address field on the policy details tab — selecting a suggestion auto-fills city, state (with abbreviation mapping), and ZIP
- **Location table autocomplete**: Same Nominatim autocomplete on contenteditable address cells in the client locations table, with auto-fill of city/state/zip in the same row

## Test plan
- [ ] Open a client edit page, type an address, pick from autocomplete dropdown — verify lat/lon hidden fields are populated
- [ ] Save and return to client detail — verify sidebar map renders instantly with a pin
- [ ] Open a policy details tab, type in the Street Address field — verify Nominatim suggestions appear and selecting one fills city/state/zip
- [ ] On a client's Policies tab, type in a location address cell — verify autocomplete and auto-fill works

🤖 Generated with [Claude Code](https://claude.com/claude-code)