### PR TITLE
fix: compliance Edit button opens slideover instead of old inline form

### DIFF
--- a/src/policydb/web/templates/compliance/_location_detail.html
+++ b/src/policydb/web/templates/compliance/_location_detail.html
@@ -175,9 +175,9 @@
                 <td class="py-2 w-20 text-right no-print">
                   <span class="opacity-0 group-hover:opacity-100 transition-opacity">
                     <button class="text-marsh hover:text-green-800 text-xs mr-1"
-                            hx-get="/compliance/client/{{ client_id }}/requirements/{{ r.id }}/row/edit"
-                            hx-target="#req-row-{{ r.id }}"
-                            hx-swap="outerHTML">Edit</button>
+                            hx-get="/compliance/client/{{ client_id }}/requirements/{{ r.id }}/detail"
+                            hx-target="#requirement-slideover-container"
+                            hx-swap="innerHTML">Edit</button>
                     <button class="text-red-400 hover:text-red-600 text-xs"
                             hx-post="/compliance/client/{{ client_id }}/requirements/{{ r.id }}/delete"
                             hx-target="#location-tab-content"


### PR DESCRIPTION
## Summary
- Fixed stale Edit button in `_location_detail.html` that targeted the deprecated `/row/edit` inline form endpoint instead of the new `/detail` slideover endpoint
- First click was showing the old inline edit form; second click opened the slideover

## Test plan
- [ ] Click Edit on any compliance requirement row — slideover opens immediately (no inline form flash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)