### PR TITLE
fix: PNG export, copy to clipboard, rate basis for manual charts

### DIFF
--- a/src/policydb/web/templates/charts/manual/_tpl_quote_comparison.html
+++ b/src/policydb/web/templates/charts/manual/_tpl_quote_comparison.html
@@ -83,15 +83,26 @@
   <!-- Hidden state for snapshot compatibility -->
   <textarea id="qc-state" name="qc-state" style="display:none;"></textarea>
 
-  <!-- Carrier row header -->
+  <!-- Rate Basis -->
   <div style="margin-top:0.75rem;">
+    <div class="section-head midnight">Settings</div>
+    <div style="display:flex;align-items:center;gap:0.65rem;margin-bottom:0.75rem;">
+      <label style="font-size:0.72rem;color:#7B7974;font-weight:500;white-space:nowrap;">Rate per $</label>
+      <input type="number" id="cfg-rate-basis" name="cfg-rate-basis" value="100" min="1" step="1"
+             style="width:100px;border:1px solid var(--mc-border);border-radius:3px;padding:0.38rem 0.5rem;font-family:'Noto Sans',sans-serif;font-size:0.82rem;color:var(--mc-text);background:var(--mc-bg);">
+      <span style="font-size:0.7rem;color:#7B7974;">TIV (e.g. 1, 100, 1000)</span>
+    </div>
+  </div>
+
+  <!-- Carrier row header -->
+  <div>
     <div class="section-head midnight">Carrier Quotes</div>
-    <div style="display:grid;grid-template-columns:14px 1.6fr 1.3fr 0.7fr 0.7fr auto auto;gap:0.5rem;margin-bottom:0.3rem;padding:0 0.1rem;">
+    <div id="carrier-col-header" style="display:grid;grid-template-columns:14px 1.6fr 1.3fr 0.7fr 0.7fr auto auto;gap:0.5rem;margin-bottom:0.3rem;padding:0 0.1rem;">
       <div></div>
       <div class="col-label" style="font-size:0.65rem;text-transform:uppercase;letter-spacing:0.06em;color:#7B7974;font-weight:600;">Carrier</div>
       <div class="col-label" style="font-size:0.65rem;text-transform:uppercase;letter-spacing:0.06em;color:#7B7974;font-weight:600;">TIV ($)</div>
       <div class="col-label" style="font-size:0.65rem;text-transform:uppercase;letter-spacing:0.06em;color:#7B7974;font-weight:600;">Factor</div>
-      <div class="col-label" style="font-size:0.65rem;text-transform:uppercase;letter-spacing:0.06em;color:#7B7974;font-weight:600;">Rate/$100</div>
+      <div class="col-label" id="rate-col-label" style="font-size:0.65rem;text-transform:uppercase;letter-spacing:0.06em;color:#7B7974;font-weight:600;">Rate/$100</div>
       <div class="col-label" style="font-size:0.65rem;text-transform:uppercase;letter-spacing:0.06em;color:#7B7974;font-weight:600;min-width:70px;text-align:right;">Premium</div>
       <div></div>
     </div>
@@ -137,7 +148,10 @@
   ];
 
   // ── Helpers ────────────────────────────────────────────────────────────
-  function premium(c)     { return (c.tiv / 100) * (c.factor * c.rate); }
+  function getRateBasis() {
+    return parseFloat(document.getElementById('cfg-rate-basis').value) || 100;
+  }
+  function premium(c)     { return (c.tiv / getRateBasis()) * (c.factor * c.rate); }
   function appliedRate(c) { return c.factor * c.rate; }
   function fmtRate(n)     { return Number(n).toFixed(4); }
 
@@ -204,7 +218,7 @@
           var tiv    = parseFloat(row.querySelector('.qc-tiv').value)    || 0;
           var factor = parseFloat(row.querySelector('.qc-factor').value) || 1;
           var rate   = parseFloat(row.querySelector('.qc-rate').value)   || 0;
-          var p      = (tiv / 100) * (factor * rate);
+          var p      = (tiv / getRateBasis()) * (factor * rate);
           row.querySelector('.qc-computed').textContent = fmtUSD(p);
         });
       });
@@ -333,7 +347,7 @@
                 return [
                   ' TIV: ' + fmtUSD(c.tiv),
                   ' Factor: ' + c.factor.toFixed(2) + '\u00d7  |  Base Rate: ' + fmtRate(c.rate),
-                  ' Applied Rate: ' + fmtRate(appliedRate(c)) + ' / $100',
+                  ' Applied Rate: ' + fmtRate(appliedRate(c)) + ' / $' + getRateBasis(),
                   ' Premium: ' + fmtUSDFull(p),
                 ];
               }
@@ -364,7 +378,7 @@
             max: rateMax + ratePad,
             title: {
               display: true,
-              text: 'Applied Rate (per $100 TIV)',
+              text: 'Applied Rate (per $' + getRateBasis() + ' TIV)',
               font: { family: 'Noto Sans', size: 10, weight: '500' },
               color: '#7B7974',
               padding: { bottom: 4 }
@@ -465,6 +479,11 @@
     var subtitle = document.getElementById('val-subtitle').value;
     document.getElementById('chart-title-display').textContent = title || 'Quote Comparison';
     document.getElementById('chart-subtitle-display').textContent = subtitle || '';
+
+    // Update rate basis label in editor
+    var basis = getRateBasis();
+    var rateLabel = document.getElementById('rate-col-label');
+    if (rateLabel) rateLabel.textContent = 'Rate/$' + basis;
 
     // Serialize state for snapshot save
     serializeState();

--- a/src/policydb/web/templates/charts/manual/editor.html
+++ b/src/policydb/web/templates/charts/manual/editor.html
@@ -22,6 +22,9 @@
       <button class="btn-mc outline sm" onclick="document.getElementById('snapshot-panel').classList.toggle('hidden')">
         Snapshots
       </button>
+      <button class="btn-mc outline sm" onclick="copyToClipboard()">
+        Copy
+      </button>
       <button class="btn-mc" onclick="exportChart(event)" id="export-btn">
         Export PNG &#9662;
       </button>
@@ -176,13 +179,31 @@
     }, 10);
   }
 
-  function exportChartAtSize(chartPage, sizeKey, preset) {
-    // Clone the chart page, strip no-print elements
+  // ── Canvas-to-img helper (html2canvas can't render <canvas>) ──────────
+  function convertCanvasesToImages(sourceEl, cloneEl) {
+    var origCanvases = sourceEl.querySelectorAll('canvas');
+    var cloneCanvases = cloneEl.querySelectorAll('canvas');
+    for (var i = 0; i < origCanvases.length; i++) {
+      if (i < cloneCanvases.length) {
+        var img = document.createElement('img');
+        img.src = origCanvases[i].toDataURL('image/png');
+        img.style.width = origCanvases[i].offsetWidth + 'px';
+        img.style.height = origCanvases[i].offsetHeight + 'px';
+        cloneCanvases[i].parentNode.replaceChild(img, cloneCanvases[i]);
+      }
+    }
+  }
+
+  function prepareClone(chartPage) {
     var clone = chartPage.cloneNode(true);
     clone.querySelectorAll('.no-print, .chart-export-btn').forEach(function (el) { el.remove(); });
+    convertCanvasesToImages(chartPage, clone);
+    return clone;
+  }
 
-    // Scale factor: render at preset size (chart page is 960x540 native)
-    var scale = (preset.w / 960) * 2;  // 2x for retina
+  function exportChartAtSize(chartPage, sizeKey, preset) {
+    var clone = prepareClone(chartPage);
+    var scale = (preset.w / 960) * 2;
 
     var container = document.createElement('div');
     container.style.cssText = 'position:fixed;left:-9999px;top:0;width:960px;height:540px;background:white;';
@@ -190,12 +211,8 @@
     container.appendChild(clone);
 
     html2canvas(container, {
-      width: 960,
-      height: 540,
-      scale: scale,
-      backgroundColor: '#ffffff',
-      useCORS: true,
-      logging: false
+      width: 960, height: 540, scale: scale,
+      backgroundColor: '#ffffff', useCORS: true, logging: false
     }).then(function (canvas) {
       document.body.removeChild(container);
       canvas.toBlob(function (blob) {
@@ -216,18 +233,18 @@
   }
 
   function exportAutoHeight(chartPage) {
-    var clone = chartPage.cloneNode(true);
-    clone.querySelectorAll('.no-print, .chart-export-btn').forEach(function(el) { el.remove(); });
+    var clone = prepareClone(chartPage);
     var nativeW = chartPage.offsetWidth;
     var nativeH = chartPage.offsetHeight;
+
     var container = document.createElement('div');
     container.style.cssText = 'position:fixed;left:-9999px;top:0;width:' + nativeW + 'px;height:' + nativeH + 'px;background:white;';
     document.body.appendChild(container);
     container.appendChild(clone);
+
     html2canvas(container, {
-      width: nativeW, height: nativeH,
-      scale: 2, backgroundColor: '#ffffff',
-      useCORS: true, logging: false
+      width: nativeW, height: nativeH, scale: 2,
+      backgroundColor: '#ffffff', useCORS: true, logging: false
     }).then(function(canvas) {
       document.body.removeChild(container);
       canvas.toBlob(function(blob) {
@@ -243,6 +260,45 @@
     }).catch(function(err) {
       document.body.removeChild(container);
       ManualChart.toast('Export failed: ' + err.message, 'error');
+    });
+  }
+
+  // ── Copy to clipboard ───────────────────────────────────────────────────
+  function copyToClipboard() {
+    var chartPage = document.querySelector('.manual-chart-page')
+                 || document.querySelector('.manual-chart-page-auto');
+    if (!chartPage) { ManualChart.toast('Nothing to copy', 'error'); return; }
+
+    var clone = prepareClone(chartPage);
+    var w = chartPage.offsetWidth;
+    var h = chartPage.offsetHeight;
+
+    var container = document.createElement('div');
+    container.style.cssText = 'position:fixed;left:-9999px;top:0;width:' + w + 'px;height:' + h + 'px;background:white;';
+    document.body.appendChild(container);
+    container.appendChild(clone);
+
+    html2canvas(container, {
+      width: w, height: h, scale: 2,
+      backgroundColor: '#ffffff', useCORS: true, logging: false
+    }).then(function(canvas) {
+      document.body.removeChild(container);
+      canvas.toBlob(function(blob) {
+        if (navigator.clipboard && navigator.clipboard.write) {
+          navigator.clipboard.write([
+            new ClipboardItem({ 'image/png': blob })
+          ]).then(function() {
+            ManualChart.toast('Copied to clipboard', 'success');
+          }).catch(function() {
+            ManualChart.toast('Copy failed — try Export PNG instead', 'error');
+          });
+        } else {
+          ManualChart.toast('Clipboard API not available — use Export PNG', 'error');
+        }
+      }, 'image/png');
+    }).catch(function(err) {
+      document.body.removeChild(container);
+      ManualChart.toast('Copy failed: ' + err.message, 'error');
     });
   }
 


### PR DESCRIPTION
## Summary
- **PNG export fix**: Convert `<canvas>` elements to `<img>` before html2canvas renders — fixes blank Chart.js charts in PNG exports (Quote Comparison and all canvas-based charts)
- **Copy to clipboard**: New "Copy" button in the shared editor header copies any chart/visual builder as PNG to clipboard
- **Rate basis field**: Quote Comparison now has configurable "Rate per $X" (1, 100, 1000 etc.) instead of hardcoded $100 — updates calculations, labels, and axis titles dynamically

## Test plan
- [ ] Open Quote Comparison, export PNG — verify bubble chart appears in export
- [ ] Click Copy button — verify image pastes into PowerPoint/email
- [ ] Change rate basis to $1000 — verify premium recalculates, Y-axis label updates
- [ ] Test export on a callout card (auto-height path) — verify clean PNG

🤖 Generated with [Claude Code](https://claude.com/claude-code)