### PR TITLE
fix: strip unreplaced email template tokens + fix template edit cancel

### DIFF
--- a/src/policydb/email_templates.py
+++ b/src/policydb/email_templates.py
@@ -19,10 +19,17 @@ def _cycle_label(cycle: str | None) -> str:
 
 
 def render_tokens(template_text: str, context: dict) -> str:
-    """Replace {{token}} placeholders. Missing/None values render as empty string."""
+    """Replace {{token}} placeholders. Missing/None values render as empty string.
+
+    Any remaining {{...}} placeholders not found in context are stripped to avoid
+    raw tokens appearing in composed emails.
+    """
+    import re
     for key, value in context.items():
         placeholder = "{{" + key + "}}"
         template_text = template_text.replace(placeholder, str(value) if value else "")
+    # Strip any remaining unreplaced {{token}} placeholders
+    template_text = re.sub(r"\{\{[^}]+\}\}", "", template_text)
     return template_text
 
 

--- a/src/policydb/web/routes/compose.py
+++ b/src/policydb/web/routes/compose.py
@@ -384,7 +384,7 @@ def compose_render(
     if not tpl:
         return JSONResponse({"subject": "", "body": ""}, status_code=404)
 
-    # Build rendering context
+    # Build rendering context — priority must match compose_panel()
     ctx: dict = {}
     if mode == "rfi_notify" and bundle_id:
         try:
@@ -392,8 +392,6 @@ def compose_render(
             ctx = rfi_notify_context(conn, bundle_id)
         except ImportError:
             ctx = {}
-    elif project_name and client_id:
-        ctx = location_context(conn, client_id, project_name)
     elif policy_uid:
         ctx = policy_context(conn, policy_uid)
         try:
@@ -402,6 +400,8 @@ def compose_render(
                 ctx.update(tl_ctx)
         except Exception:
             pass
+    elif project_name and client_id:
+        ctx = location_context(conn, client_id, project_name)
     elif client_id:
         ctx = client_context(conn, client_id)
 

--- a/src/policydb/web/routes/templates.py
+++ b/src/policydb/web/routes/templates.py
@@ -67,6 +67,24 @@ def template_create(
     return RedirectResponse("/templates", status_code=303)
 
 
+@router.get("/{template_id}/card", response_class=HTMLResponse)
+def template_card(request: Request, template_id: int, conn=Depends(get_db)):
+    """Return just the card partial for a single template (used by Cancel)."""
+    row = conn.execute(
+        "SELECT * FROM email_templates WHERE id=?", (template_id,)
+    ).fetchone()
+    if not row:
+        return HTMLResponse("", status_code=404)
+    return templates.TemplateResponse("templates/_template_card.html", {
+        "request": request,
+        "t": dict(row),
+        "context_labels": _CONTEXT_LABELS,
+        "context_tokens": CONTEXT_TOKENS,
+        "context_token_groups": CONTEXT_TOKEN_GROUPS,
+        "context_tokens_json": _CONTEXT_TOKENS_JSON,
+    })
+
+
 @router.get("/{template_id}/edit", response_class=HTMLResponse)
 def template_edit_form(request: Request, template_id: int, conn=Depends(get_db)):
     row = conn.execute(

--- a/src/policydb/web/templates/templates/_template_form.html
+++ b/src/policydb/web/templates/templates/_template_form.html
@@ -103,7 +103,7 @@
     </button>
     {% if editing %}
     <button type="button"
-      hx-get="/templates"
+      hx-get="/templates/{{ t.id }}/card"
       hx-target="#template-card-{{ t.id }}"
       hx-swap="outerHTML"
       class="text-sm text-gray-500 hover:text-gray-700 border border-gray-200 rounded-lg px-4 py-2">


### PR DESCRIPTION
## Summary
- **Email compose tokens**: `render_tokens()` now strips any remaining `{{...}}` placeholders after replacement, preventing raw tags from appearing in composed emails when context is empty or uses unknown tokens. Also fixed priority ordering in `/compose/render` to match `compose_panel()` (policy_uid before project_name+client_id).
- **Template edit cancel**: Cancel button was fetching the full `/templates` page via HTMX and replacing the card with the entire page (page-within-page). Added `GET /templates/{id}/card` endpoint and pointed Cancel at it.

## Test plan
- [ ] Open compose from a policy → select a template → verify tokens render correctly
- [ ] Open compose with no policy context → verify no raw `{{tags}}` appear
- [ ] Go to Email Templates → click Edit on a template → click Cancel → verify card restores cleanly without duplicate page

🤖 Generated with [Claude Code](https://claude.com/claude-code)