### PR TITLE
fix: UI tweaks — expand policy groups, shrink exposure font

### DIFF
--- a/src/policydb/web/templates/clients/_exposure_matrix_row.html
+++ b/src/policydb/web/templates/clients/_exposure_matrix_row.html
@@ -32,7 +32,7 @@
   {# Current Year (editable) #}
   <td class="px-3 py-2.5 text-right">
     <div contenteditable="true"
-         class="matrix-cell-editable outline-none text-gray-800 text-sm font-semibold rounded px-1 -mx-1 border border-dashed border-blue-200 bg-blue-50/30"
+         class="matrix-cell-editable outline-none text-gray-800 text-xs font-semibold rounded px-1 -mx-1 border border-dashed border-blue-200 bg-blue-50/30"
          data-field="amount"
          data-placeholder="Enter value...">{% if e.amount is not none %}{% if e.unit == 'currency' %}{{ "${:,.0f}".format(e.amount) }}{% else %}{{ "{:,.0f}".format(e.amount) }}{% endif %}{% endif %}</div>
   </td>

--- a/src/policydb/web/templates/clients/_tab_policies.html
+++ b/src/policydb/web/templates/clients/_tab_policies.html
@@ -93,7 +93,7 @@
 
   {% if ns.standalone > 0 %}
   {% if show_header %}
-  <details class="card mb-3 overflow-hidden" {% if not project_name or ns.standalone <= 8 %}open{% endif %}>
+  <details class="card mb-3 overflow-hidden" open>
     <summary class="px-4 py-2 bg-gray-50 border-b border-gray-200 cursor-pointer select-none list-none flex items-center gap-2 hover:bg-gray-100 transition-colors">
       <span class="text-xs text-gray-400 details-arrow">▶</span>
       {% set _proj_id = project_ids.get((project_name or '').lower().strip(), 0) if project_ids else 0 %}


### PR DESCRIPTION
## Summary
- Policy groups on client Policies tab now always open expanded (removed conditional collapse based on policy count)
- Exposure matrix current-year amount cell font reduced from `text-sm` to `text-xs` to prevent overflow with large currency values

## Test plan
- [ ] Open a client with multiple policy location groups — all should be expanded
- [ ] Enter a large revenue value (e.g., 42476000) in exposures tab — should fit without overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)