### PR TITLE
fix: remove legacy is_program filter from schematic

### DIFF
--- a/src/policydb/web/routes/programs.py
+++ b/src/policydb/web/routes/programs.py
@@ -155,11 +155,9 @@ def program_tab_schematic(
     ).fetchall()
     policies = [dict(r) for r in rows]
 
-    # Split underlying vs excess
-    underlying = [p for p in policies if (p.get("layer_position") or "Primary") == "Primary"
-                  and not p.get("is_program")]
-    excess = [p for p in policies if (p.get("layer_position") or "") in ("Umbrella", "Excess")
-              and not p.get("is_program")]
+    # Split underlying vs excess (is_program filter removed — programs are standalone now)
+    underlying = [p for p in policies if (p.get("layer_position") or "Primary") == "Primary"]
+    excess = [p for p in policies if (p.get("layer_position") or "") in ("Umbrella", "Excess")]
 
     # Attach sub-coverage data
     all_ids = [p["id"] for p in policies]


### PR DESCRIPTION
## Summary
- Removed `not p.get("is_program")` filter from schematic underlying/excess split
- Programs are standalone objects now — the `is_program` flag is legacy and shouldn't affect schematic display
- This caused GL policies with stale `is_program=1` to disappear from the schematic while still showing correctly in the Overview tab
- With this fix, the GL and its umbrella sub-coverage ghost will appear in the schematic

## Test plan
- [ ] Refresh the Casualty program schematic — GL should now appear in Underlying Lines
- [ ] Umbrella/Excess ghost from GL package should appear in Excess Layers
- [ ] Verify schematic preview still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)