### PR TITLE
feat: Make Pulse the default tab on policy edit page

### DIFF
--- a/src/policydb/web/templates/policies/edit.html
+++ b/src/policydb/web/templates/policies/edit.html
@@ -81,7 +81,9 @@
 {# ── Tab Bar + Content ── #}
 <div id="policy-tabs">
   <div class="tab-bar">
-    <button class="tab-btn active" data-tab="details"
+    <button class="tab-btn active" data-tab="pulse"
+      data-tab-url="/policies/{{ policy.policy_uid }}/tab/pulse">Pulse</button>
+    <button class="tab-btn" data-tab="details"
       data-tab-url="/policies/{{ policy.policy_uid }}/tab/details">Details</button>
     <button class="tab-btn" data-tab="activity"
       data-tab-url="/policies/{{ policy.policy_uid }}/tab/activity">
@@ -101,8 +103,6 @@
       {% set total = checklist | length %}
       {% if total %}<span class="tab-badge">{{ done }}/{{ total }}</span>{% endif %}
     </button>
-    <button class="tab-btn" data-tab="pulse"
-      data-tab-url="/policies/{{ policy.policy_uid }}/tab/pulse">Pulse</button>
   </div>
   <div class="tab-content" id="ai-import-target">
     <div class="py-4 text-sm text-gray-400 text-center">Loading…</div>


### PR DESCRIPTION
## Summary
- Moves the Pulse tab to first position in the policy edit page tab bar
- Pulse now loads by default when opening any policy in edit mode (previously Details was the default)

## Test plan
- [ ] Open any policy in edit mode — Pulse tab should be selected and loaded by default
- [ ] Click through all other tabs (Details, Activity, Contacts, Workflow) to confirm they still load correctly
- [ ] Verify session storage tab persistence still works (revisiting a policy remembers last-used tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)