### PR TITLE
feat: Data Export page

### DIFF
--- a/src/policydb/web/app.py
+++ b/src/policydb/web/app.py
@@ -282,7 +282,7 @@ def get_db() -> Generator[sqlite3.Connection, None, None]:
 
 
 # ── Register routers ──────────────────────────────────────────────────────────
-from policydb.web.routes import dashboard, clients, policies, activities, settings, reconcile, templates as tpl_routes, contacts, review, briefing, meetings, inbox, ref_lookup, compliance, action_center, logs, compose, import_history, geocoder as geocoder_routes, charts as charts_routes, programs as programs_routes  # noqa: E402
+from policydb.web.routes import dashboard, clients, policies, activities, settings, reconcile, templates as tpl_routes, contacts, review, briefing, meetings, inbox, ref_lookup, compliance, action_center, logs, compose, import_history, geocoder as geocoder_routes, charts as charts_routes, programs as programs_routes, exports as exports_routes  # noqa: E402
 
 app.include_router(dashboard.router)
 app.include_router(clients.router)
@@ -305,6 +305,7 @@ app.include_router(compose.router)
 app.include_router(geocoder_routes.router)
 app.include_router(charts_routes.router)
 app.include_router(programs_routes.router)
+app.include_router(exports_routes.router)
 
 # Static files (charts JS/CSS assets)
 STATIC_DIR = Path(__file__).parent / "static"

--- a/src/policydb/web/routes/exports.py
+++ b/src/policydb/web/routes/exports.py
@@ -1,0 +1,155 @@
+"""Data Export page — browse tables/views and download as CSV, XLSX, or JSON."""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import sqlite3
+from datetime import date
+
+from fastapi import APIRouter, Depends, Query, Request
+from fastapi.responses import HTMLResponse, Response
+
+from openpyxl import Workbook
+
+from policydb.exporter import _write_sheet, _wb_to_bytes
+from policydb.web.app import get_db, templates
+
+router = APIRouter(prefix="/exports", tags=["exports"])
+
+# Tables excluded from the export list (internal bookkeeping)
+_EXCLUDE_TABLES = {
+    "schema_version", "sqlite_sequence", "app_log", "audit_log",
+}
+
+_VALID_FORMATS = {"csv", "xlsx", "json"}
+
+
+def _get_sources(conn: sqlite3.Connection) -> dict[str, list[str]]:
+    """Introspect SQLite for exportable tables and views."""
+    tables = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+    ).fetchall()
+    views = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='view' ORDER BY name"
+    ).fetchall()
+    return {
+        "views": [r[0] for r in views],
+        "tables": [r[0] for r in tables if r[0] not in _EXCLUDE_TABLES],
+    }
+
+
+def _validate_source(conn: sqlite3.Connection, name: str) -> bool:
+    """Check source name exists in sqlite_master (prevents injection)."""
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE name = ? AND type IN ('table', 'view')",
+        (name,),
+    ).fetchone()
+    return row is not None
+
+
+def _get_columns(conn: sqlite3.Connection, source: str) -> list[str]:
+    """Get column names for a table or view."""
+    info = conn.execute(f"PRAGMA table_info([{source}])").fetchall()  # noqa: S608
+    return [r[1] for r in info]
+
+
+# ── Main page ────────────────────────────────────────────────────────────────
+
+@router.get("", response_class=HTMLResponse)
+def exports_page(request: Request, conn=Depends(get_db)):
+    sources = _get_sources(conn)
+    return templates.TemplateResponse("exports/index.html", {
+        "request": request,
+        "active": "exports",
+        "sources": sources,
+    })
+
+
+# ── Preview partial (HTMX) ──────────────────────────────────────────────────
+
+@router.get("/preview", response_class=HTMLResponse)
+def exports_preview(
+    request: Request,
+    source: str = Query(""),
+    limit: int = Query(25, ge=1, le=500),
+    conn=Depends(get_db),
+):
+    if not source or not _validate_source(conn, source):
+        return HTMLResponse('<p class="text-gray-400 text-sm">Invalid source.</p>')
+
+    columns = _get_columns(conn, source)
+    total = conn.execute(f"SELECT COUNT(*) FROM [{source}]").fetchone()[0]  # noqa: S608
+    rows = conn.execute(f"SELECT * FROM [{source}] LIMIT ?", (limit,)).fetchall()  # noqa: S608
+    rows_dicts = [dict(r) for r in rows]
+
+    return templates.TemplateResponse("exports/_preview.html", {
+        "request": request,
+        "source": source,
+        "columns": columns,
+        "rows": rows_dicts,
+        "total": total,
+        "limit": limit,
+    })
+
+
+# ── Download endpoint ────────────────────────────────────────────────────────
+
+@router.get("/download")
+def exports_download(
+    source: str = Query(""),
+    format: str = Query("csv"),
+    columns: str = Query(""),
+    conn=Depends(get_db),
+):
+    if not source or not _validate_source(conn, source):
+        return Response("Invalid source", status_code=400)
+    if format not in _VALID_FORMATS:
+        return Response("Invalid format. Use csv, xlsx, or json.", status_code=400)
+
+    # Validate and filter columns
+    all_cols = _get_columns(conn, source)
+    if columns:
+        requested = [c.strip() for c in columns.split(",") if c.strip()]
+        selected = [c for c in requested if c in all_cols]
+        if not selected:
+            selected = all_cols
+    else:
+        selected = all_cols
+
+    col_list = ", ".join(f"[{c}]" for c in selected)
+    rows = conn.execute(f"SELECT {col_list} FROM [{source}]").fetchall()  # noqa: S608
+    rows_dicts = [dict(r) for r in rows]
+
+    today = date.today().isoformat()
+    safe_name = source.lower().replace(" ", "_")
+
+    if format == "csv":
+        buf = io.StringIO()
+        writer = csv.writer(buf)
+        writer.writerow(selected)
+        for row in rows_dicts:
+            writer.writerow([row.get(c, "") for c in selected])
+        return Response(
+            content=buf.getvalue(),
+            media_type="text/csv",
+            headers={"Content-Disposition": f'attachment; filename="{safe_name}_{today}.csv"'},
+        )
+
+    if format == "xlsx":
+        wb = Workbook()
+        wb.remove(wb.active)  # remove default empty sheet
+        _write_sheet(wb, source[:31], rows_dicts)  # sheet title max 31 chars
+        return Response(
+            content=_wb_to_bytes(wb),
+            media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            headers={"Content-Disposition": f'attachment; filename="{safe_name}_{today}.xlsx"'},
+        )
+
+    # JSON
+    return Response(
+        content=json.dumps(rows_dicts, default=str, indent=2),
+        media_type="application/json",
+        headers={"Content-Disposition": f'attachment; filename="{safe_name}_{today}.json"'},
+    )

--- a/src/policydb/web/templates/base.html
+++ b/src/policydb/web/templates/base.html
@@ -503,7 +503,7 @@
 
             <!-- Tools dropdown -->
             <div class="relative" onmouseenter="openNavDrop(this)" onmouseleave="closeNavDrop(this)">
-              <button class="nav-link flex items-center gap-1 {% if active in ['briefing','reconcile','templates','settings','ref-lookup','review','meetings','charts','manual-charts'] %}bg-marsh-light border-b-2 border-[#c8a96e]{% endif %}">
+              <button class="nav-link flex items-center gap-1 {% if active in ['briefing','reconcile','templates','settings','ref-lookup','review','meetings','charts','manual-charts','exports'] %}bg-marsh-light border-b-2 border-[#c8a96e]{% endif %}">
                 Tools
                 <svg class="w-3 h-3 opacity-60" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
               </button>
@@ -518,6 +518,7 @@
                 <a href="/settings" class="block px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-100 {% if active == 'settings' %}font-semibold text-marsh{% endif %}">Settings</a>
                 <a href="/logs" class="block px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-100 {% if active == 'logs' %}font-semibold text-marsh{% endif %}">Logs</a>
                 <a href="/ref-lookup" class="block px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-100 {% if active == 'ref-lookup' %}font-semibold text-marsh{% endif %}">Ref Lookup</a>
+                <a href="/exports" class="block px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-100 {% if active == 'exports' %}font-semibold text-marsh{% endif %}">Data Export</a>
               </div>
             </div>
 

--- a/src/policydb/web/templates/exports/_preview.html
+++ b/src/policydb/web/templates/exports/_preview.html
@@ -1,0 +1,105 @@
+<!-- HTMX partial: data preview + format picker + download -->
+
+<div class="card p-0">
+  <!-- Header -->
+  <div class="px-4 py-3 border-b border-gray-200 flex items-center justify-between flex-wrap gap-2">
+    <div class="flex items-center gap-3">
+      <h2 class="text-base font-semibold text-gray-900">{{ source }}</h2>
+      <span class="text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded-full">
+        {{ "{:,}".format(total) }} row{{ 's' if total != 1 else '' }} total{% if total > limit %}, showing first {{ limit }}{% endif %}
+      </span>
+    </div>
+
+    <!-- Format picker + download -->
+    <div class="flex items-center gap-2">
+      <div class="inline-flex rounded-md border border-gray-300 overflow-hidden" id="format-picker">
+        <button type="button" onclick="pickFormat(this, 'csv')"
+                class="fmt-btn px-3 py-1 text-xs font-medium bg-marsh text-white">CSV</button>
+        <button type="button" onclick="pickFormat(this, 'xlsx')"
+                class="fmt-btn px-3 py-1 text-xs font-medium bg-white text-gray-600 hover:bg-gray-50 border-l border-gray-300">XLSX</button>
+        <button type="button" onclick="pickFormat(this, 'json')"
+                class="fmt-btn px-3 py-1 text-xs font-medium bg-white text-gray-600 hover:bg-gray-50 border-l border-gray-300">JSON</button>
+      </div>
+      <button type="button" onclick="downloadExport()"
+              class="px-3 py-1 text-xs font-medium bg-marsh text-white rounded-md hover:bg-marsh/90 transition-colors">
+        Download
+      </button>
+    </div>
+  </div>
+
+  <!-- Column toggles -->
+  <div class="px-4 py-2 border-b border-gray-100 bg-gray-50">
+    <div class="flex items-center gap-1 flex-wrap">
+      <span class="text-xs text-gray-400 mr-1">Columns:</span>
+      <button type="button" onclick="toggleAllCols(true)" class="text-xs text-blue-600 hover:underline mr-1">All</button>
+      <button type="button" onclick="toggleAllCols(false)" class="text-xs text-blue-600 hover:underline mr-2">None</button>
+      {% for col in columns %}
+      <label class="inline-flex items-center gap-1 text-xs text-gray-600 bg-white border border-gray-200 rounded px-1.5 py-0.5 cursor-pointer hover:bg-gray-50">
+        <input type="checkbox" class="col-check rounded text-marsh" value="{{ col }}" checked>
+        {{ col }}
+      </label>
+      {% endfor %}
+    </div>
+  </div>
+
+  <!-- Data table -->
+  <div class="overflow-x-auto" style="max-height: 500px; overflow-y: auto;">
+    <table class="w-full text-sm">
+      <thead class="bg-gray-50 sticky top-0">
+        <tr>
+          {% for col in columns %}
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap border-b border-gray-200">{{ col }}</th>
+          {% endfor %}
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-gray-100">
+        {% for row in rows %}
+        <tr class="hover:bg-gray-50">
+          {% for col in columns %}
+          <td class="px-3 py-1.5 text-gray-700 whitespace-nowrap max-w-[300px] truncate" title="{{ row[col] | default('', true) }}">{{ row[col] | default('', true) }}</td>
+          {% endfor %}
+        </tr>
+        {% endfor %}
+        {% if not rows %}
+        <tr><td colspan="{{ columns | length }}" class="px-3 py-6 text-center text-gray-400">No data</td></tr>
+        {% endif %}
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<script>
+(function() {
+  var _source = '{{ source }}';
+  var _format = 'csv';
+
+  window.pickFormat = function(btn, fmt) {
+    _format = fmt;
+    document.querySelectorAll('.fmt-btn').forEach(function(b) {
+      b.classList.remove('bg-marsh', 'text-white');
+      b.classList.add('bg-white', 'text-gray-600');
+    });
+    btn.classList.remove('bg-white', 'text-gray-600');
+    btn.classList.add('bg-marsh', 'text-white');
+  };
+
+  window.toggleAllCols = function(on) {
+    document.querySelectorAll('.col-check').forEach(function(cb) { cb.checked = on; });
+  };
+
+  window.downloadExport = function() {
+    var checked = [];
+    document.querySelectorAll('.col-check:checked').forEach(function(cb) {
+      checked.push(cb.value);
+    });
+    if (!checked.length) {
+      alert('Select at least one column.');
+      return;
+    }
+    var url = '/exports/download?source=' + encodeURIComponent(_source)
+            + '&format=' + _format
+            + '&columns=' + encodeURIComponent(checked.join(','));
+    window.location.href = url;
+  };
+})();
+</script>

--- a/src/policydb/web/templates/exports/index.html
+++ b/src/policydb/web/templates/exports/index.html
@@ -1,0 +1,78 @@
+{% extends "base.html" %}
+{% block title %}Data Export — PolicyDB{% endblock %}
+{% block content %}
+
+<div class="mb-6">
+  <h1 class="text-2xl font-bold text-gray-900">Data Export</h1>
+  <p class="text-sm text-gray-500 mt-1">Browse tables and views, preview data, and download as CSV, XLSX, or JSON.</p>
+</div>
+
+<div class="flex gap-6" style="min-height: 600px;">
+
+  <!-- Sidebar: source list -->
+  <div class="w-60 flex-shrink-0">
+    <div class="card p-0 sticky top-4">
+
+      <!-- Views -->
+      <div class="px-3 pt-3 pb-1">
+        <h3 class="text-xs font-semibold text-gray-400 uppercase tracking-wider">Views</h3>
+      </div>
+      <div class="space-y-0.5 px-1 pb-2">
+        {% for v in sources.views %}
+        <button type="button"
+                class="export-src-btn w-full text-left px-3 py-1.5 text-sm rounded-md hover:bg-gray-100 transition-colors truncate"
+                data-source="{{ v }}"
+                hx-get="/exports/preview?source={{ v }}"
+                hx-target="#preview-area"
+                hx-swap="innerHTML"
+                onclick="setActiveSource(this)">
+          {{ v }}
+        </button>
+        {% endfor %}
+      </div>
+
+      <hr class="border-gray-200">
+
+      <!-- Tables -->
+      <div class="px-3 pt-3 pb-1">
+        <h3 class="text-xs font-semibold text-gray-400 uppercase tracking-wider">Tables</h3>
+      </div>
+      <div class="space-y-0.5 px-1 pb-3 max-h-[400px] overflow-y-auto">
+        {% for t in sources.tables %}
+        <button type="button"
+                class="export-src-btn w-full text-left px-3 py-1.5 text-sm rounded-md hover:bg-gray-100 transition-colors truncate"
+                data-source="{{ t }}"
+                hx-get="/exports/preview?source={{ t }}"
+                hx-target="#preview-area"
+                hx-swap="innerHTML"
+                onclick="setActiveSource(this)">
+          {{ t }}
+        </button>
+        {% endfor %}
+      </div>
+
+    </div>
+  </div>
+
+  <!-- Main: preview area -->
+  <div class="flex-1 min-w-0" id="preview-area">
+    <div class="card p-12 text-center">
+      <svg class="w-12 h-12 text-gray-300 mx-auto mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 7v10c0 2 1 3 3 3h10c2 0 3-1 3-3V7M4 7c0-2 1-3 3-3h10c2 0 3 1 3 3M4 7h16M9 11h6M9 15h4"/>
+      </svg>
+      <p class="text-gray-400 text-sm">Select a table or view to preview its data.</p>
+    </div>
+  </div>
+
+</div>
+
+<script>
+function setActiveSource(btn) {
+  document.querySelectorAll('.export-src-btn').forEach(function(b) {
+    b.classList.remove('bg-blue-50', 'text-blue-700', 'font-semibold');
+  });
+  btn.classList.add('bg-blue-50', 'text-blue-700', 'font-semibold');
+}
+</script>
+
+{% endblock %}


### PR DESCRIPTION
## Summary
- New `/exports` page (Tools > Data Export) for browsing and exporting any SQLite table or view
- HTMX-driven preview with column toggles and CSV/XLSX/JSON format picker
- Source names validated against `sqlite_master` to prevent injection

## Test plan
- [x] Page loads with views and tables listed in sidebar
- [x] Click source → preview shows first 25 rows with column checkboxes
- [x] CSV/XLSX/JSON downloads work with column filtering
- [x] Invalid source names return 400
- [x] Nav link appears in Tools dropdown with active state

🤖 Generated with [Claude Code](https://claude.com/claude-code)