### PR TITLE
fix: Action Center quick action buttons (#67)

### DIFF
--- a/src/policydb/web/templates/action_center/_activities.html
+++ b/src/policydb/web/templates/action_center/_activities.html
@@ -1,6 +1,65 @@
 {# Action Center — Activities Tab (HTMX partial, no base inheritance) #}
 <div id="ac-activities-panel">
 
+  {# ── Quick Log Form (toggled by sidebar button) ── #}
+  <div id="ac-quick-log" style="display:none" class="mb-4 bg-blue-50 border border-blue-200 rounded-lg p-4">
+    <div class="flex items-center justify-between mb-3">
+      <span class="text-xs font-semibold text-gray-700 uppercase tracking-wide">Quick Log Activity</span>
+      <button type="button" onclick="document.getElementById('ac-quick-log').style.display='none'"
+        class="text-gray-400 hover:text-gray-600 text-sm">&times;</button>
+    </div>
+    <form hx-post="/activities/log" hx-swap="none"
+          hx-on::after-request="if(event.detail.successful){this.reset();document.getElementById('ac-quick-log').style.display='none';htmx.ajax('GET','/action-center/activities',{target:'#ac-tab-content'});htmx.ajax('GET','/action-center/sidebar',{target:'#action-center-sidebar'})}">
+      <div class="grid grid-cols-2 gap-3 mb-3">
+        {# Client #}
+        <div>
+          <label class="block text-[10px] text-gray-500 uppercase mb-1">Client *</label>
+          <select name="client_id" required
+            class="w-full text-xs border border-gray-200 rounded px-2 py-1.5 bg-white focus:ring-1 focus:ring-marsh">
+            <option value="">Select client...</option>
+            {% for c in all_clients %}
+            <option value="{{ c.id }}">{{ c.name }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        {# Type #}
+        <div>
+          <label class="block text-[10px] text-gray-500 uppercase mb-1">Type *</label>
+          <select name="activity_type" required
+            class="w-full text-xs border border-gray-200 rounded px-2 py-1.5 bg-white focus:ring-1 focus:ring-marsh">
+            {% for t in activity_types %}
+            <option value="{{ t }}" {{ 'selected' if t == 'Note' }}>{{ t }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        {# Subject #}
+        <div>
+          <label class="block text-[10px] text-gray-500 uppercase mb-1">Subject *</label>
+          <input type="text" name="subject" required placeholder="What happened?"
+            class="w-full text-xs border border-gray-200 rounded px-2 py-1.5 bg-white focus:ring-1 focus:ring-marsh placeholder-gray-300">
+        </div>
+        {# Duration #}
+        <div>
+          <label class="block text-[10px] text-gray-500 uppercase mb-1">Hours</label>
+          <input type="number" name="duration_hours" step="0.25" min="0" placeholder="0.5"
+            class="w-full text-xs border border-gray-200 rounded px-2 py-1.5 bg-white focus:ring-1 focus:ring-marsh placeholder-gray-300">
+        </div>
+      </div>
+      {# Details #}
+      <div class="mb-3">
+        <label class="block text-[10px] text-gray-500 uppercase mb-1">Details</label>
+        <textarea name="details" rows="2" placeholder="Optional notes..."
+          class="w-full text-xs border border-gray-200 rounded px-2 py-1.5 bg-white focus:ring-1 focus:ring-marsh placeholder-gray-300 resize-none"></textarea>
+      </div>
+      <div class="flex justify-end gap-2">
+        <button type="button" onclick="document.getElementById('ac-quick-log').style.display='none'"
+          class="text-xs text-gray-500 px-3 py-1.5 rounded border border-gray-200 hover:bg-gray-50">Cancel</button>
+        <button type="submit"
+          class="text-xs bg-marsh text-white px-4 py-1.5 rounded font-medium hover:bg-marsh-light transition-colors">Log Activity</button>
+      </div>
+    </form>
+  </div>
+
   {# ── Filter Bar ── #}
   <div class="flex flex-wrap items-center gap-3 mb-4">
     <select id="ac-act-days"

--- a/src/policydb/web/templates/action_center/_followups.html
+++ b/src/policydb/web/templates/action_center/_followups.html
@@ -11,6 +11,74 @@
 {% set suggested_count = suggested | length %}
 {% set total_action = triage_count + today_b_count + overdue_b_count + stale_count %}
 
+{# ── New Follow-up Form (toggled by sidebar button) ── #}
+<div id="ac-new-followup" style="display:none" class="mb-4 bg-green-50 border border-green-200 rounded-lg p-4">
+  <div class="flex items-center justify-between mb-3">
+    <span class="text-xs font-semibold text-gray-700 uppercase tracking-wide">New Follow-up</span>
+    <button type="button" onclick="document.getElementById('ac-new-followup').style.display='none'"
+      class="text-gray-400 hover:text-gray-600 text-sm">&times;</button>
+  </div>
+  <form hx-post="/activities/log" hx-swap="none"
+        hx-on::after-request="if(event.detail.successful){this.reset();document.getElementById('ac-new-followup').style.display='none';htmx.ajax('GET','/action-center/followups',{target:'#ac-tab-content'});htmx.ajax('GET','/action-center/sidebar',{target:'#action-center-sidebar'})}">
+    <div class="grid grid-cols-2 gap-3 mb-3">
+      {# Client #}
+      <div>
+        <label class="block text-[10px] text-gray-500 uppercase mb-1">Client *</label>
+        <select name="client_id" required
+          class="w-full text-xs border border-gray-200 rounded px-2 py-1.5 bg-white focus:ring-1 focus:ring-marsh">
+          <option value="">Select client...</option>
+          {% for c in all_clients %}
+          <option value="{{ c.id }}">{{ c.name }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      {# Type #}
+      <div>
+        <label class="block text-[10px] text-gray-500 uppercase mb-1">Type</label>
+        <select name="activity_type"
+          class="w-full text-xs border border-gray-200 rounded px-2 py-1.5 bg-white focus:ring-1 focus:ring-marsh">
+          {% for t in activity_types %}
+          <option value="{{ t }}" {{ 'selected' if t == 'Follow-up' or t == 'Note' }}>{{ t }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      {# Subject #}
+      <div>
+        <label class="block text-[10px] text-gray-500 uppercase mb-1">Subject *</label>
+        <input type="text" name="subject" required placeholder="Follow up on..."
+          class="w-full text-xs border border-gray-200 rounded px-2 py-1.5 bg-white focus:ring-1 focus:ring-marsh placeholder-gray-300">
+      </div>
+      {# Follow-up Date #}
+      <div>
+        <label class="block text-[10px] text-gray-500 uppercase mb-1">Follow-up Date *</label>
+        <input type="date" name="follow_up_date" required
+          class="w-full text-xs border border-gray-200 rounded px-2 py-1.5 bg-white focus:ring-1 focus:ring-marsh">
+      </div>
+    </div>
+    {# Quick date pills #}
+    <div class="flex gap-1.5 mb-3">
+      <button type="button" onclick="setQuickFuDate(this.form, 1)" class="text-[10px] bg-white border border-gray-200 text-gray-600 px-2 py-1 rounded hover:border-gray-400">Tomorrow</button>
+      <button type="button" onclick="setQuickFuDate(this.form, 3)" class="text-[10px] bg-white border border-gray-200 text-gray-600 px-2 py-1 rounded hover:border-gray-400">+3d</button>
+      <button type="button" onclick="setQuickFuDate(this.form, 7)" class="text-[10px] bg-white border border-gray-200 text-gray-600 px-2 py-1 rounded hover:border-gray-400">+1wk</button>
+      <button type="button" onclick="setQuickFuDate(this.form, 14)" class="text-[10px] bg-white border border-gray-200 text-gray-600 px-2 py-1 rounded hover:border-gray-400">+2wk</button>
+      <button type="button" onclick="setQuickFuDate(this.form, 30)" class="text-[10px] bg-white border border-gray-200 text-gray-600 px-2 py-1 rounded hover:border-gray-400">+30d</button>
+    </div>
+    <div class="flex justify-end gap-2">
+      <button type="button" onclick="document.getElementById('ac-new-followup').style.display='none'"
+        class="text-xs text-gray-500 px-3 py-1.5 rounded border border-gray-200 hover:bg-gray-50">Cancel</button>
+      <button type="submit"
+        class="text-xs bg-marsh text-white px-4 py-1.5 rounded font-medium hover:bg-marsh-light transition-colors">Create Follow-up</button>
+    </div>
+  </form>
+</div>
+<script>
+function setQuickFuDate(form, days) {
+  var d = new Date();
+  d.setDate(d.getDate() + days);
+  form.querySelector('input[name="follow_up_date"]').value = d.toISOString().split('T')[0];
+}
+</script>
+
 {# ══════════════════════════════════════════════════════════════════
    FILTER BAR
    ══════════════════════════════════════════════════════════════════ #}

--- a/src/policydb/web/templates/action_center/_sidebar.html
+++ b/src/policydb/web/templates/action_center/_sidebar.html
@@ -30,11 +30,11 @@
 <div class="mb-5">
   <p class="text-[11px] font-semibold text-gray-500 uppercase tracking-wider mb-2">Quick Actions</p>
   <div class="flex flex-col gap-1">
-    <button onclick="document.querySelector('[data-tab=activities]').click();setTimeout(function(){var f=document.getElementById('ac-quick-log');if(f)f.style.display='block'},300)"
+    <button onclick="document.querySelector('[data-tab=activities]').click();setTimeout(function(){var f=document.getElementById('ac-quick-log');if(f){f.style.display='block';var s=f.querySelector('select[name=client_id]');if(s)s.focus()}},400)"
             class="text-left text-[11px] bg-marsh text-white px-3 py-1.5 rounded hover:bg-marsh-light transition-colors">
       + Log Activity
     </button>
-    <button onclick="document.querySelector('[data-tab=followups]').click()"
+    <button onclick="document.querySelector('[data-tab=followups]').click();setTimeout(function(){var f=document.getElementById('ac-new-followup');if(f){f.style.display='block';var s=f.querySelector('select[name=client_id]');if(s)s.focus()}},400)"
             class="text-left text-[11px] bg-white text-gray-700 border border-gray-300 px-3 py-1.5 rounded hover:bg-gray-50 transition-colors">
       + New Follow-up
     </button>


### PR DESCRIPTION
## Summary
- **+ Log Activity** button now opens an inline form (client, type, subject, hours, details) in the Activities tab
- **+ New Follow-up** button now opens an inline form (client, type, subject, date + quick date pills) in the Follow-ups tab
- Both forms POST to existing `/activities/log` endpoint and refresh tab + sidebar on success

Fixes #67

## Test plan
- [x] + Log Activity opens form, submits, refreshes activities table and sidebar
- [x] + New Follow-up opens form, quick date pills work, submits, refreshes followups and sidebar
- [x] Cancel/close buttons dismiss forms correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)