### PR TITLE
fix: client geocoding autosave + map/COPE on project page

### DIFF
--- a/src/policydb/db.py
+++ b/src/policydb/db.py
@@ -1064,6 +1064,15 @@ def init_db(path: Path | None = None) -> None:
         )
         conn.commit()
 
+    if 77 not in applied:
+        sql = (_MIGRATIONS_DIR / "077_add_project_geocoding.sql").read_text()
+        conn.executescript(sql)
+        conn.execute(
+            "INSERT INTO schema_version (version, description) VALUES (?, ?)",
+            (77, "Add latitude/longitude columns to projects for map geocoding cache"),
+        )
+        conn.commit()
+
     # Data hygiene: fix 'None' string corruption in text fields (runs every startup, fast no-op if clean)
     conn.execute("UPDATE clients SET cn_number = NULL WHERE cn_number = 'None'")
 

--- a/src/policydb/migrations/077_add_project_geocoding.sql
+++ b/src/policydb/migrations/077_add_project_geocoding.sql
@@ -1,0 +1,3 @@
+-- Add latitude/longitude columns to projects for map geocoding cache
+ALTER TABLE projects ADD COLUMN latitude REAL;
+ALTER TABLE projects ADD COLUMN longitude REAL;

--- a/src/policydb/web/routes/clients.py
+++ b/src/policydb/web/routes/clients.py
@@ -2825,14 +2825,15 @@ def project_detail(
         (project_id,),
     ).fetchall()
     project = dict(project)
-    # Pull address from first policy that has one
-    for pol in policies:
-        if pol["exposure_address"] or pol["exposure_city"]:
-            project["exposure_address"] = pol["exposure_address"] or ""
-            project["exposure_city"] = pol["exposure_city"] or ""
-            project["exposure_state"] = pol["exposure_state"] or ""
-            project["exposure_zip"] = pol["exposure_zip"] or ""
-            break
+    # Pull address from first policy that has one (fallback when project has no own address)
+    if not project.get("address"):
+        for pol in policies:
+            if pol["exposure_address"] or pol["exposure_city"]:
+                project["exposure_address"] = pol["exposure_address"] or ""
+                project["exposure_city"] = pol["exposure_city"] or ""
+                project["exposure_state"] = pol["exposure_state"] or ""
+                project["exposure_zip"] = pol["exposure_zip"] or ""
+                break
     if project.get("updated_at"):
         try:
             dt = dateparser.parse(project["updated_at"])
@@ -2842,6 +2843,13 @@ def project_detail(
                 ).replace("AM", "am").replace("PM", "pm")
         except Exception:
             project["updated_at_fmt"] = project["updated_at"][:16]
+
+    # COPE data for this project/location
+    cope_row = conn.execute(
+        "SELECT * FROM cope_data WHERE project_id = ?", (project_id,)
+    ).fetchone()
+    cope = dict(cope_row) if cope_row else None
+
     return templates.TemplateResponse(
         "clients/project.html",
         {
@@ -2849,6 +2857,7 @@ def project_detail(
             "project": project,
             "client": dict(client),
             "policies": [dict(p) for p in policies],
+            "cope": cope,
         },
     )
 
@@ -4070,7 +4079,8 @@ async def project_pipeline_field(
 
     allowed = {"project_type", "status", "name", "project_value", "start_date",
                "target_completion", "insurance_needed_by", "scope_description",
-               "general_contractor", "owner_name", "address", "city", "state", "zip"}
+               "general_contractor", "owner_name", "address", "city", "state", "zip",
+               "latitude", "longitude"}
     if field not in allowed:
         return JSONResponse({"ok": False, "error": f"Invalid field: {field}"}, status_code=400)
 
@@ -4087,6 +4097,13 @@ async def project_pipeline_field(
         num = parse_currency_with_magnitude(value)
         conn.execute("UPDATE projects SET project_value = ? WHERE id = ?", (num, project_id))
         formatted = f"${num:,.0f}"
+    elif field in ("latitude", "longitude"):
+        try:
+            num = float(value) if str(value).strip() else None
+        except ValueError:
+            num = None
+        conn.execute(f"UPDATE projects SET {field} = ? WHERE id = ?", (num, project_id))
+        formatted = str(num) if num is not None else ""
     elif field in ("start_date", "target_completion", "insurance_needed_by"):
         conn.execute(f"UPDATE projects SET {field} = ? WHERE id = ?",
                      (value.strip() or None, project_id))
@@ -4639,12 +4656,19 @@ def location_create(
     city: str = Form(""),
     state: str = Form(""),
     zip: str = Form(""),
+    latitude: str = Form(""),
+    longitude: str = Form(""),
     conn=Depends(get_db),
 ):
     """Create a new location/project for a client."""
+    def _fl(v):
+        try:
+            return float(v) if str(v).strip() else None
+        except ValueError:
+            return None
     conn.execute(
-        "INSERT INTO projects (name, client_id, address, city, state, zip, project_type) VALUES (?, ?, ?, ?, ?, ?, 'Location')",
-        (name, client_id, address, city, state, zip),
+        "INSERT INTO projects (name, client_id, address, city, state, zip, latitude, longitude, project_type) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'Location')",
+        (name, client_id, address, city, state, zip, _fl(latitude), _fl(longitude)),
     )
     conn.commit()
     return HTMLResponse("", headers={"HX-Trigger": "locationChanged"})

--- a/src/policydb/web/templates/action_center/_followup_sections.html
+++ b/src/policydb/web/templates/action_center/_followup_sections.html
@@ -470,7 +470,7 @@
             {% endif %}
           </div>
           <div class="flex gap-1.5 flex-shrink-0 no-print">
-            <a href="/policies/{{ item.policy_uid }}"
+            <a href="/policies/{{ item.policy_uid }}/edit"
                class="text-xs text-gray-500 bg-white border border-gray-200 px-2 py-1.5 rounded hover:border-gray-300 transition-colors">View</a>
           </div>
         </div>

--- a/src/policydb/web/templates/clients/_project_locations.html
+++ b/src/policydb/web/templates/clients/_project_locations.html
@@ -214,6 +214,10 @@ window.addLocation = function(clientId) {
                 });
               }
 
+              // Save geocoded lat/lng to the project
+              if (item.lat) patchLocField(endpoint, 'latitude', item.lat);
+              if (item.lon) patchLocField(endpoint, 'longitude', item.lon);
+
               locAddrDropdown.classList.add('hidden');
             });
             locAddrDropdown.appendChild(div);

--- a/src/policydb/web/templates/clients/edit.html
+++ b/src/policydb/web/templates/clients/edit.html
@@ -135,6 +135,9 @@
                     if (latField) latField.value = item.lat || '';
                     if (lonField) lonField.value = item.lon || '';
                     dropdown.classList.add('hidden');
+                    // Trigger autosave with updated lat/lng (use 'change' to avoid
+                    // re-triggering the autocomplete 'input' handler which clears lat/lng)
+                    input.dispatchEvent(new Event('change', { bubbles: true }));
                   });
                   dropdown.appendChild(div);
                 });

--- a/src/policydb/web/templates/clients/project.html
+++ b/src/policydb/web/templates/clients/project.html
@@ -64,15 +64,123 @@
       {% endif %}
     </div>
 
-    {# Address #}
-    {% if project.exposure_address or project.exposure_city %}
+    {# Address + Map #}
+    {% set addr = project.address or project.get('exposure_address', '') %}
+    {% set city = project.city or project.get('exposure_city', '') %}
+    {% set state = project.state or project.get('exposure_state', '') %}
+    {% set zip_code = project.zip or project.get('exposure_zip', '') %}
+    {% if addr or city %}
     <div class="card p-4">
-      <p class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Address</p>
-      <p class="text-sm text-gray-700">
-        {% if project.exposure_address %}{{ project.exposure_address }}<br>{% endif %}
-        {% if project.exposure_city %}{{ project.exposure_city }}{% if project.exposure_state %}, {{ project.exposure_state }}{% endif %}{% if project.exposure_zip %} {{ project.exposure_zip }}{% endif %}{% endif %}
+      <p class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Location</p>
+      <p class="text-sm text-gray-700 mb-2">
+        {% if addr %}{{ addr }}<br>{% endif %}
+        {% if city %}{{ city }}{% if state %}, {{ state }}{% endif %}{% if zip_code %} {{ zip_code }}{% endif %}{% endif %}
       </p>
-      <a href="/clients/{{ client.id }}" class="text-xs text-gray-400 hover:text-marsh mt-1 block">Edit on client page ↗</a>
+      <div id="project-map-container" style="width:100%;height:120px;border-radius:6px;background:#f3f4f6;display:flex;align-items:center;justify-content:center">
+        <span class="text-xs text-gray-400">Loading map...</span>
+      </div>
+      {% set full_addr = [addr, city, state, zip_code] | select | join(', ') %}
+      <a href="https://www.openstreetmap.org/search?query={{ full_addr | urlencode }}"
+         target="_blank" rel="noopener"
+         class="text-xs text-marsh hover:underline mt-1 block">Open full map →</a>
+      <script>
+      (function() {
+        var container = document.getElementById('project-map-container');
+        if (!container) return;
+        function showMap(lat, lon) {
+          var d = 0.01;
+          var bbox = (lon - d) + ',' + (lat - d) + ',' + (lon + d) + ',' + (lat + d);
+          container.innerHTML = '<iframe src="https://www.openstreetmap.org/export/embed.html?bbox=' + bbox + '&layer=mapnik&marker=' + lat + ',' + lon + '" style="width:100%;height:120px;border:0;border-radius:6px" loading="lazy"></iframe>';
+        }
+        {% if project.latitude and project.longitude %}
+        showMap({{ project.latitude }}, {{ project.longitude }});
+        {% else %}
+        var addr = {{ full_addr | tojson }};
+        if (!addr) { container.innerHTML = '<span class="text-xs text-gray-400">No address for map</span>'; return; }
+        fetch('https://nominatim.openstreetmap.org/search?format=json&q=' + encodeURIComponent(addr) + '&limit=1&countrycodes=us,gb,ca')
+          .then(function(r) { return r.json(); })
+          .then(function(data) {
+            if (data && data.length > 0) {
+              showMap(parseFloat(data[0].lat), parseFloat(data[0].lon));
+            } else {
+              container.innerHTML = '<span class="text-xs text-gray-400">Address not found on map</span>';
+            }
+          }).catch(function() {
+            container.innerHTML = '<span class="text-xs text-gray-400">Map unavailable</span>';
+          });
+        {% endif %}
+      })();
+      </script>
+    </div>
+    {% endif %}
+
+    {# COPE Data #}
+    {% if cope %}
+    <div class="card p-4">
+      <p class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">COPE Data</p>
+      <dl class="text-xs text-gray-600 space-y-1.5">
+        {% if cope.construction_type %}
+        <div class="flex justify-between gap-2">
+          <dt class="text-gray-400 shrink-0">Construction</dt>
+          <dd class="text-right">{{ cope.construction_type }}</dd>
+        </div>
+        {% endif %}
+        {% if cope.occupancy_description %}
+        <div class="flex justify-between gap-2">
+          <dt class="text-gray-400 shrink-0">Occupancy</dt>
+          <dd class="text-right">{{ cope.occupancy_description }}</dd>
+        </div>
+        {% endif %}
+        {% if cope.protection_class %}
+        <div class="flex justify-between gap-2">
+          <dt class="text-gray-400 shrink-0">Protection Class</dt>
+          <dd class="text-right">{{ cope.protection_class }}</dd>
+        </div>
+        {% endif %}
+        {% if cope.year_built %}
+        <div class="flex justify-between gap-2">
+          <dt class="text-gray-400 shrink-0">Year Built</dt>
+          <dd class="text-right">{{ cope.year_built }}</dd>
+        </div>
+        {% endif %}
+        {% if cope.stories %}
+        <div class="flex justify-between gap-2">
+          <dt class="text-gray-400 shrink-0">Stories</dt>
+          <dd class="text-right">{{ cope.stories }}</dd>
+        </div>
+        {% endif %}
+        {% if cope.sq_footage %}
+        <div class="flex justify-between gap-2">
+          <dt class="text-gray-400 shrink-0">Sq Footage</dt>
+          <dd class="text-right">{{ '{:,.0f}'.format(cope.sq_footage) }}</dd>
+        </div>
+        {% endif %}
+        {% if cope.sprinklered and cope.sprinklered != 'Unknown' %}
+        <div class="flex justify-between gap-2">
+          <dt class="text-gray-400 shrink-0">Sprinklered</dt>
+          <dd class="text-right">{{ cope.sprinklered }}</dd>
+        </div>
+        {% endif %}
+        {% if cope.roof_type %}
+        <div class="flex justify-between gap-2">
+          <dt class="text-gray-400 shrink-0">Roof Type</dt>
+          <dd class="text-right">{{ cope.roof_type }}</dd>
+        </div>
+        {% endif %}
+        {% if cope.total_insurable_value %}
+        <div class="flex justify-between gap-2">
+          <dt class="text-gray-400 shrink-0">TIV</dt>
+          <dd class="text-right font-medium text-gray-800">{{ cope.total_insurable_value | currency }}</dd>
+        </div>
+        {% endif %}
+        {% if cope.notes %}
+        <div class="pt-1 border-t border-gray-100 mt-1">
+          <dt class="text-gray-400 mb-0.5">Notes</dt>
+          <dd class="text-gray-600">{{ cope.notes }}</dd>
+        </div>
+        {% endif %}
+      </dl>
+      <a href="/clients/{{ client.id }}?tab=risk" class="text-xs text-gray-400 hover:text-marsh mt-2 block">Edit COPE data ↗</a>
     </div>
     {% endif %}
 


### PR DESCRIPTION
## Summary
- **Bug fix:** Client edit address autocomplete now triggers autosave after Nominatim selection, ensuring lat/lng are persisted (was a race condition where autosave fired during typing with empty coords, then no re-fire after selection)
- **New:** Map widget on project detail page with cached lat/lng or Nominatim geocoding fallback
- **New:** COPE data summary card on project detail page (Construction, Occupancy, Protection, Exposure) for locations with compliance data
- **New:** Migration 077 adds latitude/longitude columns to projects table; location autocomplete and create endpoint now save geocoded coordinates
- **Minor:** Fixed followup section "View" link to point to `/edit` instead of bare policy URL

## Test plan
- [ ] Edit a client address via autocomplete — verify lat/lng saved and map renders on reload
- [ ] Visit a project page with address — verify map displays correctly
- [ ] Visit a project page with COPE data — verify COPE card renders all fields
- [ ] Edit a location address in the locations table — verify lat/lng PATCHed to project
- [ ] Create a new location — verify lat/lng accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)