### PR TITLE
fix: repair orphaned program-policy links and charts.py error

### DIFF
--- a/src/policydb/charts.py
+++ b/src/policydb/charts.py
@@ -283,7 +283,7 @@ def get_tower_data(conn: sqlite3.Connection, client_id: int) -> list[dict]:
     _WC_KEYWORDS = ("workers comp", "workers' comp")
     groups: dict[str, dict] = {}
     for r in rows:
-        tg = r.get("program_name") or r["tower_group"] or "Ungrouped"
+        tg = r["program_name"] or r["tower_group"] or "Ungrouped"
         if tg not in groups:
             groups[tg] = {"underlying": [], "layers": []}
 

--- a/src/policydb/db.py
+++ b/src/policydb/db.py
@@ -1506,6 +1506,36 @@ def init_db(path: Path | None = None) -> None:
     except Exception as e:
         logger.warning("Carrier normalization failed: %s", e)
 
+    # Data hygiene: relink orphaned policies to programs (tower_group matches but program_id is NULL)
+    try:
+        _before_relink = conn.total_changes
+        conn.execute("""
+            UPDATE policies
+            SET program_id = (
+                SELECT pg.id FROM programs pg
+                WHERE pg.client_id = policies.client_id
+                  AND LOWER(TRIM(pg.name)) = LOWER(TRIM(policies.tower_group))
+                  AND pg.archived = 0
+                LIMIT 1
+            )
+            WHERE tower_group IS NOT NULL AND tower_group != ''
+              AND (is_program = 0 OR is_program IS NULL)
+              AND program_id IS NULL
+              AND archived = 0
+              AND EXISTS (
+                  SELECT 1 FROM programs pg
+                  WHERE pg.client_id = policies.client_id
+                    AND LOWER(TRIM(pg.name)) = LOWER(TRIM(policies.tower_group))
+                    AND pg.archived = 0
+              )
+        """)
+        _relinked = conn.total_changes - _before_relink
+        if _relinked:
+            conn.commit()
+            logger.info("Relinked %d orphaned policies to programs", _relinked)
+    except Exception as e:
+        logger.warning("Program relink failed: %s", e)
+
     _create_views(conn)
     conn.commit()
 

--- a/src/policydb/web/routes/programs.py
+++ b/src/policydb/web/routes/programs.py
@@ -347,11 +347,11 @@ def assign_to_program_v2(
     if not policy:
         return JSONResponse({"ok": False, "error": "Policy not found"}, status_code=404)
 
-    # Set tower_group for backward compat with schematic endpoints
+    # Set program_id FK + tower_group for backward compat with schematic endpoints
     conn.execute(
-        """UPDATE policies SET tower_group = ?, layer_position = COALESCE(layer_position, 'Primary')
+        """UPDATE policies SET program_id = ?, tower_group = ?, layer_position = COALESCE(layer_position, 'Primary')
            WHERE policy_uid = ?""",
-        (program["name"], policy_uid),
+        (program["id"], program["name"], policy_uid),
     )
     conn.commit()
     logger.info("Assigned %s to program %s", policy_uid, program_uid)


### PR DESCRIPTION
## Summary
- **Startup data repair**: Adds idempotent relink query in `init_db()` that matches orphaned policies (program_id IS NULL) to programs via case-insensitive tower_group/name match. Runs every boot, logs count.
- **assign_to_program_v2() fix**: Now sets `program_id` FK alongside `tower_group` so assigned policies actually appear in program views.
- **charts.py fix**: `sqlite3.Row` has no `.get()` method — replaced with direct `[]` access on line 286.

## Test plan
- [ ] Start server, check logs for "Relinked N orphaned policies to programs" message
- [ ] Verify previously-blank programs now show child policies
- [ ] Assign a policy to a program, confirm it appears in schematic tab
- [ ] Navigate to client chart deck page, confirm no `.get()` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)