### PR TITLE
fix: compose email To field defaults to external stakeholders

### DIFF
--- a/src/policydb/web/routes/compose.py
+++ b/src/policydb/web/routes/compose.py
@@ -231,12 +231,11 @@ def compose_panel(
         if not primary_to:
             primary_to = {"name": "", "email": to_email, "role": "", "badge": "", "source": "manual"}
     elif mode != "rfi_notify":
-        # Default: first CLIENT badge contact, or first contact overall
+        # Default: first CLIENT badge contact only — never default to
+        # placement colleagues or underwriters in the To field
         client_contacts = [r for r in recipients if r["badge"] == "CLIENT"]
         if client_contacts:
             primary_to = client_contacts[0]
-        elif recipients:
-            primary_to = recipients[0]
 
     # ── Pre-fill subject from config template ────────────────────────────
     if mode == "rfi_notify":


### PR DESCRIPTION
## Summary
- Removed fallback that selected the first recipient (placement colleague/underwriter) as the To address when no client contacts existed
- To field now stays empty unless a CLIENT-badged contact is found, keeping external stakeholders in CC only

## Test plan
- [ ] Open compose from a policy with both client and policy contacts — verify client contact in To
- [ ] Open compose from a policy with only policy contacts (no client contacts) — verify To field is empty
- [ ] Open compose with explicit `to_email` param — verify it still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)