### PR TITLE
fix: Working Notes float blocking Archive/Delete/Renew buttons

### DIFF
--- a/src/policydb/web/templates/base.html
+++ b/src/policydb/web/templates/base.html
@@ -702,26 +702,7 @@ function copyRefTag(btn, tag) {
   });
 }
 
-/* Inline two-click confirmation for destructive actions.
-   First click: button text changes to confirmation prompt.
-   Second click within 3s: submits the parent form.
-   Auto-reverts after 3s if not confirmed. */
-function confirmAction(btn, msg) {
-  if (btn.dataset.confirming === '1') {
-    btn.closest('form').submit();
-    return;
-  }
-  var orig = btn.textContent;
-  var origClass = btn.className;
-  btn.textContent = msg + ' Click again to confirm';
-  btn.dataset.confirming = '1';
-  btn.className = btn.className.replace(/border-\S+/g, 'border-gray-400').replace(/text-\S+/g, 'text-gray-800') + ' bg-gray-100 font-semibold';
-  setTimeout(function() {
-    btn.textContent = orig;
-    btn.className = origClass;
-    delete btn.dataset.confirming;
-  }, 3000);
-}
+/* confirmAction is defined via window.confirmAction in the IIFE above */
 </script>
 
 

--- a/src/policydb/web/templates/policies/_tab_details.html
+++ b/src/policydb/web/templates/policies/_tab_details.html
@@ -560,7 +560,7 @@
 </div>
 
 <!-- Archive / Delete actions -->
-<div class="pt-4 border-t border-gray-200 flex items-center justify-between gap-4 no-print">
+<div class="pt-4 mb-14 border-t border-gray-200 flex items-center justify-between gap-4 no-print">
   <p class="text-xs text-gray-400">Entered in error? <strong>Archive</strong> hides from views (data preserved). <strong>Delete</strong> permanently removes all data.</p>
   <div class="flex gap-2 shrink-0">
     <form id="form-archive" method="post" action="/policies/{{ policy.policy_uid }}/archive">

--- a/src/policydb/web/templates/policies/_working_notes_float.html
+++ b/src/policydb/web/templates/policies/_working_notes_float.html
@@ -1,7 +1,7 @@
 {# Floating Working Notes panel — accessible from any tab #}
-<div id="working-notes-float" class="fixed bottom-4 right-4 z-40 no-print" style="width: 50vw; max-width: calc(100vw - 2rem); min-width: 400px;">
+<div id="working-notes-float" class="fixed bottom-4 right-4 z-40 no-print">
   <div id="wn-collapsed" class="cursor-pointer flex justify-end">
-    <button type="button" onclick="document.getElementById('wn-collapsed').classList.add('hidden'); document.getElementById('wn-expanded').classList.remove('hidden');"
+    <button type="button" onclick="document.getElementById('wn-collapsed').classList.add('hidden'); document.getElementById('wn-expanded').classList.remove('hidden'); document.getElementById('working-notes-float').style.width='50vw'; document.getElementById('working-notes-float').style.minWidth='400px';"
       class="bg-marsh text-white text-xs font-medium px-3 py-2 rounded-lg shadow-lg hover:bg-marsh-light transition-colors flex items-center gap-1.5">
       <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/></svg>
       Working Notes
@@ -12,7 +12,7 @@
   <div id="wn-expanded" class="hidden bg-white border border-gray-200 rounded-xl shadow-xl flex flex-col" style="max-height: 70vh; min-height: 300px;">
     <div class="flex items-center justify-between px-3 py-2 border-b border-gray-100 bg-gray-50 rounded-t-xl">
       <span class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Working Notes</span>
-      <button type="button" onclick="document.getElementById('wn-expanded').classList.add('hidden'); document.getElementById('wn-collapsed').classList.remove('hidden');"
+      <button type="button" onclick="document.getElementById('wn-expanded').classList.add('hidden'); document.getElementById('wn-collapsed').classList.remove('hidden'); document.getElementById('working-notes-float').style.width=''; document.getElementById('working-notes-float').style.minWidth='';"
         class="text-gray-400 hover:text-gray-600 text-sm leading-none">&times;</button>
     </div>
     <div class="flex-1 overflow-y-auto p-3">


### PR DESCRIPTION
## Summary
- The Working Notes floating panel had `width: 50vw` on its container even when collapsed, creating an invisible 792px-wide div that intercepted all clicks on the Archive, Delete, and Renew buttons at the bottom of the policy edit page
- Width is now only applied dynamically when the panel is expanded and cleared on collapse
- Added `mb-14` bottom margin to the action buttons section so they scroll clear of the fixed float
- Removed duplicate `confirmAction` function definition in `base.html`

## Test plan
- [ ] Navigate to any policy edit page, scroll to bottom
- [ ] Click Archive — confirm two-click confirmation works (text changes, second click redirects)
- [ ] Click Delete — confirm two-click confirmation works
- [ ] Click Renew Policy — confirm two-click confirmation works
- [ ] Click Working Notes — confirm panel expands to full width
- [ ] Close Working Notes — confirm buttons remain clickable after collapse

🤖 Generated with [Claude Code](https://claude.com/claude-code)