### PR TITLE
feat: compliance requirement row color coding

### DIFF
--- a/src/policydb/web/templates/compliance/_location_detail.html
+++ b/src/policydb/web/templates/compliance/_location_detail.html
@@ -65,7 +65,18 @@
             {# Show all requirements from this source #}
             {% for r in reqs %}
               {% if (r.source_id or 0) == src_id %}
-              <tr id="req-row-{{ r.id }}" class="border-b border-gray-50 group">
+              {# Row color coding: status-based left border for quick compliance scan #}
+              {% set _rs = (r.compliance_status or 'Needs Review') | lower %}
+              {% set _line = r.coverage_line %}
+              {% set _is_overridden = false %}
+              {% if _line in gov %}
+                {% set _gov_req = gov[_line] %}
+                {% if not (_gov_req.source_name == r.source_name and _gov_req.required_limit == r.required_limit) %}
+                  {% set _is_overridden = true %}
+                {% endif %}
+              {% endif %}
+              {% set _rb = 'border-l-gray-200' if _is_overridden else 'border-l-green-400' if _rs == 'compliant' else 'border-l-red-400' if _rs == 'gap' else 'border-l-amber-400' if _rs == 'partial' else 'border-l-blue-300' if _rs == 'needs review' else 'border-l-gray-300' %}
+              <tr id="req-row-{{ r.id }}" class="border-b border-gray-50 group border-l-2 {{ _rb }}">
                 <td class="py-2 w-48">{{ r.coverage_line }}</td>
                 <td class="py-2 w-32">
                   {% if r.required_limit is not none %}

--- a/src/policydb/web/templates/compliance/_requirement_row.html
+++ b/src/policydb/web/templates/compliance/_requirement_row.html
@@ -1,5 +1,8 @@
 {# Single requirement display row — returned by row restore endpoint (cancel edit) #}
-<tr id="req-row-{{ req.id }}" class="border-b border-gray-50 group">
+{# Row color coding: status-based left border for quick compliance scan #}
+{% set _rs = (req.compliance_status or 'Needs Review') | lower %}
+{% set _rb = 'border-l-green-400' if _rs == 'compliant' else 'border-l-red-400' if _rs == 'gap' else 'border-l-amber-400' if _rs == 'partial' else 'border-l-blue-300' if _rs == 'needs review' else 'border-l-gray-300' %}
+<tr id="req-row-{{ req.id }}" class="border-b border-gray-50 group border-l-2 {{ _rb }}">
   <td class="py-2 w-48">{{ req.coverage_line }}</td>
   <td class="py-2 w-32">
     {% if req.required_limit is not none %}


### PR DESCRIPTION
## Summary
- Adds status-based colored left borders to compliance requirement rows for quick visual scanning
- Green (compliant), red (gap), amber (partial), blue (needs review), gray (waived/N/A), light gray (overridden)
- Applied to both the location detail table and the standalone row partial

## Test plan
- [x] Navigate to compliance page, drill into a location
- [x] Verify governing rows show blue border (needs review status)
- [x] Verify overridden rows show light gray border
- [x] Inspect computed styles confirm 2px solid borders rendering correctly
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)