### PR TITLE
fix: guard migrations against duplicate program_id column

### DIFF
--- a/src/policydb/db.py
+++ b/src/policydb/db.py
@@ -838,8 +838,12 @@ def init_db(path: Path | None = None) -> None:
         conn.commit()
 
     if 53 not in applied:
-        sql = (_MIGRATIONS_DIR / "053_add_program_id.sql").read_text()
-        conn.executescript(sql)
+        cols = {r["name"] for r in conn.execute("PRAGMA table_info(policies)").fetchall()}
+        if "program_id" not in cols:
+            sql = (_MIGRATIONS_DIR / "053_add_program_id.sql").read_text()
+            conn.executescript(sql)
+        else:
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_policies_program_id ON policies(program_id)")
         conn.execute(
             "INSERT INTO schema_version (version, description) VALUES (?, ?)",
             (53, "Add program_id FK to policies for program linkage"),
@@ -1339,9 +1343,11 @@ def init_db(path: Path | None = None) -> None:
         conn.commit()
 
     if 101 not in applied:
-        # Step 0: Structural SQL
-        sql = (_MIGRATIONS_DIR / "101_phase4_program_cutover.sql").read_text()
-        conn.executescript(sql)
+        # Step 0: Structural SQL — only if column doesn't already exist
+        cols = {r["name"] for r in conn.execute("PRAGMA table_info(program_tower_lines)").fetchall()}
+        if "program_id" not in cols:
+            sql = (_MIGRATIONS_DIR / "101_phase4_program_cutover.sql").read_text()
+            conn.executescript(sql)
 
         # Step A: Link child policies to programs via FK
         conn.execute("""


### PR DESCRIPTION
## Summary
- Adds PRAGMA `table_info` checks before `ALTER TABLE ADD COLUMN program_id` in migrations 053 and 101
- Prevents "duplicate column program_id" crash on server start when a prior migration run partially succeeded

## Test plan
- [x] `init_db()` runs cleanly on existing database
- [x] Double `init_db()` call confirms idempotency
- [ ] Fresh install from clean database starts without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)