### PR TITLE
fix: default Corporate/Standalone section to open on client page

### DIFF
--- a/src/policydb/web/templates/clients/_tab_policies.html
+++ b/src/policydb/web/templates/clients/_tab_policies.html
@@ -38,7 +38,7 @@
   {% set show_header = policy_groups | length > 1 or project_name %}
 
   {% if show_header %}
-  <details class="card mb-3 overflow-hidden" {% if group | length <= 8 %}open{% endif %}>
+  <details class="card mb-3 overflow-hidden" {% if not project_name or group | length <= 8 %}open{% endif %}>
     <summary class="px-4 py-2 bg-gray-50 border-b border-gray-200 cursor-pointer select-none list-none flex items-center gap-2 hover:bg-gray-100 transition-colors">
       <span class="text-xs text-gray-400 details-arrow">▶</span>
       {% set _proj_id = project_ids.get((project_name or '').lower().strip(), 0) if project_ids else 0 %}


### PR DESCRIPTION
## Summary
- Corporate/Standalone policy group now always defaults to open (expanded)
- Project groups retain the existing <= 8 policy threshold for auto-open

## Test plan
- [ ] Open a client page with a Corporate/Standalone section — verify it's expanded by default
- [ ] Verify project groups with >8 policies still default to collapsed

🤖 Generated with [Claude Code](https://claude.com/claude-code)