### PR TITLE
fix: exclude programs from corporate/standalone policies section

### DIFF
--- a/src/policydb/web/routes/clients.py
+++ b/src/policydb/web/routes/clients.py
@@ -697,6 +697,7 @@ def client_tab_policies(request: Request, client_id: int, conn=Depends(get_db)):
     ).fetchall()]
     _program_linked_ids = set()
     for pgm in programs:
+        _program_linked_ids.add(pgm["policy_uid"])
         pgm["carrier_rows"] = [dict(r) for r in conn.execute(
             "SELECT id, carrier, policy_number, premium, limit_amount FROM program_carriers WHERE program_id = ? ORDER BY sort_order",
             (pgm["id"],),
@@ -1071,6 +1072,7 @@ def client_detail(request: Request, client_id: int, add_contact: str = "", conn=
     ).fetchall()]
     _program_linked_ids = set()
     for pgm in programs:
+        _program_linked_ids.add(pgm["policy_uid"])
         # Carrier rows from structured table
         pgm["carrier_rows"] = [dict(r) for r in conn.execute(
             """SELECT id, carrier, policy_number, premium, limit_amount


### PR DESCRIPTION
## Summary
- Programs (policies with `is_program=1`) were appearing in both the Corporate Programs section and the regular Corporate/Standalone policies section on the client detail page
- Added program UIDs to the `_program_linked_ids` exclusion set so the template filter correctly hides them from the regular section
- Fixed in both `client_detail()` and `client_tab_policies()` routes

## Test plan
- [ ] Navigate to a client with program policies
- [ ] Verify programs appear only in the Corporate Programs section
- [ ] Verify programs no longer appear in regular policy groups
- [ ] Verify child policies of programs also remain excluded from regular section

🤖 Generated with [Claude Code](https://claude.com/claude-code)