### PR TITLE
feat: Executive Financial Summary chart + snapshot persistence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,47 @@ The app uses a **light theme** throughout. Key conventions:
 
 **Rule:** Never use dark-theme classes (`bg-gray-800`, `bg-gray-900`, `text-gray-100`, `text-blue-400`, `text-emerald-400`, `border-gray-600/700`) in new UI. The Policy Pulse tab was converted to light theme — all new sections should follow the light `card` pattern.
 
+### Marsh Brand Guide (Charts & Deliverables)
+
+All charts, deck slides, and client-facing exports MUST use the official Marsh color palette and typography.
+
+**Typography:**
+- **Noto Serif** — headings, chart titles, section headers
+- **Noto Sans** — body text, data labels, axis labels, table content
+
+**Core Colors:**
+
+| Token | HEX | Role |
+|-------|-----|------|
+| Midnight Blue (1000) | `#000F47` | Core brand blue, primary heading/border color |
+| Sky Blue (250) | `#CEECFF` | Light blue backgrounds, highlights |
+| White | `#FFFFFF` | Chart backgrounds |
+
+**Warm Neutrals:**
+
+| Token | HEX | Use |
+|-------|-----|-----|
+| Neutral 1000 | `#3D3C37` | Dark text, labels |
+| Neutral 750 | `#7B7974` | Secondary text |
+| Neutral 500 | `#B9B6B1` | Borders, dividers |
+| Neutral 250 | `#F7F3EE` | Light backgrounds, subtotal rows |
+
+**Active Accent:** `#0B4BFF` (Blue 750) — interactive highlights, links, attention
+
+**Data Color Order** (use in this sequence for multi-series charts):
+
+| Priority | Color | 1000 | 750 | 500 | 250 |
+|----------|-------|------|-----|-----|-----|
+| 1st (Workhorse) | Blue | `#000F47` | — | `#82BAFF` | `#CEECFF` |
+| 2nd | Green | `#2F7500` | `#6ABF30` | `#B0DC92` | `#DFECD7` |
+| 3rd | Purple | `#5E017F` | `#8F20DE` | `#DEB1FF` | `#F5E8FF` |
+| 4th | Gold | `#CB7E03` | `#FFBF00` | `#FFD98A` | `#FFF3DA` |
+
+**Rules:**
+- Additional tint stacks (500, 250) are for complex data sets and accessibility
+- Each tint stack goes from dark (1000) to light (250) — use 1000 for fills, 250 for backgrounds
+- The app's current `#003865` (marsh Tailwind color) is the UI brand color; `#000F47` (Midnight Blue) is the official Marsh deliverable color
+
 ### Currency & Phone Rules
 
 **Currency:** Every money field MUST use `parse_currency_with_magnitude()` from `utils.py` (supports `1m`, `500k`, `$2,000,000`). Never use raw `float()`. For display: `{{ value | currency }}` or `{{ value | currency_short }}`. Never use Python `%g` (produces scientific notation).

--- a/src/policydb/charts.py
+++ b/src/policydb/charts.py
@@ -803,3 +803,131 @@ def get_exposure_vs_premium_data(
         "exposure_growth": exposure_growth,
         "premium_growth": premium_growth,
     }
+
+
+# ---------------------------------------------------------------------------
+# 13. Executive Financial Summary  (bound program table by section)
+# ---------------------------------------------------------------------------
+
+def get_exec_financial_summary_data(
+    conn: sqlite3.Connection,
+    client_id: int,
+) -> dict:
+    """Executive Financial Summary — bound program premiums grouped by tower section.
+
+    Returns:
+    {
+        "sections": [
+            {
+                "title": "Casualty — Primary",
+                "rows": [
+                    {"line": "General Liability", "carrier": "Travelers",
+                     "expiring": 35000, "normalized": null, "renewal": 38000,
+                     "delta_dollars": 3000, "delta_pct": 8.6},
+                    ...
+                ],
+                "subtotal_expiring": 70000,
+                "subtotal_normalized": null,
+                "subtotal_renewal": 76000,
+                "subtotal_delta_dollars": 6000,
+                "subtotal_delta_pct": 8.6
+            },
+            ...
+        ],
+        "grand_total_expiring": float,
+        "grand_total_normalized": null,
+        "grand_total_renewal": float,
+        "grand_total_delta_dollars": float,
+        "grand_total_delta_pct": float | null
+    }
+    """
+    rows = conn.execute(
+        f"""
+        SELECT
+            p.policy_type,
+            p.carrier,
+            p.tower_group,
+            p.layer_position,
+            p.attachment_point,
+            p.limit_amount,
+            p.participation_of,
+            COALESCE(p.prior_premium, 0) AS prior_premium,
+            COALESCE(p.premium, 0)       AS premium
+        FROM policies p
+        WHERE p.client_id = ? AND {_ACTIVE_POLICY}
+          AND p.policy_type IS NOT NULL AND p.policy_type != ''
+        ORDER BY p.tower_group, p.layer_position, p.attachment_point
+        """,
+        (client_id,),
+    ).fetchall()
+
+    # Group into sections: {tower_group} — Primary / Excess
+    sections: dict[str, dict] = {}
+    for r in rows:
+        tg = r["tower_group"] or "General"
+        lp = (r["layer_position"] or "Primary").strip().lower()
+        att = r["attachment_point"] or 0
+        is_primary = lp == "primary" or (att == 0 and lp not in ("umbrella",))
+
+        section_label = "Primary" if is_primary else "Excess"
+        section_key = f"{tg}|{section_label}"
+        if section_key not in sections:
+            sections[section_key] = {"title": f"{tg} — {section_label}", "rows": []}
+
+        prior = r["prior_premium"] or 0
+        current = r["premium"] or 0
+        delta = current - prior
+        delta_pct = round((delta / prior) * 100, 1) if prior > 0 else None
+
+        # Build line description
+        if is_primary:
+            line = r["policy_type"] or "Unknown"
+        else:
+            line = _layer_notation(
+                r["limit_amount"], r["attachment_point"], r["participation_of"]
+            )
+            pt = r["policy_type"]
+            if pt:
+                line = f"{pt} — {line}"
+
+        sections[section_key]["rows"].append({
+            "line": line,
+            "carrier": r["carrier"] or "",
+            "expiring": prior,
+            "normalized": None,
+            "renewal": current,
+            "delta_dollars": delta,
+            "delta_pct": delta_pct,
+        })
+
+    # Calculate subtotals and assemble
+    result_sections = []
+    grand_exp = 0
+    grand_ren = 0
+    for key in sorted(sections.keys()):
+        section = sections[key]
+        sub_exp = sum(r["expiring"] for r in section["rows"])
+        sub_ren = sum(r["renewal"] for r in section["rows"])
+        sub_delta = sub_ren - sub_exp
+        section["subtotal_expiring"] = sub_exp
+        section["subtotal_normalized"] = None
+        section["subtotal_renewal"] = sub_ren
+        section["subtotal_delta_dollars"] = sub_delta
+        section["subtotal_delta_pct"] = (
+            round((sub_delta / sub_exp) * 100, 1) if sub_exp > 0 else None
+        )
+        grand_exp += sub_exp
+        grand_ren += sub_ren
+        result_sections.append(section)
+
+    grand_delta = grand_ren - grand_exp
+    return {
+        "sections": result_sections,
+        "grand_total_expiring": grand_exp,
+        "grand_total_normalized": None,
+        "grand_total_renewal": grand_ren,
+        "grand_total_delta_dollars": grand_delta,
+        "grand_total_delta_pct": (
+            round((grand_delta / grand_exp) * 100, 1) if grand_exp > 0 else None
+        ),
+    }

--- a/src/policydb/db.py
+++ b/src/policydb/db.py
@@ -359,7 +359,7 @@ def init_db(path: Path | None = None) -> None:
 
     # Back up the database once before running any pending migrations.
     # This gives a clean restore point regardless of which migration fails.
-    _KNOWN_MIGRATIONS = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87}
+    _KNOWN_MIGRATIONS = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88}
     if _KNOWN_MIGRATIONS - applied:
         _backup_db(conn, db_path)
 
@@ -1164,6 +1164,15 @@ def init_db(path: Path | None = None) -> None:
         conn.execute(
             "INSERT INTO schema_version (version, description) VALUES (?, ?)",
             (87, "Add schematic_column to policies for tower chart positioning"),
+        )
+        conn.commit()
+
+    if 88 not in applied:
+        sql = (_MIGRATIONS_DIR / "088_chart_snapshots.sql").read_text()
+        conn.executescript(sql)
+        conn.execute(
+            "INSERT INTO schema_version (version, description) VALUES (?, ?)",
+            (88, "Chart snapshots for persisting edited chart data"),
         )
         conn.commit()
 

--- a/src/policydb/migrations/088_chart_snapshots.sql
+++ b/src/policydb/migrations/088_chart_snapshots.sql
@@ -1,0 +1,13 @@
+-- Chart snapshots: persist edited chart data for recall
+CREATE TABLE IF NOT EXISTS chart_snapshots (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    client_id INTEGER NOT NULL REFERENCES clients(id),
+    chart_type TEXT NOT NULL,          -- e.g. 'exec_summary'
+    name TEXT NOT NULL DEFAULT '',     -- user label e.g. '2026 Casualty Final'
+    data TEXT NOT NULL DEFAULT '{}',   -- JSON blob of chart data
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_chart_snapshots_client
+    ON chart_snapshots(client_id, chart_type);

--- a/src/policydb/web/routes/charts.py
+++ b/src/policydb/web/routes/charts.py
@@ -28,6 +28,7 @@ CHART_REGISTRY = [
     {"id": "normalized_premium", "title": "Normalized Premium", "category": "exposure", "type": "d3"},
     {"id": "observations", "title": "Key Observations", "category": "exposure", "type": "html"},
     {"id": "exposure_vs_premium", "title": "Exposure vs Premium", "category": "exposure", "type": "d3"},
+    {"id": "exec_summary", "title": "Executive Financial Summary", "category": "exec", "type": "html"},
 ]
 
 _CHART_TITLE_MAP = {c["id"]: c["title"] for c in CHART_REGISTRY}
@@ -74,6 +75,10 @@ async def deck_configurator(
     ).fetchall()
     policy_types = [r["policy_type"] for r in rows]
 
+    # Pre-fetch exec summary data for configurator pre-population
+    from policydb.charts import get_exec_financial_summary_data
+    exec_summary_data = get_exec_financial_summary_data(conn, client_id)
+
     return templates.TemplateResponse(
         "charts/deck.html",
         {
@@ -82,6 +87,7 @@ async def deck_configurator(
             "charts": CHART_REGISTRY,
             "deck_type": type,
             "policy_types": policy_types,
+            "exec_summary_data": exec_summary_data,
         },
     )
 
@@ -122,6 +128,7 @@ async def deck_view(
         get_normalized_premium_data,
         get_exposure_observations_data,
         get_exposure_vs_premium_data,
+        get_exec_financial_summary_data,
     )
 
     DATA_FUNCTIONS = {
@@ -144,7 +151,92 @@ async def deck_view(
 
     chart_data = {}
     for chart_id in selected_charts:
-        if chart_id == "market_conditions":
+        if chart_id == "exec_summary":
+            # Check for manual override rows from configurator
+            exec_sections = form.getlist("exec__section[]")
+            exec_lines = form.getlist("exec__line[]")
+            exec_carriers = form.getlist("exec__carrier[]")
+            exec_expiring = form.getlist("exec__expiring[]")
+            exec_normalized = form.getlist("exec__normalized[]")
+            exec_renewal = form.getlist("exec__renewal[]")
+
+            has_manual = any(l.strip() for l in exec_lines)
+            if has_manual:
+                # Parse manual rows into sections
+                section_map: dict[str, list] = {}
+                for i, line in enumerate(exec_lines):
+                    if not line.strip():
+                        continue
+                    sec = exec_sections[i] if i < len(exec_sections) else "General"
+                    carrier = exec_carriers[i] if i < len(exec_carriers) else ""
+                    try:
+                        exp = float(exec_expiring[i]) if i < len(exec_expiring) and exec_expiring[i] else 0
+                    except ValueError:
+                        exp = 0
+                    try:
+                        norm = float(exec_normalized[i]) if i < len(exec_normalized) and exec_normalized[i] else None
+                    except ValueError:
+                        norm = None
+                    try:
+                        ren = float(exec_renewal[i]) if i < len(exec_renewal) and exec_renewal[i] else 0
+                    except ValueError:
+                        ren = 0
+                    delta = ren - exp
+                    delta_pct = round((delta / exp) * 100, 1) if exp > 0 else None
+                    section_map.setdefault(sec, []).append({
+                        "line": line.strip(),
+                        "carrier": carrier.strip(),
+                        "expiring": exp,
+                        "normalized": norm,
+                        "renewal": ren,
+                        "delta_dollars": delta,
+                        "delta_pct": delta_pct,
+                    })
+                # Build sections with subtotals
+                sections = []
+                grand_exp = grand_norm = grand_ren = 0
+                has_any_norm = False
+                for sec_title in dict.fromkeys(
+                    exec_sections[i] for i in range(len(exec_lines)) if i < len(exec_sections)
+                ):
+                    if sec_title not in section_map:
+                        continue
+                    sec_rows = section_map[sec_title]
+                    sub_exp = sum(r["expiring"] for r in sec_rows)
+                    sub_ren = sum(r["renewal"] for r in sec_rows)
+                    norms = [r["normalized"] for r in sec_rows if r["normalized"] is not None]
+                    sub_norm = sum(norms) if norms else None
+                    sub_delta = sub_ren - sub_exp
+                    if sub_norm is not None:
+                        has_any_norm = True
+                    sections.append({
+                        "title": sec_title,
+                        "rows": sec_rows,
+                        "subtotal_expiring": sub_exp,
+                        "subtotal_normalized": sub_norm,
+                        "subtotal_renewal": sub_ren,
+                        "subtotal_delta_dollars": sub_delta,
+                        "subtotal_delta_pct": round((sub_delta / sub_exp) * 100, 1) if sub_exp > 0 else None,
+                    })
+                    grand_exp += sub_exp
+                    grand_ren += sub_ren
+                    if sub_norm is not None:
+                        grand_norm += sub_norm
+
+                grand_delta = grand_ren - grand_exp
+                chart_data["exec_summary"] = {
+                    "sections": sections,
+                    "grand_total_expiring": grand_exp,
+                    "grand_total_normalized": grand_norm if has_any_norm else None,
+                    "grand_total_renewal": grand_ren,
+                    "grand_total_delta_dollars": grand_delta,
+                    "grand_total_delta_pct": round((grand_delta / grand_exp) * 100, 1) if grand_exp > 0 else None,
+                }
+            else:
+                # Auto-populate from DB
+                chart_data["exec_summary"] = get_exec_financial_summary_data(conn, client_id)
+            continue
+        elif chart_id == "market_conditions":
             lines = form.getlist("market__line[]")
             avg_pcts = form.getlist("market__avg_pct[]")
             notes = form.getlist("market__notes[]")
@@ -215,3 +307,88 @@ async def deck_view(
             "tower_incomplete": tower_incomplete,
         },
     )
+
+
+# ── Chart Snapshots CRUD ────────────────────────────────────────────────────
+
+@router.get("/{client_id}/snapshots/{chart_type}", response_class=JSONResponse)
+async def list_snapshots(
+    client_id: int,
+    chart_type: str,
+    conn=Depends(get_db),
+):
+    """List saved snapshots for a client + chart type."""
+    rows = conn.execute(
+        "SELECT id, name, updated_at FROM chart_snapshots "
+        "WHERE client_id = ? AND chart_type = ? ORDER BY updated_at DESC",
+        (client_id, chart_type),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+@router.get("/{client_id}/snapshots/{chart_type}/{snapshot_id}", response_class=JSONResponse)
+async def load_snapshot(
+    client_id: int,
+    chart_type: str,
+    snapshot_id: int,
+    conn=Depends(get_db),
+):
+    """Load a single snapshot's data."""
+    row = conn.execute(
+        "SELECT id, name, data, updated_at FROM chart_snapshots "
+        "WHERE id = ? AND client_id = ? AND chart_type = ?",
+        (snapshot_id, client_id, chart_type),
+    ).fetchone()
+    if not row:
+        return JSONResponse({"error": "Not found"}, status_code=404)
+    result = dict(row)
+    result["data"] = json.loads(result["data"])
+    return result
+
+
+@router.post("/{client_id}/snapshots/{chart_type}", response_class=JSONResponse)
+async def save_snapshot(
+    request: Request,
+    client_id: int,
+    chart_type: str,
+    conn=Depends(get_db),
+):
+    """Save or update a chart snapshot."""
+    body = await request.json()
+    name = body.get("name", "").strip() or "Untitled"
+    data = body.get("data", {})
+    snapshot_id = body.get("id")
+
+    if snapshot_id:
+        # Update existing
+        conn.execute(
+            "UPDATE chart_snapshots SET name = ?, data = ?, updated_at = datetime('now') "
+            "WHERE id = ? AND client_id = ? AND chart_type = ?",
+            (name, json.dumps(data), snapshot_id, client_id, chart_type),
+        )
+        conn.commit()
+        return {"ok": True, "id": snapshot_id, "name": name}
+    else:
+        # Insert new
+        cur = conn.execute(
+            "INSERT INTO chart_snapshots (client_id, chart_type, name, data) VALUES (?, ?, ?, ?)",
+            (client_id, chart_type, name, json.dumps(data)),
+        )
+        conn.commit()
+        return {"ok": True, "id": cur.lastrowid, "name": name}
+
+
+@router.delete("/{client_id}/snapshots/{chart_type}/{snapshot_id}", response_class=JSONResponse)
+async def delete_snapshot(
+    client_id: int,
+    chart_type: str,
+    snapshot_id: int,
+    conn=Depends(get_db),
+):
+    """Delete a chart snapshot."""
+    conn.execute(
+        "DELETE FROM chart_snapshots WHERE id = ? AND client_id = ? AND chart_type = ?",
+        (snapshot_id, client_id, chart_type),
+    )
+    conn.commit()
+    return {"ok": True}

--- a/src/policydb/web/static/charts/charts.css
+++ b/src/policydb/web/static/charts/charts.css
@@ -3,6 +3,8 @@
 /* Chart page container — 16:9 aspect ratio */
 .chart-page {
   width: 960px;
+  min-width: 0;
+  max-width: 100%;
   height: 540px;
   background: #fff;
   position: relative;
@@ -11,6 +13,8 @@
   box-shadow: 0 1px 3px rgba(0,0,0,0.08);
   border-radius: 4px;
 }
+/* HTML table charts allow internal scroll */
+.chart-page[data-chart-type="html"] { overflow: auto; }
 
 /* Chart title area */
 .chart-title { font-size: 20px; font-weight: 700; color: #1f2937; margin-bottom: 4px; }

--- a/src/policydb/web/templates/base.html
+++ b/src/policydb/web/templates/base.html
@@ -503,11 +503,12 @@
 
             <!-- Tools dropdown -->
             <div class="relative" onmouseenter="openNavDrop(this)" onmouseleave="closeNavDrop(this)">
-              <button class="nav-link flex items-center gap-1 {% if active in ['briefing','reconcile','templates','settings','ref-lookup','review','meetings'] %}bg-marsh-light border-b-2 border-[#c8a96e]{% endif %}">
+              <button class="nav-link flex items-center gap-1 {% if active in ['briefing','reconcile','templates','settings','ref-lookup','review','meetings','charts'] %}bg-marsh-light border-b-2 border-[#c8a96e]{% endif %}">
                 Tools
                 <svg class="w-3 h-3 opacity-60" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
               </button>
               <div class="nav-drop-panel hidden absolute left-0 top-full mt-0.5 w-40 bg-white rounded-md shadow-lg border border-gray-200 py-1 z-50">
+                <a href="/charts" class="block px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-100 {% if active == 'charts' %}font-semibold text-marsh{% endif %}">Chart Deck</a>
                 <a href="/meetings" class="block px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-100 {% if active == 'meetings' %}font-semibold text-marsh{% endif %}">Meetings</a>
                 <a href="/review" class="block px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-100 {% if active == 'review' %}font-semibold text-marsh{% endif %}">Review</a>
                 <a href="/briefing" class="block px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-100 {% if active == 'briefing' %}font-semibold text-marsh{% endif %}">Briefing</a>

--- a/src/policydb/web/templates/charts/_chart_exec_summary.html
+++ b/src/policydb/web/templates/charts/_chart_exec_summary.html
@@ -1,0 +1,125 @@
+{# Executive Financial Summary — HTML Table Chart
+   Data: chartData_exec_summary = {
+     sections: [{title, rows: [{line, carrier, expiring, normalized, renewal, delta_dollars, delta_pct}],
+                  subtotal_expiring, subtotal_normalized, subtotal_renewal, subtotal_delta_dollars, subtotal_delta_pct}],
+     grand_total_expiring, grand_total_normalized, grand_total_renewal, grand_total_delta_dollars, grand_total_delta_pct
+   }
+#}
+{% from "charts/_chart_base.html" import chart_frame %}
+
+{% call(area_id) chart_frame("Executive Financial Summary", "Bound Program — Premium Analysis") %}
+<div id="{{ area_id }}" style="overflow:auto; flex:1;">
+  <script>
+  window.render_exec_summary = function() {
+    var data = chartData_exec_summary;
+    var el = document.getElementById('{{ area_id }}');
+    if (!data || !data.sections || data.sections.length === 0) {
+      el.innerHTML = '<div class="chart-empty">No financial summary data available</div>';
+      return;
+    }
+
+    // Detect if any row has a normalized value
+    var hasNorm = false;
+    data.sections.forEach(function(s) {
+      if (s.subtotal_normalized != null) hasNorm = true;
+      s.rows.forEach(function(r) { if (r.normalized != null) hasNorm = true; });
+    });
+
+    var normColSpan = hasNorm ? 1 : 0;
+    var totalCols = 6 + normColSpan; // line, carrier, expiring, [normalized], renewal, delta$, delta%
+
+    function fmtDollar(v) {
+      if (v == null) return '\u2014';
+      return '$' + Math.round(v).toLocaleString();
+    }
+    function fmtDelta(v) {
+      if (v == null) return '\u2014';
+      var sign = v >= 0 ? '+' : '';
+      return sign + '$' + Math.round(Math.abs(v)).toLocaleString();
+    }
+    function fmtPct(v) {
+      if (v == null) return '\u2014';
+      var sign = v >= 0 ? '+' : '';
+      return sign + v.toFixed(1) + '%';
+    }
+    function deltaColor(v) {
+      if (v == null || v === 0) return '';
+      return v > 0 ? 'color:#dc2626' : 'color:#059669';
+    }
+
+    var html = '<table class="chart-table" style="font-size:12px;min-width:700px">';
+
+    // Header row
+    html += '<thead><tr style="border-bottom:2px solid #003865">'
+      + '<th style="text-align:left;padding:6px 8px;color:#003865">Line / Layer</th>'
+      + '<th style="text-align:left;padding:6px 8px;color:#003865">Carrier</th>'
+      + '<th style="text-align:right;padding:6px 8px;color:#003865;white-space:nowrap">Expiring</th>';
+    if (hasNorm) {
+      html += '<th style="text-align:right;padding:6px 8px;color:#003865;white-space:nowrap">Normalized</th>';
+    }
+    html += '<th style="text-align:right;padding:6px 8px;color:#003865;white-space:nowrap">Renewal</th>'
+      + '<th style="text-align:right;padding:6px 8px;color:#003865;white-space:nowrap">\u0394$</th>'
+      + '<th style="text-align:right;padding:6px 8px;color:#003865;white-space:nowrap">\u0394%</th>'
+      + '</tr></thead><tbody>';
+
+    data.sections.forEach(function(section, si) {
+      // Section header row
+      html += '<tr><td colspan="' + totalCols + '" style="padding:10px 8px 4px;font-weight:700;font-size:11px;'
+        + 'color:#003865;text-transform:uppercase;letter-spacing:0.05em;border-bottom:1px solid #e5e7eb">'
+        + section.title + '</td></tr>';
+
+      // Data rows
+      section.rows.forEach(function(r) {
+        html += '<tr>'
+          + '<td style="padding:5px 8px;font-weight:500">' + (r.line || '\u2014') + '</td>'
+          + '<td style="padding:5px 8px;color:#6b7280">' + (r.carrier || '\u2014') + '</td>'
+          + '<td style="padding:5px 8px;text-align:right;white-space:nowrap">' + fmtDollar(r.expiring) + '</td>';
+        if (hasNorm) {
+          html += '<td style="padding:5px 8px;text-align:right;white-space:nowrap;color:#9ca3af">'
+            + (r.normalized != null ? fmtDollar(r.normalized) : '\u2014') + '</td>';
+        }
+        html += '<td style="padding:5px 8px;text-align:right;white-space:nowrap;font-weight:600">' + fmtDollar(r.renewal) + '</td>'
+          + '<td style="padding:5px 8px;text-align:right;white-space:nowrap;' + deltaColor(r.delta_dollars) + '">' + fmtDelta(r.delta_dollars) + '</td>'
+          + '<td style="padding:5px 8px;text-align:right;white-space:nowrap;' + deltaColor(r.delta_pct) + '">' + fmtPct(r.delta_pct) + '</td>'
+          + '</tr>';
+      });
+
+      // Section subtotal row
+      html += '<tr style="border-top:1px solid #d1d5db;background:#f9fafb">'
+        + '<td colspan="2" style="padding:5px 8px;font-weight:600;font-size:11px;text-align:right">Subtotal</td>'
+        + '<td style="padding:5px 8px;text-align:right;font-weight:600">' + fmtDollar(section.subtotal_expiring) + '</td>';
+      if (hasNorm) {
+        html += '<td style="padding:5px 8px;text-align:right;font-weight:600;color:#9ca3af">'
+          + (section.subtotal_normalized != null ? fmtDollar(section.subtotal_normalized) : '\u2014') + '</td>';
+      }
+      html += '<td style="padding:5px 8px;text-align:right;font-weight:600">' + fmtDollar(section.subtotal_renewal) + '</td>'
+        + '<td style="padding:5px 8px;text-align:right;font-weight:600;' + deltaColor(section.subtotal_delta_dollars) + '">'
+          + fmtDelta(section.subtotal_delta_dollars) + '</td>'
+        + '<td style="padding:5px 8px;text-align:right;font-weight:600;' + deltaColor(section.subtotal_delta_pct) + '">'
+          + fmtPct(section.subtotal_delta_pct) + '</td>'
+        + '</tr>';
+    });
+
+    html += '</tbody>';
+
+    // Grand total footer
+    html += '<tfoot><tr style="border-top:2px solid #003865;background:#f0f4f8">'
+      + '<td colspan="2" style="padding:8px;font-weight:700;text-align:right;color:#003865">TOTAL PROGRAM</td>'
+      + '<td style="padding:8px;text-align:right;font-weight:700;color:#003865">' + fmtDollar(data.grand_total_expiring) + '</td>';
+    if (hasNorm) {
+      html += '<td style="padding:8px;text-align:right;font-weight:700;color:#9ca3af">'
+        + (data.grand_total_normalized != null ? fmtDollar(data.grand_total_normalized) : '\u2014') + '</td>';
+    }
+    html += '<td style="padding:8px;text-align:right;font-weight:700;color:#003865">' + fmtDollar(data.grand_total_renewal) + '</td>'
+      + '<td style="padding:8px;text-align:right;font-weight:700;' + deltaColor(data.grand_total_delta_dollars) + '">'
+        + fmtDelta(data.grand_total_delta_dollars) + '</td>'
+      + '<td style="padding:8px;text-align:right;font-weight:700;' + deltaColor(data.grand_total_delta_pct) + '">'
+        + fmtPct(data.grand_total_delta_pct) + '</td>'
+      + '</tr></tfoot>';
+
+    html += '</table>';
+    el.innerHTML = html;
+  };
+  </script>
+</div>
+{% endcall %}

--- a/src/policydb/web/templates/charts/deck.html
+++ b/src/policydb/web/templates/charts/deck.html
@@ -35,6 +35,7 @@
         "activity_timeline": "Vertical timeline of recent activities and touchpoints",
         "market_conditions": "Manual benchmark data vs your client's rates",
         "premium_history": "Multi-line trend of premiums across renewal cycles",
+        "exec_summary": "Bound program financials: expiring vs renewal by section",
         "coverage_comparison": "Side-by-side prior vs current term comparison",
         "exposure_trend": "Multi-line trend of exposure values by type over years",
         "normalized_premium": "Premium per $M of exposure for benchmarking",
@@ -46,12 +47,13 @@
       {% for chart in charts %}
       {% set is_market = chart.id == "market_conditions" %}
       {% set is_tower = chart.id == "tower" %}
-      <label class="deck-chart-card {{ 'col-span-2' if is_market }}" {{ 'id=market-card' if is_market }}>
+      {% set is_exec = chart.id == "exec_summary" %}
+      <label class="deck-chart-card {{ 'col-span-2' if is_market or is_exec }}" {{ 'id=market-card' if is_market }}>
         <div class="flex items-start gap-3">
           <input type="checkbox" name="selected_charts[]" value="{{ chart.id }}"
             {{ 'checked' if chart.category == 'core' }}
             class="mt-1 text-marsh focus:ring-marsh rounded"
-            {% if is_market %}id="market-check"{% elif is_tower %}id="tower-check"{% endif %}>
+            {% if is_market %}id="market-check"{% elif is_tower %}id="tower-check"{% elif is_exec %}id="exec-check"{% endif %}>
           <div class="flex-1">
             <div class="text-sm font-semibold text-gray-800">{{ chart.title }}</div>
             <div class="text-xs text-gray-500 mt-0.5">{{ chart_descriptions.get(chart.id, '') }}</div>
@@ -116,6 +118,121 @@
         <button type="button" onclick="addMarketRow()" class="text-xs text-blue-600 hover:text-blue-800 mt-1">+ Add row</button>
       </div>
       {% endif %}
+
+      {% if is_exec %}
+      {# Executive Financial Summary inline config — pre-populated from policy data, editable #}
+      <div class="col-span-2 border border-gray-200 rounded-lg p-4 bg-gray-50 hidden" id="exec-config">
+        {# Snapshot save/load bar #}
+        <div class="flex items-center gap-2 mb-3 pb-3 border-b border-gray-200">
+          <select id="exec-snapshot-select" class="text-xs border border-gray-300 rounded px-2 py-1 text-gray-700 focus:ring-marsh min-w-[160px]">
+            <option value="">Fresh from policies</option>
+          </select>
+          <button type="button" onclick="loadExecSnapshot()" id="exec-load-btn"
+            class="text-xs text-blue-600 hover:text-blue-800 disabled:text-gray-300 disabled:cursor-not-allowed" disabled>Load</button>
+          <div class="flex-1"></div>
+          <span id="exec-snapshot-status" class="text-xs text-gray-400"></span>
+          <button type="button" onclick="saveExecSnapshot(false)"
+            class="text-xs bg-gray-200 hover:bg-gray-300 text-gray-700 px-3 py-1 rounded transition-colors">Save</button>
+          <button type="button" onclick="saveExecSnapshot(true)"
+            class="text-xs bg-marsh text-white px-3 py-1 rounded hover:bg-marsh/90 transition-colors">Save As&hellip;</button>
+          <button type="button" onclick="deleteExecSnapshot()" id="exec-delete-btn"
+            class="text-xs text-red-500 hover:text-red-700 disabled:text-gray-300 disabled:cursor-not-allowed" disabled>&times;</button>
+        </div>
+        <div class="flex items-center justify-between mb-3">
+          <div class="text-xs font-semibold text-gray-500 uppercase tracking-wide">Financial Summary Data</div>
+          <span class="text-xs text-gray-400">Pre-populated from policies &mdash; edit as needed</span>
+        </div>
+        <table class="w-full text-xs" id="exec-rows-table" style="table-layout:fixed">
+          <colgroup>
+            <col style="width:18%">
+            <col style="width:22%">
+            <col style="width:14%">
+            <col style="width:13%">
+            <col style="width:13%">
+            <col style="width:13%">
+            <col style="width:28px">
+          </colgroup>
+          <thead>
+            <tr class="text-gray-500">
+              <th class="text-left pb-2 font-medium">Section</th>
+              <th class="text-left pb-2 font-medium">Line / Layer</th>
+              <th class="text-left pb-2 font-medium">Carrier</th>
+              <th class="text-right pb-2 font-medium">Expiring $</th>
+              <th class="text-right pb-2 font-medium">Normalized $</th>
+              <th class="text-right pb-2 font-medium">Renewal $</th>
+              <th class="pb-2" style="width:28px"></th>
+            </tr>
+          </thead>
+          <tbody id="exec-rows-body">
+            {% for section in exec_summary_data.sections %}
+            {% for row in section.rows %}
+            <tr class="exec-row">
+              <td class="pr-2 pb-2">
+                <input type="text" name="exec__section[]" value="{{ section.title }}"
+                  class="w-full border border-gray-300 rounded px-2 py-1 text-xs text-gray-800 focus:ring-marsh">
+              </td>
+              <td class="pr-2 pb-2">
+                <input type="text" name="exec__line[]" value="{{ row.line }}"
+                  class="w-full border border-gray-300 rounded px-2 py-1 text-xs text-gray-800 focus:ring-marsh">
+              </td>
+              <td class="pr-2 pb-2">
+                <input type="text" name="exec__carrier[]" value="{{ row.carrier }}"
+                  class="w-full border border-gray-300 rounded px-2 py-1 text-xs text-gray-800 focus:ring-marsh">
+              </td>
+              <td class="pr-2 pb-2">
+                <input type="text" name="exec__expiring[]" value="{{ row.expiring | int if row.expiring else '' }}"
+                  class="w-full border border-gray-300 rounded px-2 py-1 text-xs text-gray-800 text-right focus:ring-marsh">
+              </td>
+              <td class="pr-2 pb-2">
+                <input type="text" name="exec__normalized[]" value="{{ row.normalized | int if row.normalized else '' }}"
+                  placeholder="Optional" class="w-full border border-gray-300 rounded px-2 py-1 text-xs text-gray-400 text-right focus:ring-marsh">
+              </td>
+              <td class="pr-2 pb-2">
+                <input type="text" name="exec__renewal[]" value="{{ row.renewal | int if row.renewal else '' }}"
+                  class="w-full border border-gray-300 rounded px-2 py-1 text-xs text-gray-800 text-right focus:ring-marsh">
+              </td>
+              <td class="pb-2 text-center">
+                <button type="button" onclick="removeExecRow(this)" class="text-gray-400 hover:text-red-500 text-sm">&times;</button>
+              </td>
+            </tr>
+            {% endfor %}
+            {% endfor %}
+            {% if not exec_summary_data.sections %}
+            <tr class="exec-row">
+              <td class="pr-2 pb-2">
+                <input type="text" name="exec__section[]" placeholder="e.g. Casualty — Primary"
+                  class="w-full border border-gray-300 rounded px-2 py-1 text-xs text-gray-800 focus:ring-marsh">
+              </td>
+              <td class="pr-2 pb-2">
+                <input type="text" name="exec__line[]" placeholder="Line or layer"
+                  class="w-full border border-gray-300 rounded px-2 py-1 text-xs text-gray-800 focus:ring-marsh">
+              </td>
+              <td class="pr-2 pb-2">
+                <input type="text" name="exec__carrier[]" placeholder="Carrier"
+                  class="w-full border border-gray-300 rounded px-2 py-1 text-xs text-gray-800 focus:ring-marsh">
+              </td>
+              <td class="pr-2 pb-2">
+                <input type="text" name="exec__expiring[]" placeholder="0"
+                  class="w-full border border-gray-300 rounded px-2 py-1 text-xs text-gray-800 text-right focus:ring-marsh">
+              </td>
+              <td class="pr-2 pb-2">
+                <input type="text" name="exec__normalized[]" placeholder="Optional"
+                  class="w-full border border-gray-300 rounded px-2 py-1 text-xs text-gray-400 text-right focus:ring-marsh">
+              </td>
+              <td class="pr-2 pb-2">
+                <input type="text" name="exec__renewal[]" placeholder="0"
+                  class="w-full border border-gray-300 rounded px-2 py-1 text-xs text-gray-800 text-right focus:ring-marsh">
+              </td>
+              <td class="pb-2 text-center">
+                <button type="button" onclick="removeExecRow(this)" class="text-gray-400 hover:text-red-500 text-sm">&times;</button>
+              </td>
+            </tr>
+            {% endif %}
+          </tbody>
+        </table>
+        <button type="button" onclick="addExecRow()" class="text-xs text-blue-600 hover:text-blue-800 mt-1">+ Add row</button>
+      </div>
+      {% endif %}
       {% endfor %}
     </div>
 
@@ -160,6 +277,15 @@
     if (towerCheck.checked) towerConfig.classList.remove('hidden');
   }
 
+  var execCheck = document.getElementById('exec-check');
+  var execConfig = document.getElementById('exec-config');
+  if (execCheck && execConfig) {
+    execCheck.addEventListener('change', function() {
+      execConfig.classList.toggle('hidden', !execCheck.checked);
+    });
+    if (execCheck.checked) execConfig.classList.remove('hidden');
+  }
+
   form.addEventListener('change', function(e) {
     if (e.target.name === 'selected_charts[]') updateCount();
   });
@@ -195,5 +321,167 @@ function removeMarketRow(btn) {
     row.querySelector('select').selectedIndex = 0;
   }
 }
+
+function addExecRow() {
+  var tbody = document.getElementById('exec-rows-body');
+  var firstRow = tbody.querySelector('.exec-row');
+  if (!firstRow) return;
+  var clone = firstRow.cloneNode(true);
+  clone.querySelectorAll('input').forEach(function(inp) { inp.value = ''; });
+  tbody.appendChild(clone);
+}
+
+function removeExecRow(btn) {
+  var row = btn.closest('tr.exec-row');
+  var tbody = document.getElementById('exec-rows-body');
+  if (tbody.querySelectorAll('.exec-row').length > 1) {
+    row.remove();
+  } else {
+    row.querySelectorAll('input').forEach(function(inp) { inp.value = ''; });
+  }
+}
+
+// ── Exec Summary Snapshot Management ──────────────────────────────────────
+var _execClientId = {{ client.id }};
+var _execCurrentSnapshotId = null;
+
+function _execCollectRows() {
+  var rows = [];
+  document.querySelectorAll('#exec-rows-body .exec-row').forEach(function(tr) {
+    var inputs = tr.querySelectorAll('input');
+    if (inputs.length < 6) return;
+    var line = inputs[1].value.trim();
+    if (!line) return;
+    rows.push({
+      section: inputs[0].value.trim(),
+      line: line,
+      carrier: inputs[2].value.trim(),
+      expiring: inputs[3].value.trim(),
+      normalized: inputs[4].value.trim(),
+      renewal: inputs[5].value.trim()
+    });
+  });
+  return rows;
+}
+
+function _execPopulateRows(rows) {
+  var tbody = document.getElementById('exec-rows-body');
+  tbody.innerHTML = '';
+  if (!rows || rows.length === 0) rows = [{section:'',line:'',carrier:'',expiring:'',normalized:'',renewal:''}];
+  rows.forEach(function(r) {
+    var tr = document.createElement('tr');
+    tr.className = 'exec-row';
+    tr.innerHTML = '<td class="pr-2 pb-2"><input type="text" name="exec__section[]" value="' + (r.section||'') + '" class="w-full border border-gray-300 rounded px-2 py-1 text-xs text-gray-800 focus:ring-marsh"></td>'
+      + '<td class="pr-2 pb-2"><input type="text" name="exec__line[]" value="' + (r.line||'') + '" class="w-full border border-gray-300 rounded px-2 py-1 text-xs text-gray-800 focus:ring-marsh"></td>'
+      + '<td class="pr-2 pb-2"><input type="text" name="exec__carrier[]" value="' + (r.carrier||'') + '" class="w-full border border-gray-300 rounded px-2 py-1 text-xs text-gray-800 focus:ring-marsh"></td>'
+      + '<td class="pr-2 pb-2"><input type="text" name="exec__expiring[]" value="' + (r.expiring||'') + '" class="w-full border border-gray-300 rounded px-2 py-1 text-xs text-gray-800 text-right focus:ring-marsh"></td>'
+      + '<td class="pr-2 pb-2"><input type="text" name="exec__normalized[]" value="' + (r.normalized||'') + '" placeholder="Optional" class="w-full border border-gray-300 rounded px-2 py-1 text-xs text-gray-400 text-right focus:ring-marsh"></td>'
+      + '<td class="pr-2 pb-2"><input type="text" name="exec__renewal[]" value="' + (r.renewal||'') + '" class="w-full border border-gray-300 rounded px-2 py-1 text-xs text-gray-800 text-right focus:ring-marsh"></td>'
+      + '<td class="pb-2 text-center"><button type="button" onclick="removeExecRow(this)" class="text-gray-400 hover:text-red-500 text-sm">&times;</button></td>';
+    tbody.appendChild(tr);
+  });
+}
+
+function _execSetStatus(msg) {
+  var el = document.getElementById('exec-snapshot-status');
+  if (el) { el.textContent = msg; setTimeout(function(){ el.textContent = ''; }, 3000); }
+}
+
+function _execRefreshSnapshotList() {
+  fetch('/charts/' + _execClientId + '/snapshots/exec_summary')
+    .then(function(r) { return r.json(); })
+    .then(function(list) {
+      var sel = document.getElementById('exec-snapshot-select');
+      var current = _execCurrentSnapshotId;
+      sel.innerHTML = '<option value="">Fresh from policies</option>';
+      list.forEach(function(s) {
+        var opt = document.createElement('option');
+        opt.value = s.id;
+        opt.textContent = s.name + ' (' + s.updated_at.substring(0,10) + ')';
+        if (s.id === current) opt.selected = true;
+        sel.appendChild(opt);
+      });
+      _execUpdateButtons();
+    });
+}
+
+function _execUpdateButtons() {
+  var sel = document.getElementById('exec-snapshot-select');
+  var hasSelection = sel.value !== '';
+  document.getElementById('exec-load-btn').disabled = !hasSelection;
+  document.getElementById('exec-delete-btn').disabled = !hasSelection;
+}
+
+function loadExecSnapshot() {
+  var sel = document.getElementById('exec-snapshot-select');
+  var sid = sel.value;
+  if (!sid) return;
+  fetch('/charts/' + _execClientId + '/snapshots/exec_summary/' + sid)
+    .then(function(r) { return r.json(); })
+    .then(function(snap) {
+      _execCurrentSnapshotId = snap.id;
+      _execPopulateRows(snap.data.rows || []);
+      _execSetStatus('Loaded: ' + snap.name);
+      _execUpdateButtons();
+    });
+}
+
+function saveExecSnapshot(saveAs) {
+  var rows = _execCollectRows();
+  if (rows.length === 0) { _execSetStatus('No data to save'); return; }
+
+  var name;
+  if (saveAs || !_execCurrentSnapshotId) {
+    name = prompt('Snapshot name:', '');
+    if (name === null) return;
+    if (!name.trim()) { _execSetStatus('Name required'); return; }
+    _execCurrentSnapshotId = null; // force new
+  }
+
+  var body = { data: { rows: rows } };
+  if (_execCurrentSnapshotId) body.id = _execCurrentSnapshotId;
+  if (name) body.name = name.trim();
+  else {
+    // Get name from currently selected option
+    var sel = document.getElementById('exec-snapshot-select');
+    var opt = sel.options[sel.selectedIndex];
+    body.name = opt && opt.value ? opt.textContent.split(' (')[0] : 'Untitled';
+  }
+
+  fetch('/charts/' + _execClientId + '/snapshots/exec_summary', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  })
+  .then(function(r) { return r.json(); })
+  .then(function(res) {
+    if (res.ok) {
+      _execCurrentSnapshotId = res.id;
+      _execSetStatus('Saved: ' + res.name);
+      _execRefreshSnapshotList();
+    }
+  });
+}
+
+function deleteExecSnapshot() {
+  var sel = document.getElementById('exec-snapshot-select');
+  var sid = sel.value;
+  if (!sid) return;
+  var name = sel.options[sel.selectedIndex].textContent.split(' (')[0];
+  if (!confirm('Delete snapshot "' + name + '"?')) return;
+  fetch('/charts/' + _execClientId + '/snapshots/exec_summary/' + sid, { method: 'DELETE' })
+    .then(function(r) { return r.json(); })
+    .then(function(res) {
+      if (res.ok) {
+        _execCurrentSnapshotId = null;
+        _execSetStatus('Deleted');
+        _execRefreshSnapshotList();
+      }
+    });
+}
+
+// On page load, fetch existing snapshots
+document.getElementById('exec-snapshot-select').addEventListener('change', _execUpdateButtons);
+_execRefreshSnapshotList();
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- **Executive Financial Summary** — new chart type (#14) in the deck builder. Professional table showing bound program financials grouped by tower section (Primary/Excess) with Expiring, Normalized, Renewal, Δ$, Δ% columns. Auto-populates from policy data with manual override in configurator.
- **Chart Snapshot Persistence** — new `chart_snapshots` table (migration 088) with save/load/delete workflow. Snapshots store edited chart data as JSON for recall across sessions.
- **Nav link** — "Chart Deck" added to Tools dropdown in global navigation.
- **Marsh Brand Guide** — official color palette and typography (Noto Sans/Serif) added to CLAUDE.md for chart/deliverable standards.

## Test plan
- [ ] Navigate to Charts via Tools dropdown
- [ ] Select client, check Executive Financial Summary, verify pre-populated data
- [ ] Edit rows, Save As snapshot, reload page, load snapshot
- [ ] Generate deck with exec summary chart, verify table renders with sections/subtotals/grand total
- [ ] Verify delta coloring (red for increases, green for decreases)
- [ ] Test delete snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)