### PR TITLE
feat: LLM policy import contact creation + email contact extraction

### DIFF
--- a/src/policydb/llm_schemas.py
+++ b/src/policydb/llm_schemas.py
@@ -1456,3 +1456,284 @@ def parse_llm_json(raw_text: str, schema: dict) -> dict:
         }
 
     return {"ok": True, "parsed": parsed, "warnings": warnings, "raw": raw}
+
+
+# ---------------------------------------------------------------------------
+# Contact Extraction Schema — email chain → policy contact list
+# ---------------------------------------------------------------------------
+
+CONTACT_EXTRACTION_SCHEMA: dict = {
+    "name": "contact_extraction",
+    "version": 1,
+    "description": (
+        "Extract contacts from an email chain, distribution list, "
+        "or correspondence thread related to an insurance policy"
+    ),
+    "is_array": True,
+    "fields": [
+        {
+            "key": "name",
+            "label": "Full Name",
+            "type": "string",
+            "required": True,
+            "description": "Full name of the person (first and last name)",
+            "example": "Jane Smith",
+        },
+        {
+            "key": "email",
+            "label": "Email Address",
+            "type": "string",
+            "required": False,
+            "description": "Email address (from headers, cc/bcc, or signature block)",
+            "example": "jane.smith@carrier.com",
+        },
+        {
+            "key": "phone",
+            "label": "Phone Number",
+            "type": "string",
+            "required": False,
+            "description": "Office or direct phone number from signature block",
+            "example": "(555) 123-4567",
+        },
+        {
+            "key": "mobile",
+            "label": "Mobile Number",
+            "type": "string",
+            "required": False,
+            "description": "Cell/mobile number from signature block",
+            "example": "(555) 987-6543",
+        },
+        {
+            "key": "organization",
+            "label": "Company / Organization",
+            "type": "string",
+            "required": False,
+            "description": (
+                "Company or organization name from signature block or email domain. "
+                "For carrier employees, use the carrier name."
+            ),
+            "example": "Travelers Insurance",
+        },
+        {
+            "key": "title",
+            "label": "Job Title",
+            "type": "string",
+            "required": False,
+            "description": "Job title or role from signature block",
+            "example": "Senior Underwriter",
+        },
+        {
+            "key": "role",
+            "label": "Policy Role",
+            "type": "string",
+            "required": False,
+            "description": (
+                "The person's role relative to this insurance policy. "
+                "Infer from context: carrier employees are likely Underwriters, "
+                "brokerage colleagues are Placement Colleagues or Brokers, "
+                "client employees are client contacts."
+            ),
+            "config_values": "contact_roles",
+            "config_mode": "prefer",
+            "example": "Underwriter",
+        },
+    ],
+}
+
+
+def generate_contact_extraction_prompt(conn, policy_uid: str) -> str:
+    """Build a prompt for extracting contacts from an email chain."""
+    import policydb.config as _cfg
+
+    policy = conn.execute(
+        "SELECT p.*, c.name AS client_name, c.industry_segment "
+        "FROM policies p JOIN clients c ON p.client_id = c.id "
+        "WHERE p.policy_uid = ?",
+        (policy_uid,),
+    ).fetchone()
+
+    client_name = policy["client_name"] if policy else "Unknown"
+    carrier = (policy["carrier"] or "") if policy else ""
+    policy_type = (policy["policy_type"] or "") if policy else ""
+
+    contact_roles = _cfg.get("contact_roles", [])
+    config_lists = {"contact_roles": contact_roles}
+
+    parts: list[str] = []
+
+    parts.append(
+        "You are an insurance operations analyst. I will provide an email chain "
+        "or correspondence thread related to an insurance policy. Your job is to "
+        "extract all people mentioned (senders, recipients, cc'd, referenced in "
+        "signature blocks) and return their contact information as structured JSON.\n"
+    )
+
+    parts.append("## Output Format\n")
+    parts.append(
+        "Return a JSON **array** of contact objects. Each contact should have "
+        "the fields listed below. Omit fields you cannot determine.\n"
+    )
+
+    parts.append("## Fields per Contact\n")
+    for f in CONTACT_EXTRACTION_SCHEMA["fields"]:
+        parts.append(_build_field_instruction(f, config_lists))
+
+    parts.append("\n## Policy Context\n")
+    parts.append(f"- **Client**: {client_name}")
+    if carrier:
+        parts.append(f"- **Carrier**: {carrier}")
+    if policy_type:
+        parts.append(f"- **Coverage**: {policy_type}")
+
+    parts.append("\n## Extraction Rules\n")
+    parts.append("- Extract contacts from email headers (From, To, CC, BCC)")
+    parts.append("- Extract contact details from email signature blocks")
+    parts.append("- Do NOT include generic/no-reply email addresses")
+    parts.append(
+        "- If the same person appears multiple times, merge into one entry "
+        "with the most complete information"
+    )
+    if carrier:
+        parts.append(
+            f"- For the role field, infer from context. People from "
+            f"'{carrier}' are likely Underwriters or Claims contacts."
+        )
+    parts.append(
+        "- Brokerage colleagues are likely 'Placement Colleague' or 'Broker'"
+    )
+    parts.append(
+        "- People from the client organization are likely client contacts"
+    )
+
+    # JSON template
+    example = {}
+    for f in CONTACT_EXTRACTION_SCHEMA["fields"]:
+        if f.get("example"):
+            example[f["key"]] = f["example"]
+    parts.append("\n## JSON Template\n")
+    parts.append(
+        "Return ONLY valid JSON matching this structure (array of contacts):"
+    )
+    template = json.dumps([example], indent=2)
+    parts.append(f"```json\n{template}\n```")
+
+    parts.append("\n---\n")
+    parts.append("**PASTE THE EMAIL CHAIN BELOW THIS LINE:**\n")
+
+    return "\n".join(parts)
+
+
+def parse_contact_extraction_json(raw_text: str) -> dict:
+    """Parse LLM JSON response for contact extraction.
+
+    Expects a JSON array of contact objects. Normalizes each using
+    CONTACT_EXTRACTION_SCHEMA field definitions.
+
+    Returns:
+        {"ok": True, "contacts": [...], "warnings": [...], "count": N}
+        or {"ok": False, "error": "...", "raw_text": "..."}
+    """
+    if len(raw_text) > _MAX_INPUT_BYTES:
+        return {
+            "ok": False,
+            "error": "Input too large (max 500KB).",
+            "raw_text": raw_text[:200],
+        }
+
+    # Try code fences first, then raw JSON — same strategy as bulk import
+    json_str = _extract_json_str(raw_text)
+
+    # _extract_json_str only finds {} objects; also look for [] arrays
+    if json_str is None or (json_str.startswith("{") and "[" in raw_text):
+        for pattern in [_RE_JSON_CODE_FENCE, _RE_GENERIC_CODE_FENCE]:
+            m = pattern.search(raw_text)
+            if m:
+                candidate = m.group(1).strip()
+                if candidate.startswith("["):
+                    json_str = candidate
+                    break
+        if json_str is None or not json_str.startswith("["):
+            start = raw_text.find("[")
+            if start != -1:
+                depth = 0
+                in_string = False
+                escape_next = False
+                for i in range(start, len(raw_text)):
+                    ch = raw_text[i]
+                    if escape_next:
+                        escape_next = False
+                        continue
+                    if ch == "\\":
+                        escape_next = True
+                        continue
+                    if ch == '"' and not escape_next:
+                        in_string = not in_string
+                        continue
+                    if in_string:
+                        continue
+                    if ch == "[":
+                        depth += 1
+                    elif ch == "]":
+                        depth -= 1
+                        if depth == 0:
+                            json_str = raw_text[start : i + 1]
+                            break
+
+    if json_str is None:
+        return {
+            "ok": False,
+            "error": "No JSON found in input.",
+            "raw_text": raw_text,
+        }
+
+    try:
+        data = json.loads(json_str)
+    except json.JSONDecodeError as e:
+        return {
+            "ok": False,
+            "error": f"Invalid JSON: {e}",
+            "raw_text": raw_text,
+        }
+
+    if isinstance(data, dict):
+        data = [data]
+    if not isinstance(data, list):
+        return {
+            "ok": False,
+            "error": "Expected a JSON array of contacts.",
+            "raw_text": raw_text,
+        }
+
+    fields = CONTACT_EXTRACTION_SCHEMA["fields"]
+    all_warnings: list[str] = []
+    contacts: list[dict] = []
+
+    for i, item in enumerate(data):
+        if not isinstance(item, dict):
+            all_warnings.append(f"Item [{i}] is not an object, skipping.")
+            continue
+
+        parsed, _raw, warnings = _parse_flat_fields(item, fields)
+        for w in warnings:
+            all_warnings.append(f"Contact [{i}]: {w}")
+
+        if not parsed.get("name"):
+            all_warnings.append(f"Contact [{i}]: Missing name, skipping.")
+            continue
+
+        parsed["_index"] = i
+        contacts.append(parsed)
+
+    if not contacts:
+        return {
+            "ok": False,
+            "error": "No valid contacts extracted from JSON.",
+            "raw_text": raw_text,
+        }
+
+    return {
+        "ok": True,
+        "contacts": contacts,
+        "warnings": all_warnings,
+        "count": len(contacts),
+    }

--- a/src/policydb/web/routes/clients.py
+++ b/src/policydb/web/routes/clients.py
@@ -23,6 +23,7 @@ from policydb.queries import (
     get_client_total_hours,
     get_or_create_contact,
     assign_contact_to_client,
+    assign_contact_to_policy,
     remove_contact_from_client,
     set_primary_contact,
     get_linked_group_for_client,
@@ -5099,6 +5100,17 @@ def client_ai_bulk_import_apply(
                         params,
                     )
                     updated += 1
+                # Create contact records for underwriter and placement colleague
+                _upd_pol_id = db_pol["id"]
+                _pc_name = (d.get("placement_colleague") or "").strip()
+                if _pc_name:
+                    _pc_cid = get_or_create_contact(conn, _pc_name)
+                    assign_contact_to_policy(conn, _pc_cid, _upd_pol_id, is_placement_colleague=1)
+                _uw_name = (d.get("underwriter_name") or "").strip()
+                if _uw_name:
+                    _uw_email = (d.get("underwriter_contact") or "").strip() or None
+                    _uw_cid = get_or_create_contact(conn, _uw_name, email=_uw_email)
+                    assign_contact_to_policy(conn, _uw_cid, _upd_pol_id, role="Underwriter")
             else:
                 from policydb.db import next_policy_uid
                 uid = next_policy_uid(conn)
@@ -5129,13 +5141,26 @@ def client_ai_bulk_import_apply(
                 )
                 created += 1
 
+                # Fetch policy ID once for all post-insert operations
+                _new_pol_id = conn.execute("SELECT id FROM policies WHERE policy_uid = ?", (uid,)).fetchone()["id"]
+
+                # Create contact records for underwriter and placement colleague
+                _pc_name = (d.get("placement_colleague") or "").strip()
+                if _pc_name:
+                    _pc_cid = get_or_create_contact(conn, _pc_name)
+                    assign_contact_to_policy(conn, _pc_cid, _new_pol_id, is_placement_colleague=1)
+                _uw_name = (d.get("underwriter_name") or "").strip()
+                if _uw_name:
+                    _uw_email = (d.get("underwriter_contact") or "").strip() or None
+                    _uw_cid = get_or_create_contact(conn, _uw_name, email=_uw_email)
+                    assign_contact_to_policy(conn, _uw_cid, _new_pol_id, role="Underwriter")
+
                 if d.get("program_layers"):
-                    pol_id = conn.execute("SELECT id FROM policies WHERE policy_uid = ?", (uid,)).fetchone()["id"]
                     for j, layer in enumerate(d["program_layers"]):
                         conn.execute(
                             """INSERT INTO program_carriers (program_id, carrier, policy_number,
                                premium, limit_amount, sort_order) VALUES (?, ?, ?, ?, ?, ?)""",
-                            (pol_id, layer.get("carrier", ""), layer.get("policy_number", ""),
+                            (_new_pol_id, layer.get("carrier", ""), layer.get("policy_number", ""),
                              layer.get("premium", 0) or 0, layer.get("limit_amount", 0) or 0, j + 1),
                         )
                     programs_created += 1
@@ -5143,8 +5168,7 @@ def client_ai_bulk_import_apply(
                 if d.get("policy_number"):
                     try:
                         from policydb.match_memory import learn
-                        pol_id = conn.execute("SELECT id FROM policies WHERE policy_uid = ?", (uid,)).fetchone()["id"]
-                        learn(conn, pol_id, "LLM Import", d["policy_number"], "policy_number", "llm")
+                        learn(conn, _new_pol_id, "LLM Import", d["policy_number"], "policy_number", "llm")
                     except Exception:
                         pass
 

--- a/src/policydb/web/routes/policies.py
+++ b/src/policydb/web/routes/policies.py
@@ -13,11 +13,14 @@ from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Resp
 
 from policydb import config as cfg
 from policydb.llm_schemas import (
+    CONTACT_EXTRACTION_SCHEMA,
     COPE_FIELDS,
     LOCATION_FIELDS,
     POLICY_EXTRACTION_SCHEMA,
+    generate_contact_extraction_prompt,
     generate_extraction_prompt,
     generate_json_template,
+    parse_contact_extraction_json,
     parse_llm_json,
 )
 from policydb.queries import REVIEW_CYCLE_LABELS, get_all_policies, get_client_by_id, get_opportunity_by_uid, get_policy_by_uid, get_policy_total_hours, get_saved_notes, save_note, delete_saved_note, renew_policy, get_or_create_contact, assign_contact_to_policy, remove_contact_from_policy, set_placement_colleague, get_policy_contacts
@@ -1693,6 +1696,216 @@ async def policy_ai_import_apply_location(
             loc_name = loc_row["name"] or loc_name
 
     return JSONResponse({"ok": True, "location_name": loc_name, "created": created, "project_id": project_id})
+
+
+# ── AI Contact Extraction (email chain → policy contacts) ──
+
+_CONTACT_IMPORT_CACHE: dict[str, tuple] = {}
+
+
+@router.get("/{policy_uid}/ai-contacts/prompt", response_class=HTMLResponse)
+def policy_ai_contacts_prompt(request: Request, policy_uid: str, conn=Depends(get_db)):
+    """Return the AI import slideover panel with contact extraction prompt."""
+    uid = policy_uid.upper()
+    policy_dict, client_info = _policy_base(conn, uid)
+    if not policy_dict:
+        return HTMLResponse("Not found", status_code=404)
+
+    prompt_text = generate_contact_extraction_prompt(conn, uid)
+
+    # Build JSON template for the "Copy Template" button
+    example = {}
+    for f in CONTACT_EXTRACTION_SCHEMA["fields"]:
+        if f.get("example"):
+            example[f["key"]] = f["example"]
+    json_template = json.dumps([example], indent=2)
+
+    context_display = {"Client": client_info["name"]}
+    if policy_dict.get("carrier"):
+        context_display["Carrier"] = policy_dict["carrier"]
+    if policy_dict.get("policy_type"):
+        context_display["Coverage"] = policy_dict["policy_type"]
+
+    return templates.TemplateResponse("_ai_import_panel.html", {
+        "request": request,
+        "import_type": "contacts",
+        "prompt_text": prompt_text,
+        "json_template": json_template,
+        "context_display": context_display,
+        "parse_url": f"/policies/{uid}/ai-contacts/parse",
+        "import_target": "#ai-contacts-result",
+    })
+
+
+@router.post("/{policy_uid}/ai-contacts/parse", response_class=HTMLResponse)
+def policy_ai_contacts_parse(
+    request: Request,
+    policy_uid: str,
+    json_text: str = Form(...),
+    conn=Depends(get_db),
+):
+    """Parse LLM contact extraction JSON and return review panel."""
+    uid = policy_uid.upper()
+    result = parse_contact_extraction_json(json_text)
+
+    if not result["ok"]:
+        return HTMLResponse(
+            f'<div class="p-4 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">'
+            f'{result["error"]}</div>',
+            status_code=422,
+        )
+
+    policy_dict, client_info = _policy_base(conn, uid)
+    if not policy_dict:
+        return HTMLResponse("Not found", status_code=404)
+
+    contacts = result["contacts"]
+    warnings = result.get("warnings", [])
+
+    # Check for existing contacts to show dedup info
+    existing_policy_contacts = get_policy_contacts(conn, policy_dict["id"])
+    existing_names = {
+        c["name"].lower().strip()
+        for c in existing_policy_contacts
+        if c.get("name")
+    }
+
+    for contact in contacts:
+        contact["already_assigned"] = (
+            contact["name"].lower().strip() in existing_names
+        )
+        # Check if contact exists in global contacts table
+        existing = conn.execute(
+            "SELECT id, email, phone, organization FROM contacts "
+            "WHERE LOWER(TRIM(name)) = LOWER(TRIM(?))",
+            (contact["name"],),
+        ).fetchone()
+        contact["existing_contact"] = dict(existing) if existing else None
+
+    # Cache for apply step
+    import time as _time
+    import uuid as _uuid
+
+    token = str(_uuid.uuid4())
+    _CONTACT_IMPORT_CACHE[token] = (
+        contacts,
+        uid,
+        policy_dict["id"],
+        _time.time(),
+    )
+
+    return templates.TemplateResponse("policies/_ai_contacts_review.html", {
+        "request": request,
+        "policy": policy_dict,
+        "contacts": contacts,
+        "warnings": warnings,
+        "token": token,
+        "policy_uid": uid,
+        "contact_roles": cfg.get("contact_roles", []),
+    })
+
+
+@router.post("/{policy_uid}/ai-contacts/apply", response_class=HTMLResponse)
+async def policy_ai_contacts_apply(
+    request: Request,
+    policy_uid: str,
+    conn=Depends(get_db),
+):
+    """Apply selected contacts from AI extraction to the policy."""
+    uid = policy_uid.upper()
+    form = await request.form()
+    token = form.get("token", "")
+
+    cache = _CONTACT_IMPORT_CACHE.get(token)
+    if not cache:
+        return HTMLResponse(
+            '<div class="p-4 text-red-600 text-sm">Session expired — please re-parse.</div>'
+        )
+
+    contacts, cached_uid, policy_id, ts = cache
+    if cached_uid != uid:
+        return HTMLResponse(
+            '<div class="p-4 text-red-600 text-sm">Policy mismatch.</div>'
+        )
+
+    created = 0
+    updated = 0
+    skipped = 0
+    errors: list[str] = []
+
+    # Collect selected indices from form checkboxes (name="select_{i}")
+    for i, contact in enumerate(contacts):
+        if not form.get(f"select_{i}"):
+            continue
+        role = form.get(f"role_{i}", contact.get("role", ""))
+        try:
+            cid = get_or_create_contact(
+                conn,
+                contact["name"],
+                email=contact.get("email"),
+                phone=contact.get("phone"),
+                mobile=contact.get("mobile"),
+                organization=contact.get("organization"),
+            )
+
+            is_pc = 1 if role == "Placement Colleague" else 0
+            assign_contact_to_policy(
+                conn,
+                cid,
+                policy_id,
+                role=role,
+                title=contact.get("title", ""),
+                is_placement_colleague=is_pc,
+            )
+
+            if contact.get("existing_contact"):
+                updated += 1
+            else:
+                created += 1
+        except Exception as e:
+            errors.append(f"{contact['name']}: {e}")
+
+    conn.commit()
+    _CONTACT_IMPORT_CACHE.pop(token, None)
+
+    # Return success HTML
+    total = created + updated
+    parts = ['<div class="p-4 space-y-3">']
+    parts.append('<div class="flex items-center gap-2">')
+    parts.append(
+        '<svg class="w-5 h-5 text-green-600" fill="none" stroke="currentColor" '
+        'viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" '
+        'stroke-width="2" d="M5 13l4 4L19 7"/></svg>'
+    )
+    parts.append(
+        f'<span class="text-sm font-medium text-gray-900">'
+        f'{total} contact{"s" if total != 1 else ""} imported</span>'
+    )
+    parts.append("</div>")
+    parts.append('<div class="flex flex-wrap gap-2">')
+    if created:
+        parts.append(
+            f'<span class="px-2.5 py-1 rounded-full text-xs font-medium '
+            f'bg-green-50 text-green-700">{created} new</span>'
+        )
+    if updated:
+        parts.append(
+            f'<span class="px-2.5 py-1 rounded-full text-xs font-medium '
+            f'bg-blue-50 text-blue-700">{updated} updated</span>'
+        )
+    parts.append("</div>")
+    if errors:
+        parts.append(
+            '<div class="p-3 bg-red-50 border border-red-200 rounded-lg text-xs text-red-700">'
+        )
+        for e in errors:
+            parts.append(f"<div>{e}</div>")
+        parts.append("</div>")
+    parts.append(
+        '<p class="text-xs text-gray-500">Reload the Contacts tab to see updated team.</p>'
+    )
+    parts.append("</div>")
+    return HTMLResponse("\n".join(parts))
 
 
 @router.get("/{policy_uid}/tab/details", response_class=HTMLResponse)

--- a/src/policydb/web/templates/policies/_ai_contacts_review.html
+++ b/src/policydb/web/templates/policies/_ai_contacts_review.html
@@ -1,0 +1,118 @@
+{# AI Contact Extraction Review Panel — shows extracted contacts with checkboxes for import.
+   Context variables:
+     policy        — policy dict
+     contacts      — list of extracted contact dicts (name, email, phone, mobile, org, title, role, already_assigned, existing_contact)
+     warnings      — list of warning strings
+     token         — cache token for apply step
+     policy_uid    — policy UID string
+     contact_roles — list of role options from config
+#}
+<div id="ai-contacts-result" class="space-y-4">
+
+  {# Summary badges #}
+  <div class="flex items-center gap-3">
+    <span class="px-2.5 py-1 rounded-full text-xs font-medium bg-indigo-50 text-indigo-700">
+      {{ contacts | length }} contact{{ 's' if contacts | length != 1 else '' }} extracted
+    </span>
+    {% set new_count = contacts | selectattr('already_assigned', 'equalto', false) | list | length %}
+    {% set existing_count = contacts | length - new_count %}
+    {% if new_count %}
+    <span class="px-2.5 py-1 rounded-full text-xs font-medium bg-green-50 text-green-700">
+      {{ new_count }} new
+    </span>
+    {% endif %}
+    {% if existing_count %}
+    <span class="px-2.5 py-1 rounded-full text-xs font-medium bg-amber-50 text-amber-700">
+      {{ existing_count }} already assigned
+    </span>
+    {% endif %}
+  </div>
+
+  {# Warnings #}
+  {% if warnings %}
+  <div class="p-3 bg-amber-50 border border-amber-200 rounded-lg">
+    <p class="text-xs font-semibold text-amber-800 mb-1">Warnings</p>
+    {% for w in warnings %}
+    <p class="text-xs text-amber-700">{{ w }}</p>
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  {# Contact list form #}
+  <form id="ai-contacts-apply-form">
+    <input type="hidden" name="token" value="{{ token }}">
+    <div class="border border-gray-200 rounded-lg overflow-hidden">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="text-left text-xs text-gray-400 uppercase tracking-wide bg-gray-50 border-b border-gray-200">
+            <th class="px-3 py-2 w-8">
+              <input type="checkbox" id="ai-contacts-select-all" checked
+                     class="rounded border-gray-300 text-marsh focus:ring-marsh"
+                     onchange="document.querySelectorAll('.ai-contact-cb:not(:disabled)').forEach(function(c){c.checked=this.checked}.bind(this))">
+            </th>
+            <th class="px-3 py-2">Name</th>
+            <th class="px-3 py-2">Email</th>
+            <th class="px-3 py-2">Phone</th>
+            <th class="px-3 py-2">Org</th>
+            <th class="px-3 py-2">Title</th>
+            <th class="px-3 py-2">Role</th>
+            <th class="px-3 py-2 w-16">Status</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-100">
+          {% for c in contacts %}
+          <tr class="{% if c.already_assigned %}bg-gray-50 opacity-60{% else %}hover:bg-gray-50{% endif %}">
+            <td class="px-3 py-2">
+              <input type="checkbox" name="select_{{ loop.index0 }}" value="1"
+                     class="ai-contact-cb rounded border-gray-300 text-marsh focus:ring-marsh"
+                     {% if not c.already_assigned %}checked{% endif %}
+                     {% if c.already_assigned %}disabled{% endif %}>
+            </td>
+            <td class="px-3 py-2 font-medium text-gray-900">{{ c.name }}</td>
+            <td class="px-3 py-2 text-gray-600">{{ c.email or '' }}</td>
+            <td class="px-3 py-2 text-gray-600">{{ c.phone or '' }}{% if c.mobile %}<br><span class="text-xs text-gray-400">Cell: {{ c.mobile }}</span>{% endif %}</td>
+            <td class="px-3 py-2 text-gray-600">{{ c.organization or '' }}</td>
+            <td class="px-3 py-2 text-gray-500 text-xs">{{ c.title or '' }}</td>
+            <td class="px-3 py-2">
+              <select name="role_{{ loop.index0 }}"
+                      class="w-full rounded border-gray-200 text-xs py-1 px-2 focus:ring-marsh focus:border-marsh">
+                <option value="">-- Role --</option>
+                {% for r in contact_roles %}
+                <option value="{{ r }}" {% if c.role and c.role == r %}selected{% endif %}>{{ r }}</option>
+                {% endfor %}
+                {# Include the LLM-inferred role if not in config list #}
+                {% if c.role and c.role not in contact_roles %}
+                <option value="{{ c.role }}" selected>{{ c.role }}</option>
+                {% endif %}
+              </select>
+            </td>
+            <td class="px-3 py-2">
+              {% if c.already_assigned %}
+              <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium bg-green-100 text-green-700">Assigned</span>
+              {% elif c.existing_contact %}
+              <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium bg-blue-100 text-blue-700">Exists</span>
+              {% else %}
+              <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium bg-gray-100 text-gray-500">New</span>
+              {% endif %}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+
+    <div class="flex items-center justify-between mt-4">
+      <p class="text-xs text-gray-400">
+        Uncheck contacts you don't want to import. Already-assigned contacts are skipped.
+      </p>
+      <button type="submit"
+              hx-post="/policies/{{ policy_uid }}/ai-contacts/apply"
+              hx-target="#ai-contacts-result"
+              hx-swap="innerHTML"
+              hx-include="#ai-contacts-apply-form"
+              class="px-4 py-2 bg-marsh text-white text-sm font-medium rounded-lg hover:bg-marsh-light transition-colors">
+        Apply Selected
+      </button>
+    </div>
+  </form>
+</div>

--- a/src/policydb/web/templates/policies/_tab_contacts.html
+++ b/src/policydb/web/templates/policies/_tab_contacts.html
@@ -49,12 +49,28 @@
 <!-- Policy Team -->
 <div class="mb-4">{% include 'policies/_policy_team.html' %}</div>
 
-<!-- Compose Email -->
-<div class="mb-4 no-print">
+<!-- AI Contact Extraction Result -->
+<div id="ai-contacts-result" class="mb-4"></div>
+
+<!-- Action Buttons -->
+<div class="mb-4 flex flex-wrap gap-2 no-print">
   <button type="button"
     onclick="openComposeSlideover({context:'policy', policy_uid:'{{ policy.policy_uid }}', client_id:{{ policy.client_id }}})"
-    class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-marsh hover:text-white bg-white hover:bg-marsh border border-marsh/30 hover:border-marsh rounded-lg transition-colors no-print">
-    ✉ Compose Email
+    class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-marsh hover:text-white bg-white hover:bg-marsh border border-marsh/30 hover:border-marsh rounded-lg transition-colors">
+    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+    </svg>
+    Compose Email
+  </button>
+  <button type="button"
+    hx-get="/policies/{{ policy.policy_uid }}/ai-contacts/prompt"
+    hx-target="#ai-import-container"
+    hx-swap="innerHTML"
+    class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-indigo-600 hover:text-white bg-white hover:bg-indigo-600 border border-indigo-300 hover:border-indigo-600 rounded-lg transition-colors">
+    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"/>
+    </svg>
+    Extract Contacts from Email
   </button>
 </div>
 


### PR DESCRIPTION
## Summary
- **LLM bulk import now creates contact records** — when underwriter_name or placement_colleague are captured during AI bulk import, proper contact records are created via `get_or_create_contact()` + `assign_contact_to_policy()`, matching the CSV importer's behavior
- **New "Extract Contacts from Email" feature** — paste an email chain into an LLM prompt, extract all contacts (names, emails, phones, orgs, titles, roles), review with dedup detection, and import selected contacts to the policy team in one step
- Adds `CONTACT_EXTRACTION_SCHEMA`, prompt generator, and JSON parser to `llm_schemas.py`
- Adds 3 new routes: prompt panel, parse/review, and apply
- New `_ai_contacts_review.html` review template with checkboxes, role dropdowns, and dedup badges

## Test plan
- [x] Parser correctly extracts named contacts and skips entries without names
- [x] Slideover panel opens with policy context (client, carrier, coverage)
- [x] Review panel shows extracted contacts with correct dedup indicators (New/Exists/Assigned)
- [x] Apply creates contacts in database with correct roles and placement colleague flags
- [x] Contacts appear in Policy Team after reload
- [x] No server errors throughout flow
- [x] 208 tests pass (2 pre-existing failures in unrelated modules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)