### PR TITLE
fix: ghost umbrella sub-coverage should not hide Add Umbrella button

### DIFF
--- a/src/policydb/web/routes/programs.py
+++ b/src/policydb/web/routes/programs.py
@@ -191,7 +191,7 @@ def program_tab_schematic(
                     "_from_sub_coverage": True, "_sub_coverage_id": sc["id"],
                 })
 
-    has_umbrella = any(p.get("layer_position") == "Umbrella" for p in excess)
+    has_umbrella = any(p.get("layer_position") == "Umbrella" and not p.get("_from_sub_coverage") for p in excess)
 
     # Compute notations
     for p in excess:


### PR DESCRIPTION
## Summary
- `has_umbrella` check in schematic now excludes ghost entries promoted from package sub-coverages (`_from_sub_coverage=True`)
- Previously, a BOP or similar package with an umbrella sub-coverage would cause the "Add Umbrella" button to disappear from the schematic, even though no real umbrella policy existed

## Test plan
- [ ] Open a program schematic that has a package policy with umbrella sub-coverage
- [ ] Verify "Add Umbrella" button is visible
- [ ] Add a real umbrella — button should then hide correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)