### PR TITLE
fix: correct column names in program activity tab

### DIFF
--- a/src/policydb/queries.py
+++ b/src/policydb/queries.py
@@ -2549,7 +2549,7 @@ def get_program_timeline_milestones(conn: sqlite3.Connection, program_id: int) -
 def get_program_activities(conn: sqlite3.Connection, program_id: int, limit: int = 50) -> list[dict]:
     """Return recent activities from all child policies of a program."""
     rows = conn.execute(
-        """SELECT a.id, a.activity_type, a.description, a.contact_name,
+        """SELECT a.id, a.activity_type, a.subject, a.details, a.contact_person,
                   a.created_at, a.follow_up_date, a.disposition,
                   p.policy_type, p.carrier, p.policy_uid
            FROM activity_log a

--- a/src/policydb/web/templates/programs/_tab_activity.html
+++ b/src/policydb/web/templates/programs/_tab_activity.html
@@ -19,11 +19,14 @@
         </div>
         <span class="text-xs text-gray-400 tabular-nums">{{ a.created_at[:10] if a.created_at else '' }}</span>
       </div>
-      {% if a.description %}
-      <p class="text-sm text-gray-700 ml-0">{{ a.description | truncate(200) }}</p>
+      {% if a.subject %}
+      <p class="text-sm text-gray-700 ml-0 font-medium">{{ a.subject }}</p>
       {% endif %}
-      {% if a.contact_name %}
-      <p class="text-xs text-gray-400 mt-1">Contact: {{ a.contact_name }}</p>
+      {% if a.details %}
+      <p class="text-sm text-gray-500 ml-0">{{ a.details | truncate(200) }}</p>
+      {% endif %}
+      {% if a.contact_person %}
+      <p class="text-xs text-gray-400 mt-1">Contact: {{ a.contact_person }}</p>
       {% endif %}
       {% if a.follow_up_date %}
       <p class="text-xs mt-1">


### PR DESCRIPTION
## Summary
- `get_program_activities()` referenced `a.description` and `a.contact_name` which don't exist on `activity_log` table
- Correct columns are `subject`, `details`, and `contact_person`
- Fixed both the SQL query in queries.py and the template references in `_tab_activity.html`

## Test plan
- [ ] Click Activity tab on a program page — should load without error
- [ ] Activities should show subject, details, and contact person correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)