### PR TITLE
feat: sort and group policies by location in compliance slideover

### DIFF
--- a/src/policydb/compliance.py
+++ b/src/policydb/compliance.py
@@ -367,21 +367,38 @@ def set_primary_link(conn, requirement_id: int, link_id: int) -> None:
     conn.commit()
 
 
-def get_linkable_policies(conn, client_id: int) -> list[dict]:
+def get_linkable_policies(conn, client_id: int, req_project_id: int | None = None) -> list[dict]:
     """Return all non-archived, non-opportunity policies for a client, grouped for UI display.
 
     Returns programs first (with nested children), then standalone policies.
+    When req_project_id is provided, each policy is tagged with _location_match
+    ('this', 'corporate', or 'other') and _project_name for display.
     """
     rows = conn.execute(
-        """SELECT policy_uid, policy_type, carrier, limit_amount, deductible,
-                  policy_number, is_program, program_id, effective_date, expiration_date
-           FROM policies
-           WHERE client_id=? AND archived=0
-             AND (is_opportunity=0 OR is_opportunity IS NULL)
-           ORDER BY is_program DESC, policy_type, carrier""",
+        """SELECT p.policy_uid, p.policy_type, p.carrier, p.limit_amount, p.deductible,
+                  p.policy_number, p.is_program, p.program_id, p.effective_date,
+                  p.expiration_date, p.project_id,
+                  pr.name AS _project_name
+           FROM policies p
+           LEFT JOIN projects pr ON p.project_id = pr.id
+           WHERE p.client_id=? AND p.archived=0
+             AND (p.is_opportunity=0 OR p.is_opportunity IS NULL)
+           ORDER BY p.is_program DESC, p.policy_type, p.carrier""",
         (client_id,),
     ).fetchall()
     policies = [dict(r) for r in rows]
+
+    # Tag each policy with location match info
+    for p in policies:
+        if req_project_id is not None:
+            if p.get("project_id") == req_project_id:
+                p["_location_match"] = "this"
+            elif not p.get("project_id"):
+                p["_location_match"] = "corporate"
+            else:
+                p["_location_match"] = "other"
+        else:
+            p["_location_match"] = None
 
     # Separate programs, children, and standalone
     programs = []
@@ -422,6 +439,11 @@ def get_linkable_policies(conn, client_id: int) -> list[dict]:
             (prog.get("_id"),),
         ).fetchall()
         prog["program_carrier_names"] = [r["carrier"] for r in carriers]
+
+    # Sort standalone: location-matched first, then corporate, then other
+    if req_project_id is not None:
+        sort_order = {"this": 0, "corporate": 1, "other": 2}
+        standalone.sort(key=lambda p: (sort_order.get(p.get("_location_match"), 2), p.get("policy_type", "")))
 
     return programs + standalone
 

--- a/src/policydb/web/routes/compliance.py
+++ b/src/policydb/web/routes/compliance.py
@@ -911,6 +911,7 @@ def requirement_detail(
     req_id: int,
     request: Request,
     conn=Depends(get_db),
+    location_project_id: int | None = Query(None),
 ):
     """Return the slideover detail panel for a requirement."""
     req = conn.execute(
@@ -936,9 +937,12 @@ def requirement_detail(
         (client_id,),
     ).fetchall()]
 
+    # Use location context from viewing tab, falling back to requirement's own project_id
+    effective_pid = location_project_id or req_dict.get("project_id")
+
     # Policy links
     links = get_requirement_links(conn, req_id)
-    linkable = get_linkable_policies(conn, client_id)
+    linkable = get_linkable_policies(conn, client_id, req_project_id=effective_pid)
 
     # Primary linked policy for comparison
     primary_policy = None
@@ -964,6 +968,7 @@ def requirement_detail(
         "projects": projects,
         "links": links,
         "linkable_policies": linkable,
+        "location_project_id": effective_pid,
         "primary_policy": primary_policy,
         "auto_status": auto_status,
         "compliance_statuses": cfg.get("compliance_statuses", []),

--- a/src/policydb/web/templates/compliance/_location_detail.html
+++ b/src/policydb/web/templates/compliance/_location_detail.html
@@ -186,7 +186,7 @@
                 <td class="py-2 w-20 text-right no-print">
                   <span class="opacity-0 group-hover:opacity-100 transition-opacity">
                     <button class="text-marsh hover:text-green-800 text-xs mr-1"
-                            hx-get="/compliance/client/{{ client_id }}/requirements/{{ r.id }}/detail"
+                            hx-get="/compliance/client/{{ client_id }}/requirements/{{ r.id }}/detail?location_project_id={{ project.id }}"
                             hx-target="#requirement-slideover-container"
                             hx-swap="innerHTML">Edit</button>
                     <button class="text-red-400 hover:text-red-600 text-xs"

--- a/src/policydb/web/templates/compliance/_policy_links.html
+++ b/src/policydb/web/templates/compliance/_policy_links.html
@@ -1,5 +1,7 @@
 {# Policy links panel — shows linked policies + combobox to add new links #}
-{# Context: client_id, req_id, links, linkable_policies #}
+{# Context: client_id, req_id, links, linkable_policies, location_project_id #}
+
+{% set loc_pid_val = ', "location_project_id": "' ~ location_project_id ~ '"' if location_project_id else '' %}
 
 <div id="policy-links-{{ req_id }}" class="space-y-2">
   {# Current links #}
@@ -14,6 +16,7 @@
         <button type="button" class="text-gray-300 hover:text-amber-500 transition-colors"
                 title="Set as primary"
                 hx-post="/compliance/client/{{ client_id }}/requirements/{{ req_id }}/links/{{ link.id }}/set-primary"
+                hx-vals='{"location_project_id": "{{ location_project_id or '' }}"}'
                 hx-target="#policy-links-{{ req_id }}"
                 hx-swap="outerHTML">&#9734;</button>
       {% endif %}
@@ -39,6 +42,7 @@
               class="ml-auto text-gray-300 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-all"
               title="Remove link"
               hx-post="/compliance/client/{{ client_id }}/requirements/{{ req_id }}/links/{{ link.id }}/remove"
+              hx-vals='{"location_project_id": "{{ location_project_id or '' }}"}'
               hx-target="#policy-links-{{ req_id }}"
               hx-swap="outerHTML"
               hx-confirm="Remove this policy link?">&#10005;</button>
@@ -56,27 +60,31 @@
            class="border border-gray-300 rounded px-2 py-1 text-xs w-full focus:border-marsh focus:outline-none"
            autocomplete="off"
            onfocus="document.getElementById('{{ dropdown_id }}').classList.remove('hidden')"
-           oninput="(function(el){var dd=document.getElementById('{{ dropdown_id }}');dd.classList.remove('hidden');var q=el.value.toLowerCase();dd.querySelectorAll('[data-search]').forEach(function(r){r.style.display=r.dataset.search.includes(q)?'':'none'})})(this)">
+           oninput="(function(el){var dd=document.getElementById('{{ dropdown_id }}');dd.classList.remove('hidden');var q=el.value.toLowerCase();dd.querySelectorAll('[data-search]').forEach(function(r){r.style.display=r.dataset.search.includes(q)?'':'none'});dd.querySelectorAll('[data-section-header]').forEach(function(h){var sec=h.nextElementSibling;var anyVisible=false;while(sec&&!sec.hasAttribute('data-section-header')){if(sec.style.display!=='none'&&sec.hasAttribute('data-search'))anyVisible=true;sec=sec.nextElementSibling}h.style.display=anyVisible||!q?'':'none'})})(this)">
 
     {# Dropdown results #}
     <div id="{{ dropdown_id }}" class="hidden absolute z-50 mt-1 w-full bg-white border border-gray-200 rounded shadow-lg max-h-64 overflow-y-auto">
 
-      {# Programs section #}
-      {% set ns = namespace(has_programs=false) %}
+      {# Detect if we have location context #}
+      {% set ns = namespace(has_programs=false, has_location_context=false, has_this_location=false, has_corporate=false, has_other=false) %}
       {% for pol in linkable_policies %}
         {% if pol.get('is_program') %}{% set ns.has_programs = true %}{% endif %}
+        {% if pol.get('_location_match') %}{% set ns.has_location_context = true %}{% endif %}
+        {% if pol.get('_location_match') == 'this' %}{% set ns.has_this_location = true %}{% endif %}
+        {% if pol.get('_location_match') == 'corporate' %}{% set ns.has_corporate = true %}{% endif %}
+        {% if pol.get('_location_match') == 'other' %}{% set ns.has_other = true %}{% endif %}
       {% endfor %}
 
+      {# ── Programs section (always first) ── #}
       {% if ns.has_programs %}
-      <div class="px-2 py-1 bg-gray-50 text-[10px] text-gray-400 uppercase tracking-wider font-semibold sticky top-0">Programs</div>
+      <div data-section-header class="px-2 py-1 bg-gray-50 text-[10px] text-gray-400 uppercase tracking-wider font-semibold sticky top-0">Programs</div>
       {% for pol in linkable_policies %}
         {% if pol.get('is_program') %}
-          {# Program row #}
           <button type="button"
                   data-search="{{ (pol.policy_uid + ' ' + (pol.policy_type or '') + ' ' + (pol.carrier or '')) | lower }}"
                   class="w-full text-left px-3 py-1.5 hover:bg-indigo-50 text-xs flex items-center gap-2 border-b border-gray-50"
                   hx-post="/compliance/client/{{ client_id }}/requirements/{{ req_id }}/links/add"
-                  hx-vals='{"policy_uid": "{{ pol.policy_uid }}", "link_type": "program"}'
+                  hx-vals='{"policy_uid": "{{ pol.policy_uid }}", "link_type": "program"{{ loc_pid_val }}}'
                   hx-target="#policy-links-{{ req_id }}"
                   hx-swap="outerHTML">
             <span class="font-mono text-gray-400">{{ pol.policy_uid }}</span>
@@ -88,13 +96,12 @@
             {% endif %}
             <span class="bg-indigo-100 text-indigo-600 px-1 py-0.5 rounded text-[10px] ml-auto">program</span>
           </button>
-          {# Child policies #}
           {% for child in pol.get('children', []) %}
           <button type="button"
                   data-search="{{ (child.policy_uid + ' ' + (child.policy_type or '') + ' ' + (child.carrier or '')) | lower }}"
                   class="w-full text-left pl-8 pr-3 py-1 hover:bg-purple-50 text-xs flex items-center gap-2 border-b border-gray-50"
                   hx-post="/compliance/client/{{ client_id }}/requirements/{{ req_id }}/links/add"
-                  hx-vals='{"policy_uid": "{{ child.policy_uid }}", "link_type": "child"}'
+                  hx-vals='{"policy_uid": "{{ child.policy_uid }}", "link_type": "child"{{ loc_pid_val }}}'
                   hx-target="#policy-links-{{ req_id }}"
                   hx-swap="outerHTML">
             <span class="text-gray-300">&#8627;</span>
@@ -110,28 +117,109 @@
       {% endfor %}
       {% endif %}
 
-      {# Standalone policies section #}
-      <div class="px-2 py-1 bg-gray-50 text-[10px] text-gray-400 uppercase tracking-wider font-semibold sticky top-0">Standalone Policies</div>
-      {% for pol in linkable_policies %}
-        {% if not pol.get('is_program') and not pol.get('program_id') %}
-        <button type="button"
-                data-search="{{ (pol.policy_uid + ' ' + (pol.policy_type or '') + ' ' + (pol.carrier or '') + ' ' + (pol.policy_number or '')) | lower }}"
-                class="w-full text-left px-3 py-1.5 hover:bg-green-50 text-xs flex items-center gap-2 border-b border-gray-50"
-                hx-post="/compliance/client/{{ client_id }}/requirements/{{ req_id }}/links/add"
-                hx-vals='{"policy_uid": "{{ pol.policy_uid }}", "link_type": "direct"}'
-                hx-target="#policy-links-{{ req_id }}"
-                hx-swap="outerHTML">
-          <span class="font-mono text-gray-400">{{ pol.policy_uid }}</span>
-          <span class="font-medium">{{ pol.policy_type }}</span>
-          {% if pol.carrier %}
-            <span class="text-gray-400">&middot; {{ pol.carrier }}</span>
+      {% if ns.has_location_context %}
+        {# ── Location-aware grouping ── #}
+
+        {# This Location policies #}
+        {% if ns.has_this_location or ns.has_corporate %}
+        <div data-section-header class="px-2 py-1 bg-green-50 text-[10px] text-green-700 uppercase tracking-wider font-semibold sticky top-0 border-t border-green-100">
+          &#9679; This Location
+        </div>
+        {% for pol in linkable_policies %}
+          {% if not pol.get('is_program') and not pol.get('program_id') and pol.get('_location_match') == 'this' %}
+          <button type="button"
+                  data-search="{{ (pol.policy_uid + ' ' + (pol.policy_type or '') + ' ' + (pol.carrier or '') + ' ' + (pol.policy_number or '')) | lower }}"
+                  class="w-full text-left px-3 py-1.5 hover:bg-green-50 text-xs flex items-center gap-2 border-b border-gray-50 border-l-2 border-l-green-400"
+                  hx-post="/compliance/client/{{ client_id }}/requirements/{{ req_id }}/links/add"
+                  hx-vals='{"policy_uid": "{{ pol.policy_uid }}", "link_type": "direct"{{ loc_pid_val }}}'
+                  hx-target="#policy-links-{{ req_id }}"
+                  hx-swap="outerHTML">
+            <span class="font-mono text-gray-400">{{ pol.policy_uid }}</span>
+            <span class="font-medium text-gray-900">{{ pol.policy_type }}</span>
+            {% if pol.carrier %}
+              <span class="text-gray-400">&middot; {{ pol.carrier }}</span>
+            {% endif %}
+            {% if pol.policy_number %}
+              <span class="text-gray-400 text-[10px]">#{{ pol.policy_number }}</span>
+            {% endif %}
+            <span class="bg-green-100 text-green-700 px-1 py-0.5 rounded text-[10px] ml-auto">location</span>
+          </button>
           {% endif %}
-          {% if pol.policy_number %}
-            <span class="text-gray-400 text-[10px]">#{{ pol.policy_number }}</span>
+        {% endfor %}
+        {# Corporate / client-wide policies #}
+        {% for pol in linkable_policies %}
+          {% if not pol.get('is_program') and not pol.get('program_id') and pol.get('_location_match') == 'corporate' %}
+          <button type="button"
+                  data-search="{{ (pol.policy_uid + ' ' + (pol.policy_type or '') + ' ' + (pol.carrier or '') + ' ' + (pol.policy_number or '')) | lower }}"
+                  class="w-full text-left px-3 py-1.5 hover:bg-green-50 text-xs flex items-center gap-2 border-b border-gray-50"
+                  hx-post="/compliance/client/{{ client_id }}/requirements/{{ req_id }}/links/add"
+                  hx-vals='{"policy_uid": "{{ pol.policy_uid }}", "link_type": "direct"{{ loc_pid_val }}}'
+                  hx-target="#policy-links-{{ req_id }}"
+                  hx-swap="outerHTML">
+            <span class="font-mono text-gray-400">{{ pol.policy_uid }}</span>
+            <span class="font-medium text-gray-700">{{ pol.policy_type }}</span>
+            {% if pol.carrier %}
+              <span class="text-gray-400">&middot; {{ pol.carrier }}</span>
+            {% endif %}
+            {% if pol.policy_number %}
+              <span class="text-gray-400 text-[10px]">#{{ pol.policy_number }}</span>
+            {% endif %}
+          </button>
           {% endif %}
-        </button>
+        {% endfor %}
         {% endif %}
-      {% endfor %}
+
+        {# Other Locations policies #}
+        {% if ns.has_other %}
+        <div data-section-header class="px-2 py-1 bg-gray-100 text-[10px] text-gray-400 uppercase tracking-wider font-semibold sticky top-0 border-t border-gray-200">
+          Other Locations
+        </div>
+        {% for pol in linkable_policies %}
+          {% if not pol.get('is_program') and not pol.get('program_id') and pol.get('_location_match') == 'other' %}
+          <button type="button"
+                  data-search="{{ (pol.policy_uid + ' ' + (pol.policy_type or '') + ' ' + (pol.carrier or '') + ' ' + (pol.policy_number or '') + ' ' + (pol.get('_project_name') or '')) | lower }}"
+                  class="w-full text-left px-3 py-1.5 hover:bg-gray-50 text-xs flex items-center gap-2 border-b border-gray-50 opacity-60"
+                  hx-post="/compliance/client/{{ client_id }}/requirements/{{ req_id }}/links/add"
+                  hx-vals='{"policy_uid": "{{ pol.policy_uid }}", "link_type": "direct"{{ loc_pid_val }}}'
+                  hx-target="#policy-links-{{ req_id }}"
+                  hx-swap="outerHTML">
+            <span class="font-mono text-gray-400">{{ pol.policy_uid }}</span>
+            <span class="text-gray-500">{{ pol.policy_type }}</span>
+            {% if pol.carrier %}
+              <span class="text-gray-400">&middot; {{ pol.carrier }}</span>
+            {% endif %}
+            {% if pol.get('_project_name') %}
+              <span class="text-gray-400 text-[10px] ml-auto truncate max-w-[120px]" title="{{ pol._project_name }}">@ {{ pol._project_name }}</span>
+            {% endif %}
+          </button>
+          {% endif %}
+        {% endfor %}
+        {% endif %}
+
+      {% else %}
+        {# ── No location context — flat standalone list (corporate-level requirement) ── #}
+        <div data-section-header class="px-2 py-1 bg-gray-50 text-[10px] text-gray-400 uppercase tracking-wider font-semibold sticky top-0">Standalone Policies</div>
+        {% for pol in linkable_policies %}
+          {% if not pol.get('is_program') and not pol.get('program_id') %}
+          <button type="button"
+                  data-search="{{ (pol.policy_uid + ' ' + (pol.policy_type or '') + ' ' + (pol.carrier or '') + ' ' + (pol.policy_number or '')) | lower }}"
+                  class="w-full text-left px-3 py-1.5 hover:bg-green-50 text-xs flex items-center gap-2 border-b border-gray-50"
+                  hx-post="/compliance/client/{{ client_id }}/requirements/{{ req_id }}/links/add"
+                  hx-vals='{"policy_uid": "{{ pol.policy_uid }}", "link_type": "direct"}'
+                  hx-target="#policy-links-{{ req_id }}"
+                  hx-swap="outerHTML">
+            <span class="font-mono text-gray-400">{{ pol.policy_uid }}</span>
+            <span class="font-medium">{{ pol.policy_type }}</span>
+            {% if pol.carrier %}
+              <span class="text-gray-400">&middot; {{ pol.carrier }}</span>
+            {% endif %}
+            {% if pol.policy_number %}
+              <span class="text-gray-400 text-[10px]">#{{ pol.policy_number }}</span>
+            {% endif %}
+          </button>
+          {% endif %}
+        {% endfor %}
+      {% endif %}
     </div>
   </div>
 </div>

--- a/src/policydb/web/templates/compliance/_requirement_slideover.html
+++ b/src/policydb/web/templates/compliance/_requirement_slideover.html
@@ -281,7 +281,17 @@
     </div>
     {% endif %}
 
-    {# + Link Policy — search dropdown #}
+    {# + Link Policy — search dropdown with location grouping #}
+    {# Detect location context from _location_match tags #}
+    {% set ns = namespace(has_location_context=false, has_this=false, has_corporate=false, has_other=false, has_programs=false) %}
+    {% for pol in linkable_policies %}
+      {% if pol.get('_location_match') %}{% set ns.has_location_context = true %}{% endif %}
+      {% if pol.get('_location_match') == 'this' %}{% set ns.has_this = true %}{% endif %}
+      {% if pol.get('_location_match') == 'corporate' %}{% set ns.has_corporate = true %}{% endif %}
+      {% if pol.get('_location_match') == 'other' %}{% set ns.has_other = true %}{% endif %}
+      {% if pol.get('is_program') %}{% set ns.has_programs = true %}{% endif %}
+    {% endfor %}
+
     <div class="relative">
       <label class="block text-[10px] text-gray-500 uppercase tracking-wider mb-1">+ Link Policy</label>
       <input type="text" id="slideover-link-search"
@@ -289,23 +299,115 @@
              class="border border-gray-300 rounded px-2 py-1.5 text-sm w-full focus:outline-none focus:ring-1 focus:ring-marsh focus:border-marsh bg-white"
              autocomplete="off"
              onfocus="document.getElementById('slideover-link-dropdown').classList.remove('hidden')"
-             oninput="(function(el){var dd=document.getElementById('slideover-link-dropdown');dd.classList.remove('hidden');var q=el.value.toLowerCase();dd.querySelectorAll('[data-search]').forEach(function(r){r.style.display=r.dataset.search.includes(q)?'':'none'})})(this)">
+             oninput="(function(el){var dd=document.getElementById('slideover-link-dropdown');dd.classList.remove('hidden');var q=el.value.toLowerCase();dd.querySelectorAll('[data-search]').forEach(function(r){r.style.display=r.dataset.search.includes(q)?'':'none'});dd.querySelectorAll('[data-section-header]').forEach(function(h){var sec=h.nextElementSibling;var anyVisible=false;while(sec&&!sec.hasAttribute('data-section-header')){if(sec.style.display!=='none'&&sec.hasAttribute('data-search'))anyVisible=true;sec=sec.nextElementSibling}h.style.display=anyVisible||!q?'':'none'})})(this)">
       <div id="slideover-link-dropdown" class="hidden absolute z-50 mt-1 w-full bg-white border border-gray-200 rounded shadow-lg max-h-48 overflow-y-auto">
+
+        {# ── Programs section ── #}
+        {% if ns.has_programs %}
+        <div data-section-header class="px-2 py-1 bg-gray-50 text-[10px] text-gray-400 uppercase tracking-wider font-semibold sticky top-0">Programs</div>
         {% for pol in linkable_policies %}
-        <button type="button"
-                data-search="{{ (pol.policy_uid + ' ' + (pol.policy_type or '') + ' ' + (pol.carrier or '')) | lower }}"
-                class="w-full text-left px-3 py-1.5 hover:bg-green-50 text-xs flex items-center gap-2 border-b border-gray-50"
-                onclick="addPolicyLink('{{ pol.policy_uid }}'); document.getElementById('slideover-link-dropdown').classList.add('hidden'); document.getElementById('slideover-link-search').value = '';">
-          <span class="font-mono text-gray-400">{{ pol.policy_uid }}</span>
-          <span class="font-medium">{{ pol.policy_type or '' }}</span>
-          {% if pol.carrier %}
-            <span class="text-gray-400">&middot; {{ pol.carrier }}</span>
+          {% if pol.get('is_program') %}
+          <button type="button"
+                  data-search="{{ (pol.policy_uid + ' ' + (pol.policy_type or '') + ' ' + (pol.carrier or '')) | lower }}"
+                  class="w-full text-left px-3 py-1.5 hover:bg-indigo-50 text-xs flex items-center gap-2 border-b border-gray-50"
+                  onclick="addPolicyLink('{{ pol.policy_uid }}'); document.getElementById('slideover-link-dropdown').classList.add('hidden'); document.getElementById('slideover-link-search').value = '';">
+            <span class="font-mono text-gray-400">{{ pol.policy_uid }}</span>
+            <span class="font-medium">{{ pol.policy_type or '' }}</span>
+            {% if pol.get('program_carrier_names') %}
+              <span class="text-gray-400">&middot; {{ pol.program_carrier_names | join(', ') }}</span>
+            {% elif pol.carrier %}
+              <span class="text-gray-400">&middot; {{ pol.carrier }}</span>
+            {% endif %}
+            <span class="bg-indigo-100 text-indigo-600 px-1 py-0.5 rounded text-[10px] ml-auto">program</span>
+          </button>
+          {% for child in pol.get('children', []) %}
+          <button type="button"
+                  data-search="{{ (child.policy_uid + ' ' + (child.policy_type or '') + ' ' + (child.carrier or '')) | lower }}"
+                  class="w-full text-left pl-8 pr-3 py-1 hover:bg-purple-50 text-xs flex items-center gap-2 border-b border-gray-50"
+                  onclick="addPolicyLink('{{ child.policy_uid }}'); document.getElementById('slideover-link-dropdown').classList.add('hidden'); document.getElementById('slideover-link-search').value = '';">
+            <span class="text-gray-300">&#8627;</span>
+            <span class="font-mono text-gray-400">{{ child.policy_uid }}</span>
+            <span>{{ child.policy_type or '' }}</span>
+            {% if child.carrier %}
+              <span class="text-gray-400">&middot; {{ child.carrier }}</span>
+            {% endif %}
+            <span class="bg-purple-100 text-purple-600 px-1 py-0.5 rounded text-[10px] ml-auto">child</span>
+          </button>
+          {% endfor %}
           {% endif %}
-          {% if pol.limit_amount %}
-            <span class="text-gray-400 ml-auto">{{ pol.limit_amount | currency_short }}</span>
-          {% endif %}
-        </button>
         {% endfor %}
+        {% endif %}
+
+        {% if ns.has_location_context %}
+          {# ── This Location + Corporate ── #}
+          {% if ns.has_this or ns.has_corporate %}
+          <div data-section-header class="px-2 py-1 bg-green-50 text-[10px] text-green-700 uppercase tracking-wider font-semibold sticky top-0 border-t border-green-100">&#9679; This Location</div>
+          {% for pol in linkable_policies %}
+            {% if not pol.get('is_program') and not pol.get('program_id') and pol.get('_location_match') == 'this' %}
+            <button type="button"
+                    data-search="{{ (pol.policy_uid + ' ' + (pol.policy_type or '') + ' ' + (pol.carrier or '')) | lower }}"
+                    class="w-full text-left px-3 py-1.5 hover:bg-green-50 text-xs flex items-center gap-2 border-b border-gray-50 border-l-2 border-l-green-400"
+                    onclick="addPolicyLink('{{ pol.policy_uid }}'); document.getElementById('slideover-link-dropdown').classList.add('hidden'); document.getElementById('slideover-link-search').value = '';">
+              <span class="font-mono text-gray-400">{{ pol.policy_uid }}</span>
+              <span class="font-medium text-gray-900">{{ pol.policy_type or '' }}</span>
+              {% if pol.carrier %}<span class="text-gray-400">&middot; {{ pol.carrier }}</span>{% endif %}
+              {% if pol.limit_amount %}<span class="text-gray-400 ml-auto">{{ pol.limit_amount | currency_short }}</span>{% endif %}
+              <span class="bg-green-100 text-green-700 px-1 py-0.5 rounded text-[10px]">location</span>
+            </button>
+            {% endif %}
+          {% endfor %}
+          {% for pol in linkable_policies %}
+            {% if not pol.get('is_program') and not pol.get('program_id') and pol.get('_location_match') == 'corporate' %}
+            <button type="button"
+                    data-search="{{ (pol.policy_uid + ' ' + (pol.policy_type or '') + ' ' + (pol.carrier or '')) | lower }}"
+                    class="w-full text-left px-3 py-1.5 hover:bg-green-50 text-xs flex items-center gap-2 border-b border-gray-50"
+                    onclick="addPolicyLink('{{ pol.policy_uid }}'); document.getElementById('slideover-link-dropdown').classList.add('hidden'); document.getElementById('slideover-link-search').value = '';">
+              <span class="font-mono text-gray-400">{{ pol.policy_uid }}</span>
+              <span class="font-medium text-gray-700">{{ pol.policy_type or '' }}</span>
+              {% if pol.carrier %}<span class="text-gray-400">&middot; {{ pol.carrier }}</span>{% endif %}
+              {% if pol.limit_amount %}<span class="text-gray-400 ml-auto">{{ pol.limit_amount | currency_short }}</span>{% endif %}
+            </button>
+            {% endif %}
+          {% endfor %}
+          {% endif %}
+
+          {# ── Other Locations ── #}
+          {% if ns.has_other %}
+          <div data-section-header class="px-2 py-1 bg-gray-100 text-[10px] text-gray-400 uppercase tracking-wider font-semibold sticky top-0 border-t border-gray-200">Other Locations</div>
+          {% for pol in linkable_policies %}
+            {% if not pol.get('is_program') and not pol.get('program_id') and pol.get('_location_match') == 'other' %}
+            <button type="button"
+                    data-search="{{ (pol.policy_uid + ' ' + (pol.policy_type or '') + ' ' + (pol.carrier or '') + ' ' + (pol.get('_project_name') or '')) | lower }}"
+                    class="w-full text-left px-3 py-1.5 hover:bg-gray-50 text-xs flex items-center gap-2 border-b border-gray-50 opacity-60"
+                    onclick="addPolicyLink('{{ pol.policy_uid }}'); document.getElementById('slideover-link-dropdown').classList.add('hidden'); document.getElementById('slideover-link-search').value = '';">
+              <span class="font-mono text-gray-400">{{ pol.policy_uid }}</span>
+              <span class="text-gray-500">{{ pol.policy_type or '' }}</span>
+              {% if pol.carrier %}<span class="text-gray-400">&middot; {{ pol.carrier }}</span>{% endif %}
+              {% if pol.get('_project_name') %}
+                <span class="text-gray-400 text-[10px] ml-auto truncate max-w-[120px]" title="{{ pol._project_name }}">@ {{ pol._project_name }}</span>
+              {% endif %}
+            </button>
+            {% endif %}
+          {% endfor %}
+          {% endif %}
+        {% else %}
+          {# ── No location context — flat list ── #}
+          <div data-section-header class="px-2 py-1 bg-gray-50 text-[10px] text-gray-400 uppercase tracking-wider font-semibold sticky top-0">Policies</div>
+          {% for pol in linkable_policies %}
+            {% if not pol.get('is_program') and not pol.get('program_id') %}
+            <button type="button"
+                    data-search="{{ (pol.policy_uid + ' ' + (pol.policy_type or '') + ' ' + (pol.carrier or '')) | lower }}"
+                    class="w-full text-left px-3 py-1.5 hover:bg-green-50 text-xs flex items-center gap-2 border-b border-gray-50"
+                    onclick="addPolicyLink('{{ pol.policy_uid }}'); document.getElementById('slideover-link-dropdown').classList.add('hidden'); document.getElementById('slideover-link-search').value = '';">
+              <span class="font-mono text-gray-400">{{ pol.policy_uid }}</span>
+              <span class="font-medium">{{ pol.policy_type or '' }}</span>
+              {% if pol.carrier %}<span class="text-gray-400">&middot; {{ pol.carrier }}</span>{% endif %}
+              {% if pol.limit_amount %}<span class="text-gray-400 ml-auto">{{ pol.limit_amount | currency_short }}</span>{% endif %}
+            </button>
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+
         {% if not linkable_policies %}
           <div class="px-3 py-2 text-xs text-gray-400 italic">No linkable policies found for this client.</div>
         {% endif %}


### PR DESCRIPTION
## Summary
- Policies in the compliance requirement slideover link dropdown are now grouped by location context when viewing from a location tab
- "This Location" policies appear first with green left border and `location` badge
- Corporate (client-wide) policies follow in the same section
- "Other Locations" policies are visually muted with `@ Location Name` shown
- Search filtering respects section headers, hiding empty sections

## Test plan
- [ ] Open compliance review for a client with multiple locations
- [ ] Click Edit on a requirement under a location tab
- [ ] Verify the policy link dropdown shows "This Location" section first with location-assigned policies
- [ ] Verify "Other Locations" section shows muted policies with location names
- [ ] Verify search filtering works across all sections
- [ ] Verify corporate-level requirements (no location context) still show flat list

🤖 Generated with [Claude Code](https://claude.com/claude-code)