### PR TITLE
fix: remove gray border/shadow from PNG exports

### DIFF
--- a/src/policydb/web/templates/charts/manual/editor.html
+++ b/src/policydb/web/templates/charts/manual/editor.html
@@ -197,6 +197,10 @@
   function prepareClone(chartPage) {
     var clone = chartPage.cloneNode(true);
     clone.querySelectorAll('.no-print, .chart-export-btn').forEach(function (el) { el.remove(); });
+    // Strip border/shadow/radius so export is clean white
+    clone.style.border = 'none';
+    clone.style.boxShadow = 'none';
+    clone.style.borderRadius = '0';
     convertCanvasesToImages(chartPage, clone);
     return clone;
   }


### PR DESCRIPTION
## Summary
- Border and box-shadow on `.manual-chart-page` were rendering as gray edges in exported PNGs
- `prepareClone()` now strips border, box-shadow, and border-radius from the clone before html2canvas

🤖 Generated with [Claude Code](https://claude.com/claude-code)