### PR TITLE
fix: move confirmAction to global scope for policy edit buttons

### DIFF
--- a/src/policydb/web/templates/base.html
+++ b/src/policydb/web/templates/base.html
@@ -120,6 +120,24 @@
 
     window.flashCell = flashCell;
 
+    /* ── Two-click confirmation for destructive actions ────────────────── */
+    window.confirmAction = function(btn, msg) {
+      if (btn.dataset.confirming === '1') {
+        btn.closest('form').submit();
+        return;
+      }
+      var orig = btn.textContent;
+      var origClass = btn.className;
+      btn.textContent = msg + ' Click again to confirm';
+      btn.dataset.confirming = '1';
+      btn.className = btn.className.replace(/border-\S+/g, 'border-gray-400').replace(/text-\S+/g, 'text-gray-800') + ' bg-gray-100 font-semibold';
+      setTimeout(function() {
+        btn.textContent = orig;
+        btn.className = origClass;
+        delete btn.dataset.confirming;
+      }, 3000);
+    };
+
     /* ── Tab Component ──────────────────────────────────────────────────── */
     window.initTabs = function(containerId, storageKey) {
       var container = document.getElementById(containerId);

--- a/src/policydb/web/templates/policies/_tab_details.html
+++ b/src/policydb/web/templates/policies/_tab_details.html
@@ -557,28 +557,6 @@
   </div>
 </div>
 
-<script>
-/* Inline two-click confirmation for destructive actions.
-   First click: button text changes to confirmation prompt.
-   Second click within 3s: submits the parent form.
-   Auto-reverts after 3s if not confirmed. */
-function confirmAction(btn, msg) {
-  if (btn.dataset.confirming === '1') {
-    btn.closest('form').submit();
-    return;
-  }
-  var orig = btn.textContent;
-  var origClass = btn.className;
-  btn.textContent = msg + ' Click again to confirm';
-  btn.dataset.confirming = '1';
-  btn.className = btn.className.replace(/border-\S+/g, 'border-gray-400').replace(/text-\S+/g, 'text-gray-800') + ' bg-gray-100 font-semibold';
-  setTimeout(function() {
-    btn.textContent = orig;
-    btn.className = origClass;
-    delete btn.dataset.confirming;
-  }, 3000);
-}
-</script>
 
 <!-- Datalists -->
 <datalist id="ac-carrier"></datalist>


### PR DESCRIPTION
## Summary
- Archive, Delete, and Renew buttons on `/policies/{uid}/edit` were non-functional because `confirmAction()` was defined in a `<script>` tag inside `_tab_details.html` (loaded dynamically via HTMX tab lazy-loading), so the function never reached global scope
- Moved `confirmAction()` to `base.html` as `window.confirmAction` so it's always globally available before any tab content loads
- Removed the now-redundant local script block from `_tab_details.html`

## Test plan
- [ ] Navigate to `/policies/{any-uid}/edit`
- [ ] Click Archive → button text changes to confirmation prompt → click again → policy archives and redirects to client page
- [ ] Test Delete and Renew buttons similarly
- [ ] Verify auto-save on blur still works (change a field, tab away, see toast)

🤖 Generated with [Claude Code](https://claude.com/claude-code)