### PR TITLE
Add dedup tool, enhanced Book Review export

### DIFF
--- a/src/policydb/db.py
+++ b/src/policydb/db.py
@@ -359,7 +359,7 @@ def init_db(path: Path | None = None) -> None:
 
     # Back up the database once before running any pending migrations.
     # This gives a clean restore point regardless of which migration fails.
-    _KNOWN_MIGRATIONS = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82}
+    _KNOWN_MIGRATIONS = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83}
     if _KNOWN_MIGRATIONS - applied:
         _backup_db(conn, db_path)
 
@@ -1119,6 +1119,15 @@ def init_db(path: Path | None = None) -> None:
         conn.execute(
             "INSERT INTO schema_version (version, description) VALUES (?, ?)",
             (82, "Import field provenance for per-field source tracking"),
+        )
+        conn.commit()
+
+    if 83 not in applied:
+        sql = (_MIGRATIONS_DIR / "083_dedup_dismissed.sql").read_text()
+        conn.executescript(sql)
+        conn.execute(
+            "INSERT INTO schema_version (version, description) VALUES (?, ?)",
+            (83, "Dedup dismissed pairs table for client-level policy deduplication"),
         )
         conn.commit()
 

--- a/src/policydb/dedup.py
+++ b/src/policydb/dedup.py
@@ -1,0 +1,494 @@
+"""Client-level policy deduplication engine.
+
+Finds likely duplicate policies within a single client — policies imported
+from multiple sources (e.g., accounting system + AE spreadsheet) that are
+actually the same policy.  Uses additive scoring with no hard gates (same
+pattern as reconciler._score_pair).
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from datetime import date, datetime
+from itertools import combinations
+
+from rapidfuzz import fuzz
+
+from policydb.utils import (
+    normalize_carrier,
+    normalize_coverage_type,
+    normalize_policy_number_for_matching,
+)
+
+logger = logging.getLogger("policydb.dedup")
+
+# ── Fields we compare for diffs ─────────────────────────────────────────────
+
+_COMPARE_FIELDS = [
+    "policy_number",
+    "policy_type",
+    "carrier",
+    "effective_date",
+    "expiration_date",
+    "premium",
+    "limit_amount",
+    "deductible",
+    "retention",
+    "project_name",
+    "first_named_insured",
+    "exposure_address",
+    "exposure_city",
+    "exposure_state",
+    "exposure_zip",
+    "notes",
+    "broker_fee",
+]
+
+# Display labels for diff fields
+_FIELD_LABELS = {
+    "policy_number": "Policy #",
+    "policy_type": "Type",
+    "carrier": "Carrier",
+    "effective_date": "Eff Date",
+    "expiration_date": "Exp Date",
+    "premium": "Premium",
+    "limit_amount": "Limit",
+    "deductible": "Deductible",
+    "retention": "Retention",
+    "project_name": "Project/Location",
+    "first_named_insured": "First Named Insured",
+    "exposure_address": "Address",
+    "exposure_city": "City",
+    "exposure_state": "State",
+    "exposure_zip": "ZIP",
+    "notes": "Notes",
+    "broker_fee": "Broker Fee",
+}
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _date_delta_days(d1: str | None, d2: str | None) -> int | None:
+    """Return absolute day difference between two YYYY-MM-DD strings, or None."""
+    if not d1 or not d2:
+        return None
+    try:
+        dt1 = datetime.strptime(str(d1).strip(), "%Y-%m-%d")
+        dt2 = datetime.strptime(str(d2).strip(), "%Y-%m-%d")
+        return abs((dt1 - dt2).days)
+    except (ValueError, TypeError):
+        return None
+
+
+def _val(row: dict, field: str) -> str:
+    """Get a trimmed string value from a row dict, empty string for None."""
+    v = row.get(field)
+    if v is None:
+        return ""
+    return str(v).strip()
+
+
+def _numeric(row: dict, field: str) -> float:
+    """Get a numeric value from a row dict, 0.0 for None/empty."""
+    v = row.get(field)
+    if v is None:
+        return 0.0
+    try:
+        return float(v)
+    except (ValueError, TypeError):
+        return 0.0
+
+
+# ── Scoring ──────────────────────────────────────────────────────────────────
+
+def _score_pair(a: dict, b: dict) -> dict | None:
+    """Score a pair of policies for deduplication.
+
+    Returns a dict with score, confidence, match_signals, diff_fields,
+    fillable_a, fillable_b, recommendation, or None if the pair should be
+    skipped entirely.
+
+    Scoring (max ~115, but capped at 100 for display):
+      - Same eff+exp dates (exact): +35 points
+      - Same eff+exp dates (within 14d): +25 points
+      - Same policy type (fuzzy >=85): +20 points
+      - Same policy type (fuzzy >=70): +12 points
+      - Same carrier (fuzzy >=80): +15 points
+      - Same policy number (exact normalized): +30 points
+      - Same policy number (fuzzy >=75): +20 points
+      - Premium within 5%: +10 points
+      - Premium within 20%: +5 points
+      - Same limit: +5 points
+    """
+
+    # ── Skip rules ───────────────────────────────────────────────────────
+    # Skip if both are programs
+    if a.get("is_program") and b.get("is_program"):
+        return None
+
+    # Skip if one is a child of the other
+    a_uid = a.get("policy_uid", "")
+    b_uid = b.get("policy_uid", "")
+    if a.get("program_id") and a["program_id"] == b.get("id"):
+        return None
+    if b.get("program_id") and b["program_id"] == a.get("id"):
+        return None
+
+    # Skip if both have different (non-empty) policy numbers
+    pn_a = normalize_policy_number_for_matching(_val(a, "policy_number"))
+    pn_b = normalize_policy_number_for_matching(_val(b, "policy_number"))
+    if pn_a and pn_b and pn_a != pn_b:
+        # Even fuzzy-check — if clearly different, skip
+        pn_ratio = fuzz.ratio(pn_a, pn_b)
+        if pn_ratio < 75:
+            return None
+
+    # ── Policy Number (max 30) ───────────────────────────────────────────
+    score_pn = 0.0
+    signals = []
+    if pn_a and pn_b:
+        if pn_a == pn_b:
+            score_pn = 30.0
+            signals.append("policy_number")
+        else:
+            pn_ratio = fuzz.ratio(pn_a, pn_b)
+            if pn_ratio >= 75:
+                score_pn = 20.0
+                signals.append("policy_number~")
+
+    # ── Dates (max 35) ───────────────────────────────────────────────────
+    eff_a = _val(a, "effective_date")
+    eff_b = _val(b, "effective_date")
+    exp_a = _val(a, "expiration_date")
+    exp_b = _val(b, "expiration_date")
+
+    eff_delta = _date_delta_days(eff_a, eff_b)
+    exp_delta = _date_delta_days(exp_a, exp_b)
+
+    score_dates = 0.0
+    # Both dates must be present for a date match
+    if eff_delta is not None and exp_delta is not None:
+        if eff_delta == 0 and exp_delta == 0:
+            score_dates = 35.0
+            signals.append("dates")
+        elif eff_delta <= 14 and exp_delta <= 14:
+            score_dates = 25.0
+            signals.append("dates~")
+
+    # ── Policy Type (max 20) ─────────────────────────────────────────────
+    type_a = normalize_coverage_type(_val(a, "policy_type"))
+    type_b = normalize_coverage_type(_val(b, "policy_type"))
+
+    score_type = 0.0
+    if type_a and type_b:
+        if type_a.lower() == type_b.lower():
+            score_type = 20.0
+            signals.append("type")
+        else:
+            type_ratio = fuzz.WRatio(type_a, type_b)
+            if type_ratio >= 85:
+                score_type = 20.0
+                signals.append("type")
+            elif type_ratio >= 70:
+                score_type = 12.0
+                signals.append("type~")
+
+    # ── Carrier (max 15) ─────────────────────────────────────────────────
+    carrier_a = normalize_carrier(_val(a, "carrier"))
+    carrier_b = normalize_carrier(_val(b, "carrier"))
+
+    score_carrier = 0.0
+    if carrier_a and carrier_b:
+        if carrier_a.lower() == carrier_b.lower():
+            score_carrier = 15.0
+            signals.append("carrier")
+        else:
+            carrier_ratio = fuzz.WRatio(carrier_a, carrier_b)
+            if carrier_ratio >= 80:
+                score_carrier = 15.0
+                signals.append("carrier")
+
+    # ── Premium (max 10) ─────────────────────────────────────────────────
+    prem_a = _numeric(a, "premium")
+    prem_b = _numeric(b, "premium")
+
+    score_prem = 0.0
+    if prem_a > 0 and prem_b > 0:
+        prem_ratio = min(prem_a, prem_b) / max(prem_a, prem_b)
+        if prem_ratio >= 0.95:
+            score_prem = 10.0
+            signals.append("premium")
+        elif prem_ratio >= 0.80:
+            score_prem = 5.0
+            signals.append("premium~")
+
+    # ── Limit (max 5) ────────────────────────────────────────────────────
+    limit_a = _numeric(a, "limit_amount")
+    limit_b = _numeric(b, "limit_amount")
+
+    score_limit = 0.0
+    if limit_a > 0 and limit_b > 0 and limit_a == limit_b:
+        score_limit = 5.0
+        signals.append("limit")
+
+    # ── Total ────────────────────────────────────────────────────────────
+    total = score_pn + score_dates + score_type + score_carrier + score_prem + score_limit
+    score = min(100, int(round(total)))
+
+    if score < 40:
+        return None
+
+    # ── Confidence / Recommendation ──────────────────────────────────────
+    if score >= 75:
+        confidence = "high"
+        recommendation = "likely_duplicate"
+    elif score >= 50:
+        confidence = "medium"
+        recommendation = "possible_duplicate"
+    else:
+        confidence = "low"
+        recommendation = "different_policies"
+
+    # ── Diff fields ──────────────────────────────────────────────────────
+    diff_fields = []
+    fillable_a = []  # fields A has that B doesn't
+    fillable_b = []  # fields B has that A doesn't
+
+    for field in _COMPARE_FIELDS:
+        va = _val(a, field)
+        vb = _val(b, field)
+
+        if va == vb:
+            continue
+
+        label = _FIELD_LABELS.get(field, field)
+        diff_fields.append({
+            "field": field,
+            "label": label,
+            "val_a": va,
+            "val_b": vb,
+        })
+
+        if va and not vb:
+            fillable_a.append(field)
+        elif vb and not va:
+            fillable_b.append(field)
+
+    return {
+        "policy_a": a,
+        "policy_b": b,
+        "score": score,
+        "confidence": confidence,
+        "match_signals": signals,
+        "diff_fields": diff_fields,
+        "fillable_a": fillable_a,
+        "fillable_b": fillable_b,
+        "recommendation": recommendation,
+    }
+
+
+# ── Public API ───────────────────────────────────────────────────────────────
+
+def find_duplicate_candidates(
+    conn: sqlite3.Connection,
+    client_id: int,
+) -> list[dict]:
+    """Find all likely duplicate policy pairs within a client.
+
+    Returns list of scored pair dicts, sorted highest score first.
+    Excludes previously dismissed pairs.
+    """
+    # Fetch all non-archived, non-opportunity policies for this client
+    rows = conn.execute(
+        """
+        SELECT p.*, p.id as policy_pk
+        FROM policies p
+        WHERE p.client_id = ?
+          AND p.archived = 0
+          AND (p.is_opportunity = 0 OR p.is_opportunity IS NULL)
+        ORDER BY p.policy_uid
+        """,
+        (client_id,),
+    ).fetchall()
+
+    policies = [dict(r) for r in rows]
+
+    if len(policies) < 2:
+        return []
+
+    # Load dismissed pairs
+    dismissed_rows = conn.execute(
+        """
+        SELECT policy_uid_a, policy_uid_b FROM dedup_dismissed
+        WHERE client_id = ?
+        """,
+        (client_id,),
+    ).fetchall()
+
+    dismissed_set: set[tuple[str, str]] = set()
+    for dr in dismissed_rows:
+        # Store both orderings for quick lookup
+        dismissed_set.add((dr["policy_uid_a"], dr["policy_uid_b"]))
+        dismissed_set.add((dr["policy_uid_b"], dr["policy_uid_a"]))
+
+    # Score all pairs
+    candidates = []
+    for a, b in combinations(policies, 2):
+        uid_a = a.get("policy_uid", "")
+        uid_b = b.get("policy_uid", "")
+
+        # Skip dismissed pairs
+        if (uid_a, uid_b) in dismissed_set:
+            continue
+
+        result = _score_pair(a, b)
+        if result is not None:
+            candidates.append(result)
+
+    # Sort by score descending
+    candidates.sort(key=lambda c: -c["score"])
+
+    return candidates
+
+
+def merge_policies(
+    conn: sqlite3.Connection,
+    keep_uid: str,
+    archive_uid: str,
+    cherry_pick: dict,
+) -> dict:
+    """Merge two policies — keep one, cherry-pick fields from the other, archive the loser.
+
+    Args:
+        keep_uid: policy_uid to keep
+        archive_uid: policy_uid to archive
+        cherry_pick: {field_name: value} — fields to copy from archive to keep
+
+    Returns:
+        {"ok": True, "kept": keep_uid, "archived": archive_uid, "fields_transferred": list}
+    """
+    # Look up both policies
+    keep_row = conn.execute(
+        "SELECT * FROM policies WHERE policy_uid = ?", (keep_uid,)
+    ).fetchone()
+    archive_row = conn.execute(
+        "SELECT * FROM policies WHERE policy_uid = ?", (archive_uid,)
+    ).fetchone()
+
+    if not keep_row or not archive_row:
+        return {"ok": False, "error": "One or both policies not found"}
+
+    keep_id = keep_row["id"]
+    archive_id = archive_row["id"]
+
+    fields_transferred = []
+
+    # 1. Update keep policy with cherry_pick fields
+    if cherry_pick:
+        safe_fields = {k: v for k, v in cherry_pick.items() if k in _COMPARE_FIELDS}
+        if safe_fields:
+            set_clause = ", ".join(f"{k} = ?" for k in safe_fields)
+            values = list(safe_fields.values()) + [keep_id]
+            conn.execute(
+                f"UPDATE policies SET {set_clause} WHERE id = ?",  # noqa: S608
+                values,
+            )
+            fields_transferred = list(safe_fields.keys())
+
+    # 2. Move activity_log entries from archive to keep
+    conn.execute(
+        "UPDATE activity_log SET policy_id = ? WHERE policy_id = ?",
+        (keep_id, archive_id),
+    )
+
+    # 3. Move policy_milestones from archive to keep (only if keep doesn't have them)
+    existing_milestones = {
+        r["milestone"]
+        for r in conn.execute(
+            "SELECT milestone FROM policy_milestones WHERE policy_uid = ?",
+            (keep_uid,),
+        ).fetchall()
+    }
+    archive_milestones = conn.execute(
+        "SELECT * FROM policy_milestones WHERE policy_uid = ?",
+        (archive_uid,),
+    ).fetchall()
+    for m in archive_milestones:
+        if m["milestone"] not in existing_milestones:
+            conn.execute(
+                "UPDATE policy_milestones SET policy_uid = ? WHERE id = ?",
+                (keep_uid, m["id"]),
+            )
+
+    # 4. Move policy_contacts from archive to keep
+    conn.execute(
+        "UPDATE contact_policy_assignments SET policy_id = ? WHERE policy_id = ?",
+        (keep_id, archive_id),
+    )
+
+    # 5. Transfer project_id if archive has one and keep doesn't
+    if archive_row["project_id"] and not keep_row["project_id"]:
+        conn.execute(
+            "UPDATE policies SET project_id = ? WHERE id = ?",
+            (archive_row["project_id"], keep_id),
+        )
+        fields_transferred.append("project_id")
+
+    # 6. Archive the loser
+    today = date.today().isoformat()
+    conn.execute(
+        "UPDATE policies SET archived = 1, notes = COALESCE(notes, '') || ? WHERE id = ?",
+        (f"\n[Merged into {keep_uid} on {today}]", archive_id),
+    )
+
+    # 7. Log activity on keep
+    cherry_desc = ", ".join(fields_transferred) if fields_transferred else "none"
+    conn.execute(
+        """
+        INSERT INTO activity_log (client_id, policy_id, activity_type, activity_date, details)
+        VALUES (?, ?, 'Note', ?, ?)
+        """,
+        (
+            keep_row["client_id"],
+            keep_id,
+            today,
+            f"Merged duplicate {archive_uid} -- cherry-picked: {cherry_desc}",
+        ),
+    )
+
+    conn.commit()
+
+    return {
+        "ok": True,
+        "kept": keep_uid,
+        "archived": archive_uid,
+        "fields_transferred": fields_transferred,
+    }
+
+
+def dismiss_pair(
+    conn: sqlite3.Connection,
+    client_id: int,
+    policy_uid_a: str,
+    policy_uid_b: str,
+) -> dict:
+    """Dismiss a duplicate pair so it doesn't resurface.
+
+    Always stores the pair in canonical order (alphabetically smaller UID first).
+    """
+    # Canonical ordering
+    uid_a, uid_b = sorted([policy_uid_a, policy_uid_b])
+    try:
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO dedup_dismissed (client_id, policy_uid_a, policy_uid_b)
+            VALUES (?, ?, ?)
+            """,
+            (client_id, uid_a, uid_b),
+        )
+        conn.commit()
+        return {"ok": True}
+    except Exception as e:
+        logger.warning("Failed to dismiss dedup pair: %s", e)
+        return {"ok": False, "error": str(e)}

--- a/src/policydb/exporter.py
+++ b/src/policydb/exporter.py
@@ -2489,11 +2489,12 @@ def save_export_bytes(content: bytes, filename: str) -> Path:
 def export_book_review_xlsx(conn: sqlite3.Connection, client_id: int, client_name: str) -> bytes:
     """Multi-tab XLSX workbook for team review of gaps and unknowns.
 
-    Tabs: Summary, All Policies, Unassigned Locations, Missing Fields,
-    Program Review, Action Items.
+    Tabs: Instructions, Summary, All Policies, Suspected Duplicates,
+    Unassigned Locations, Missing Fields, Program Review, Action Items.
     Uses friendly column labels for external team members.
     """
     from datetime import date
+    from policydb.dedup import find_duplicate_candidates
 
     # ── Query all active policies for client ──
     policies = conn.execute(
@@ -2539,11 +2540,39 @@ def export_book_review_xlsx(conn: sqlite3.Connection, client_id: int, client_nam
                 ).fetchall()
                 program_carriers[prog["policy_uid"]] = [dict(c) for c in carriers]
 
+    # ── Run dedup scan ──
+    dedup_candidates = find_duplicate_candidates(conn, client_id)
+
     wb = Workbook()
     wb.remove(wb.active)
 
     # ════════════════════════════════════════════════════════════════════════
-    # TAB 1: SUMMARY
+    # TAB 1: INSTRUCTIONS
+    # ════════════════════════════════════════════════════════════════════════
+    instructions = [
+        {"#": 1, "Section": "HOW TO USE THIS WORKBOOK", "Details": ""},
+        {"#": "", "Section": "", "Details": "This workbook was exported from PolicyDB to help the team review and complete the book of business."},
+        {"#": "", "Section": "", "Details": "Each tab focuses on a different type of gap or issue. Work through them in order."},
+        {"#": "", "Section": "", "Details": ""},
+        {"#": 2, "Section": "TAB GUIDE", "Details": ""},
+        {"#": "", "Section": "Summary", "Details": "High-level stats and gap counts. Review first to understand scope."},
+        {"#": "", "Section": "All Policies", "Details": "Complete list. Use Has Location? / Has Carrier? / Has Policy# columns to spot gaps."},
+        {"#": "", "Section": "Suspected Duplicates", "Details": "Policies that may be the same record imported from two sources. CONFIRM: are these the same policy?"},
+        {"#": "", "Section": "Unassigned Locations", "Details": "Policies not assigned to a project/location. FIND: which project does each belong to?"},
+        {"#": "", "Section": "Missing Fields", "Details": "Policies missing key data. FIND: policy numbers, carriers, premiums from source documents."},
+        {"#": "", "Section": "Program Review", "Details": "Corporate programs — check carrier lists and identify unlinked policies."},
+        {"#": "", "Section": "Action Items", "Details": "Prioritized checklist of everything that needs attention. Work top-down."},
+        {"#": "", "Section": "", "Details": ""},
+        {"#": 3, "Section": "HOW TO REPORT BACK", "Details": ""},
+        {"#": "", "Section": "", "Details": "Fill in the 'Your Notes' column on the Action Items tab with what you find."},
+        {"#": "", "Section": "", "Details": "For suspected duplicates: write SAME or DIFFERENT in the Verdict column."},
+        {"#": "", "Section": "", "Details": "For missing fields: write the missing value directly in the Notes column."},
+        {"#": "", "Section": "", "Details": "Return the completed workbook and we will update PolicyDB."},
+    ]
+    _write_sheet(wb, "Instructions", instructions, col_widths={"#": 5, "Section": 30, "Details": 80})
+
+    # ════════════════════════════════════════════════════════════════════════
+    # TAB 2: SUMMARY
     # ════════════════════════════════════════════════════════════════════════
     total_policies = len([p for p in policies if not p.get("is_program")])
     total_programs = len(programs)
@@ -2569,6 +2598,7 @@ def export_book_review_xlsx(conn: sqlite3.Connection, client_id: int, client_nam
         {"Item": "Policies Missing Premium", "Value": len(missing_premium)},
         {"Item": "Policies Missing Policy Number", "Value": len(missing_polnum)},
         {"Item": "Policies Missing Dates", "Value": len(missing_dates)},
+        {"Item": "Suspected Duplicates", "Value": len(dedup_candidates)},
     ]
     _write_sheet(wb, "Summary", summary_rows, col_widths={"Item": 40, "Value": 25})
 
@@ -2606,7 +2636,56 @@ def export_book_review_xlsx(conn: sqlite3.Connection, client_id: int, client_nam
     _write_sheet(wb, "All Policies", all_rows)
 
     # ════════════════════════════════════════════════════════════════════════
-    # TAB 3: UNASSIGNED LOCATIONS
+    # TAB 4: SUSPECTED DUPLICATES
+    # ════════════════════════════════════════════════════════════════════════
+    dup_rows = []
+    for c in dedup_candidates:
+        a = c["policy_a"]
+        b = c["policy_b"]
+        signals = ", ".join(s.replace("~", " (fuzzy)") for s in c["match_signals"])
+        fills_a = ", ".join(c.get("fillable_a", []))
+        fills_b = ", ".join(c.get("fillable_b", []))
+
+        dup_rows.append({
+            "Score": c["score"],
+            "Confidence": c["recommendation"].replace("_", " ").title(),
+            "Policy A": a.get("policy_uid", ""),
+            "A — Type": a.get("policy_type", ""),
+            "A — Carrier": a.get("carrier", ""),
+            "A — Policy #": a.get("policy_number", ""),
+            "A — Dates": f"{a.get('effective_date', '')} – {a.get('expiration_date', '')}",
+            "A — Premium": float(a.get("premium") or 0),
+            "A — Location": a.get("project_name", "") or a.get("location_name", "") or "",
+            "Policy B": b.get("policy_uid", ""),
+            "B — Type": b.get("policy_type", ""),
+            "B — Carrier": b.get("carrier", ""),
+            "B — Policy #": b.get("policy_number", ""),
+            "B — Dates": f"{b.get('effective_date', '')} – {b.get('expiration_date', '')}",
+            "B — Premium": float(b.get("premium") or 0),
+            "B — Location": b.get("project_name", "") or b.get("location_name", "") or "",
+            "Match Signals": signals,
+            "A Has (B Missing)": fills_a,
+            "B Has (A Missing)": fills_b,
+            "Verdict (SAME/DIFFERENT)": "",
+            "Notes": "",
+        })
+
+    if not dup_rows:
+        dup_rows.append({
+            "Score": "", "Confidence": "", "Policy A": "", "A — Type": "",
+            "A — Carrier": "", "A — Policy #": "", "A — Dates": "",
+            "A — Premium": "", "A — Location": "",
+            "Policy B": "", "B — Type": "", "B — Carrier": "",
+            "B — Policy #": "", "B — Dates": "", "B — Premium": "",
+            "B — Location": "", "Match Signals": "",
+            "A Has (B Missing)": "", "B Has (A Missing)": "",
+            "Verdict (SAME/DIFFERENT)": "No suspected duplicates found",
+            "Notes": "",
+        })
+    _write_sheet(wb, "Suspected Duplicates", dup_rows)
+
+    # ════════════════════════════════════════════════════════════════════════
+    # TAB 5: UNASSIGNED LOCATIONS
     # ════════════════════════════════════════════════════════════════════════
     unassigned_rows = []
     for p in unassigned:
@@ -2620,7 +2699,7 @@ def export_book_review_xlsx(conn: sqlite3.Connection, client_id: int, client_nam
             "Expiration Date": p.get("expiration_date", ""),
             "Address on File": p.get("exposure_address", ""),
             "Notes": p.get("description", ""),
-            "Action Needed": "Assign to a location or confirm as corporate-level",
+            "Action Needed": "FIND which project/location this policy covers. If corporate-wide, write 'CORPORATE'.",
         })
     _write_sheet(wb, "Unassigned Locations", unassigned_rows)
 
@@ -2711,6 +2790,21 @@ def export_book_review_xlsx(conn: sqlite3.Connection, client_id: int, client_nam
     actions = []
     action_num = 0
 
+    # Dedup items first — highest priority
+    for c in dedup_candidates:
+        a = c["policy_a"]
+        b = c["policy_b"]
+        action_num += 1
+        actions.append({
+            "#": action_num,
+            "Priority": "High" if c["confidence"] == "high" else "Medium",
+            "Category": "Suspected Duplicate",
+            "Policy ID": f"{a.get('policy_uid', '')} vs {b.get('policy_uid', '')}",
+            "What To Do": f"CONFIRM: Are these the same policy? Score: {c['score']}. See Suspected Duplicates tab.",
+            "Context": f"{a.get('policy_type', '')} · {a.get('carrier', '')} · {a.get('effective_date', '')}",
+            "Your Notes": "",
+        })
+
     for p in unassigned:
         action_num += 1
         actions.append({
@@ -2718,9 +2812,9 @@ def export_book_review_xlsx(conn: sqlite3.Connection, client_id: int, client_nam
             "Priority": "Medium",
             "Category": "Location Assignment",
             "Policy ID": p["policy_uid"],
-            "Description": f"Assign {p.get('policy_type', '')} ({p.get('carrier', '')}) to a location",
-            "Current Value": p.get("exposure_address", "") or "No address on file",
-            "Status": "Open",
+            "What To Do": f"FIND which project/location this {p.get('policy_type', '')} ({p.get('carrier', '')}) covers. Write project name or 'CORPORATE'.",
+            "Context": p.get("exposure_address", "") or "No address on file",
+            "Your Notes": "",
         })
 
     for row in missing_rows:
@@ -2731,9 +2825,9 @@ def export_book_review_xlsx(conn: sqlite3.Connection, client_id: int, client_nam
                 "Priority": "High",
                 "Category": "Missing Data",
                 "Policy ID": row["Policy ID"],
-                "Description": f"Complete missing: {row['Missing Fields']}",
-                "Current Value": f"{row['Coverage Type']} / {row.get('Carrier', '')}",
-                "Status": "Open",
+                "What To Do": f"FIND and provide: {row['Missing Fields']}. Check AMS, carrier portal, or policy documents.",
+                "Context": f"{row['Coverage Type']} / {row.get('Carrier', '')}",
+                "Your Notes": "",
             })
 
     for prog_row in program_rows:
@@ -2744,16 +2838,16 @@ def export_book_review_xlsx(conn: sqlite3.Connection, client_id: int, client_nam
                 "Priority": "Medium",
                 "Category": "Program Membership",
                 "Policy ID": prog_row["Program ID"],
-                "Description": prog_row["Review Note"],
-                "Current Value": f"{prog_row['Carrier Count']} carriers, {prog_row['Child Policies Linked']} linked",
-                "Status": "Open",
+                "What To Do": f"VERIFY: {prog_row['Review Note']}. Should these standalone policies be part of this program?",
+                "Context": f"{prog_row['Carrier Count']} carriers, {prog_row['Child Policies Linked']} linked",
+                "Your Notes": "",
             })
 
     if not actions:
         actions.append({
             "#": 1, "Priority": "", "Category": "",
-            "Policy ID": "", "Description": "No action items — book looks complete!",
-            "Current Value": "", "Status": "Complete",
+            "Policy ID": "", "What To Do": "No action items — book looks complete!",
+            "Context": "", "Your Notes": "",
         })
 
     _write_sheet(wb, "Action Items", actions)

--- a/src/policydb/migrations/083_dedup_dismissed.sql
+++ b/src/policydb/migrations/083_dedup_dismissed.sql
@@ -1,0 +1,9 @@
+-- Migration 083: Dedup dismissed pairs table
+CREATE TABLE IF NOT EXISTS dedup_dismissed (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    client_id INTEGER NOT NULL,
+    policy_uid_a TEXT NOT NULL,
+    policy_uid_b TEXT NOT NULL,
+    dismissed_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(client_id, policy_uid_a, policy_uid_b)
+);

--- a/src/policydb/web/routes/clients.py
+++ b/src/policydb/web/routes/clients.py
@@ -2519,6 +2519,77 @@ def client_note_delete(request: Request, client_id: int, note_id: int, conn=Depe
     )
 
 
+@router.get("/{client_id}/dedup")
+def dedup_page(request: Request, client_id: int, conn=Depends(get_db)):
+    """Client-level policy deduplication tool."""
+    from policydb.dedup import find_duplicate_candidates
+    client = get_client_by_id(conn, client_id)
+    if not client:
+        return HTMLResponse("Client not found", status_code=404)
+    candidates = find_duplicate_candidates(conn, client_id)
+    likely = [c for c in candidates if c["recommendation"] == "likely_duplicate"]
+    possible = [c for c in candidates if c["recommendation"] == "possible_duplicate"]
+    review = [c for c in candidates if c["recommendation"] == "different_policies"]
+    return templates.TemplateResponse("clients/dedup.html", {
+        "request": request,
+        "client": client,
+        "candidates": candidates,
+        "likely": likely,
+        "possible": possible,
+        "review": review,
+    })
+
+
+@router.post("/{client_id}/dedup/merge")
+def dedup_merge(
+    request: Request,
+    client_id: int,
+    keep_uid: str = Form(""),
+    archive_uid: str = Form(""),
+    cherry_pick: str = Form("{}"),
+    conn=Depends(get_db),
+):
+    """Merge two duplicate policies."""
+    import json
+    from policydb.dedup import merge_policies
+    try:
+        cherry_pick_dict = json.loads(cherry_pick)
+    except Exception:
+        cherry_pick_dict = {}
+    result = merge_policies(conn, keep_uid, archive_uid, cherry_pick_dict)
+    if result.get("ok"):
+        fields = result.get("fields_transferred", [])
+        field_count = len(fields)
+        s = "s" if field_count != 1 else ""
+        return HTMLResponse(f'''
+            <div id="pair-{keep_uid}-{archive_uid}" class="border border-green-200 bg-green-50 rounded-lg p-4 mb-3">
+                <div class="flex items-center gap-2">
+                    <span class="text-green-600 text-lg">&#10003;</span>
+                    <span class="text-sm font-medium text-green-800">
+                        Merged {archive_uid} into {keep_uid}. {field_count} field{s} transferred.
+                    </span>
+                </div>
+            </div>
+        ''')
+    return HTMLResponse(f'<div class="text-red-600 text-sm">{result.get("error", "Merge failed")}</div>')
+
+
+@router.post("/{client_id}/dedup/dismiss")
+def dedup_dismiss(
+    request: Request,
+    client_id: int,
+    uid_a: str = Form(""),
+    uid_b: str = Form(""),
+    conn=Depends(get_db),
+):
+    """Dismiss a pair as not duplicates."""
+    from policydb.dedup import dismiss_pair
+    dismiss_pair(conn, client_id, uid_a, uid_b)
+    return HTMLResponse(f'''
+        <div id="pair-{uid_a}-{uid_b}" class="hidden"></div>
+    ''')
+
+
 @router.get("/{client_id}/export/full")
 def export_full(client_id: int, conn=Depends(get_db)):
     """Full internal data export (XLSX) — all fields including internal notes."""

--- a/src/policydb/web/templates/clients/_sticky_sidebar.html
+++ b/src/policydb/web/templates/clients/_sticky_sidebar.html
@@ -75,6 +75,8 @@
          hx-target="#ai-import-container"
          hx-swap="innerHTML"
          class="text-xs text-center bg-gray-50 hover:bg-gray-100 text-purple-700 rounded px-2 py-1.5 transition-colors">AI Bulk Import</button>
+      <a href="/clients/{{ client.id }}/dedup"
+         class="text-xs text-center bg-gray-50 hover:bg-gray-100 text-red-600 rounded px-2 py-1.5 transition-colors">Find Duplicates</a>
     </div>
     <p class="text-[10px] text-gray-400 uppercase tracking-wide mt-2 mb-1">Quick CSV Exports</p>
     <div class="grid grid-cols-2 gap-1">

--- a/src/policydb/web/templates/clients/dedup.html
+++ b/src/policydb/web/templates/clients/dedup.html
@@ -1,0 +1,237 @@
+{% extends "base.html" %}
+{% block title %}Find Duplicates — {{ client.name }}{% endblock %}
+{% block content %}
+
+{# ── Header ── #}
+<div class="mb-4">
+  <div class="flex items-center gap-2 text-sm text-gray-400 mb-1">
+    <a href="/clients" class="hover:text-marsh">Clients</a>
+    <span>/</span>
+    <a href="/clients/{{ client.id }}" class="hover:text-marsh">{{ client.name }}</a>
+    <span>/</span>
+    <span class="text-gray-600">Find Duplicates</span>
+  </div>
+  <h1 class="text-2xl font-bold text-gray-900">Find Duplicates</h1>
+  <p class="text-sm text-gray-500 mt-1">
+    Review potential duplicate policies imported from multiple sources.
+    Merge the best fields from each or dismiss false matches.
+  </p>
+</div>
+
+{# ── Counter bar ── #}
+<div class="flex items-center gap-4 bg-white border border-gray-200 rounded-lg px-4 py-3 mb-6">
+  <span class="text-sm font-semibold text-gray-900">{{ candidates | length }} candidates</span>
+  {% if likely %}
+  <span class="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full bg-green-50 text-green-700 border border-green-200">
+    {{ likely | length }} likely
+  </span>
+  {% endif %}
+  {% if possible %}
+  <span class="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full bg-amber-50 text-amber-700 border border-amber-200">
+    {{ possible | length }} possible
+  </span>
+  {% endif %}
+  {% if review %}
+  <span class="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full bg-gray-100 text-gray-600">
+    {{ review | length }} review
+  </span>
+  {% endif %}
+  <div class="flex-1"></div>
+  <a href="/clients/{{ client.id }}" class="text-sm text-marsh hover:underline">&larr; Back to Client</a>
+</div>
+
+{% if not candidates %}
+<div class="bg-green-50 border border-green-200 rounded-lg p-8 text-center">
+  <p class="text-lg font-medium text-green-800">No duplicates found!</p>
+  <p class="text-sm text-green-600 mt-1">All policies for this client appear unique.</p>
+</div>
+{% endif %}
+
+{# ── Candidate Cards ── #}
+{% for c in candidates %}
+{% set a = c.policy_a %}
+{% set b = c.policy_b %}
+<div id="pair-{{ a.policy_uid }}-{{ b.policy_uid }}" class="bg-white border border-gray-200 rounded-lg mb-3 overflow-hidden">
+  {# Header with score #}
+  <div class="flex items-center gap-3 px-4 py-3 border-b border-gray-100
+    {% if c.confidence == 'high' %}bg-green-50{% elif c.confidence == 'medium' %}bg-amber-50{% else %}bg-gray-50{% endif %}">
+    <span class="inline-flex items-center justify-center w-10 h-10 rounded-full text-sm font-bold text-white
+      {% if c.confidence == 'high' %}bg-green-600{% elif c.confidence == 'medium' %}bg-amber-500{% else %}bg-gray-400{% endif %}">
+      {{ c.score }}
+    </span>
+    <div>
+      <span class="text-sm font-semibold
+        {% if c.confidence == 'high' %}text-green-800{% elif c.confidence == 'medium' %}text-amber-800{% else %}text-gray-700{% endif %}">
+        {% if c.recommendation == 'likely_duplicate' %}Likely Duplicate
+        {% elif c.recommendation == 'possible_duplicate' %}Possible Duplicate
+        {% else %}Review — May Be Different{% endif %}
+      </span>
+      <div class="flex items-center gap-1.5 mt-0.5">
+        {% for sig in c.match_signals %}
+        <span class="text-[10px] px-1.5 py-0.5 rounded bg-white border
+          {% if '~' in sig %}border-amber-200 text-amber-600{% else %}border-green-200 text-green-600{% endif %}">
+          &#10003; {{ sig | replace('~', '') }}
+        </span>
+        {% endfor %}
+      </div>
+    </div>
+  </div>
+
+  {# Side-by-side comparison #}
+  <div class="grid grid-cols-2 gap-4 px-4 py-3">
+    <div>
+      <p class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">{{ a.policy_uid }}</p>
+      <p class="text-sm font-medium text-gray-900">{{ a.policy_type or '—' }} &middot; {{ a.carrier or '—' }}</p>
+      <p class="text-xs text-gray-500">{{ a.effective_date or '?' }} – {{ a.expiration_date or '?' }}</p>
+      <p class="text-xs text-gray-500">Premium: {{ (a.premium or 0) | currency }} &middot; Policy #: {{ a.policy_number or '—' }}</p>
+      <p class="text-xs text-gray-500">Location: {{ a.project_name or a.location_name or '—' }}</p>
+    </div>
+    <div>
+      <p class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">{{ b.policy_uid }}</p>
+      <p class="text-sm font-medium text-gray-900">{{ b.policy_type or '—' }} &middot; {{ b.carrier or '—' }}</p>
+      <p class="text-xs text-gray-500">{{ b.effective_date or '?' }} – {{ b.expiration_date or '?' }}</p>
+      <p class="text-xs text-gray-500">Premium: {{ (b.premium or 0) | currency }} &middot; Policy #: {{ b.policy_number or '—' }}</p>
+      <p class="text-xs text-gray-500">Location: {{ b.project_name or b.location_name or '—' }}</p>
+    </div>
+  </div>
+
+  {# Diff table with radio buttons #}
+  {% if c.diff_fields %}
+  <div class="px-4 pb-3">
+    <table class="w-full text-xs">
+      <thead>
+        <tr class="border-b border-gray-100">
+          <th class="text-left py-1 text-gray-500 font-medium w-32">Field</th>
+          <th class="text-left py-1 text-gray-500 font-medium">{{ a.policy_uid }}</th>
+          <th class="text-left py-1 text-gray-500 font-medium">{{ b.policy_uid }}</th>
+          <th class="text-center py-1 text-gray-500 font-medium w-24">Keep</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for d in c.diff_fields %}
+        <tr class="border-b border-gray-50" data-field="{{ d.field }}">
+          <td class="py-1.5 text-gray-600 font-medium">{{ d.label }}</td>
+          <td class="py-1.5 {% if d.val_a %}text-gray-900{% else %}text-gray-300 italic{% endif %}">
+            {{ d.val_a if d.val_a else '(empty)' }}
+          </td>
+          <td class="py-1.5 {% if d.val_b %}text-gray-900{% else %}text-gray-300 italic{% endif %}">
+            {{ d.val_b if d.val_b else '(empty)' }}
+          </td>
+          <td class="py-1.5 text-center">
+            {% if d.val_a == d.val_b %}
+            <span class="text-gray-400">same</span>
+            {% elif d.val_a and not d.val_b %}
+            <span class="text-green-600 text-[10px]">&larr; A</span>
+            {% elif d.val_b and not d.val_a %}
+            <span class="text-green-600 text-[10px]">B &rarr;</span>
+            {% else %}
+            <label class="inline-flex items-center gap-1 mr-2">
+              <input type="radio" name="pick_{{ a.policy_uid }}_{{ b.policy_uid }}_{{ d.field }}" value="a" checked class="text-marsh">
+              <span class="text-[10px]">A</span>
+            </label>
+            <label class="inline-flex items-center gap-1">
+              <input type="radio" name="pick_{{ a.policy_uid }}_{{ b.policy_uid }}_{{ d.field }}" value="b">
+              <span class="text-[10px]">B</span>
+            </label>
+            {% endif %}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% endif %}
+
+  {# Action buttons #}
+  <div class="flex items-center gap-2 px-4 py-3 bg-gray-50 border-t border-gray-100">
+    <button type="button"
+      onclick="dedupMerge(this, '{{ client.id }}', '{{ a.policy_uid }}', '{{ b.policy_uid }}', 'a')"
+      class="text-xs font-medium bg-marsh text-white px-3 py-1.5 rounded hover:bg-marsh/90 transition-colors">
+      Keep {{ a.policy_uid }} &larr; merge from B
+    </button>
+    <button type="button"
+      onclick="dedupMerge(this, '{{ client.id }}', '{{ a.policy_uid }}', '{{ b.policy_uid }}', 'b')"
+      class="text-xs font-medium bg-white border border-marsh text-marsh px-3 py-1.5 rounded hover:bg-gray-50 transition-colors">
+      Keep {{ b.policy_uid }} &larr; merge from A
+    </button>
+    <div class="flex-1"></div>
+    <button type="button"
+      hx-post="/clients/{{ client.id }}/dedup/dismiss"
+      hx-vals='{"uid_a": "{{ a.policy_uid }}", "uid_b": "{{ b.policy_uid }}"}'
+      hx-target="#pair-{{ a.policy_uid }}-{{ b.policy_uid }}"
+      hx-swap="outerHTML"
+      class="text-xs text-gray-400 hover:text-gray-600 px-3 py-1.5">
+      Not Duplicates
+    </button>
+  </div>
+</div>
+{% endfor %}
+
+<script>
+function dedupMerge(btn, clientId, uidA, uidB, keepSide) {
+  var keepUid = keepSide === 'a' ? uidA : uidB;
+  var archiveUid = keepSide === 'a' ? uidB : uidA;
+
+  // Build cherry_pick from radio buttons and auto-fill indicators
+  var cherryPick = {};
+  var card = btn.closest('[id^="pair-"]');
+
+  // For each diff field row, determine what to cherry-pick from the archive
+  card.querySelectorAll('table tbody tr[data-field]').forEach(function(row) {
+    var field = row.getAttribute('data-field');
+    var cells = row.querySelectorAll('td');
+    if (cells.length < 4) return;
+
+    var valA = cells[1].textContent.trim();
+    var valB = cells[2].textContent.trim();
+    var keepCell = cells[3];
+
+    if (valA === '(empty)') valA = '';
+    if (valB === '(empty)') valB = '';
+
+    // Auto-fill: if one side has data and the other doesn't, cherry-pick the data
+    if (!valA && valB) {
+      if (keepSide === 'a') {
+        cherryPick[field] = valB;
+      }
+    } else if (valA && !valB) {
+      if (keepSide === 'b') {
+        cherryPick[field] = valA;
+      }
+    } else {
+      // Both have data — use radio selection if present
+      var radio = keepCell.querySelector('input[type="radio"]:checked');
+      if (radio) {
+        var selectedSide = radio.value;
+        if (keepSide === 'a' && selectedSide === 'b') {
+          cherryPick[field] = valB;
+        } else if (keepSide === 'b' && selectedSide === 'a') {
+          cherryPick[field] = valA;
+        }
+      }
+    }
+  });
+
+  var formData = new FormData();
+  formData.append('keep_uid', keepUid);
+  formData.append('archive_uid', archiveUid);
+  formData.append('cherry_pick', JSON.stringify(cherryPick));
+
+  btn.disabled = true;
+  btn.textContent = 'Merging...';
+
+  fetch('/clients/' + clientId + '/dedup/merge', {
+    method: 'POST',
+    body: formData,
+  }).then(function(resp) { return resp.text(); })
+    .then(function(html) {
+      card.outerHTML = html;
+    })
+    .catch(function() {
+      btn.disabled = false;
+      btn.textContent = 'Merge failed — retry';
+    });
+}
+</script>
+
+{% endblock %}


### PR DESCRIPTION
## Summary
- **Policy Deduplication Tool**: New `/clients/{id}/dedup` page that finds likely duplicate policies within a client (from multiple import sources), shows side-by-side comparisons with scoring, and lets you merge (cherry-pick best fields) or dismiss pairs
- **Enhanced Book Review XLSX**: Now 8 tabs with new Instructions sheet, Suspected Duplicates tab, clearer "What To Do" language and "Your Notes" column for team collaboration
- Migration 083 for dedup_dismissed persistence

## Test plan
- [ ] Navigate to client page → sidebar shows "Find Duplicates" button
- [ ] Click Find Duplicates → see scored candidate pairs (or green "no duplicates" message)
- [ ] Test merge: click "Keep A ← merge from B" → card replaced with green confirmation
- [ ] Test dismiss: click "Not Duplicates" → card disappears, won't reappear
- [ ] Download Book Review XLSX → verify 8 tabs including Instructions and Suspected Duplicates
- [ ] Action Items tab has "What To Do" and "Your Notes" columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)