### PR TITLE
feat: expand exposure year selector to include 10-year history

### DIFF
--- a/src/policydb/web/routes/clients.py
+++ b/src/policydb/web/routes/clients.py
@@ -5467,7 +5467,9 @@ def _exposure_tab_context(conn, client_id: int, year: int, project_id=None) -> d
     from datetime import date as _date
     current_year = _date.today().year
     data_years = get_exposure_years(conn, client_id, project_id)
-    available_years = sorted(set(data_years + [current_year]), reverse=True)
+    # Include last 10 years so users can enter historical exposure data
+    historical_range = list(range(current_year, current_year - 11, -1))
+    available_years = sorted(set(data_years + historical_range), reverse=True)
     if year not in available_years:
         available_years = sorted(set(available_years + [year]), reverse=True)
     exposures = get_client_exposures(conn, client_id, year, project_id)


### PR DESCRIPTION
## Summary
- Expands the exposure year dropdown to include the last 10 years, allowing users to navigate to any past year and enter historical exposure values
- Previously only showed years with existing data + current year, making it impossible to start entering data for a year with no records

## Test plan
- [ ] Navigate to a client's Exposures tab and verify the year dropdown shows 10 years of history
- [ ] Select a past year (e.g., 2020) and confirm you can add exposure types and enter values
- [ ] Verify "Copy Forward" still works between historical years

🤖 Generated with [Claude Code](https://claude.com/claude-code)