### PR TITLE
feat: expiration-aware follow-up dates + smart catch-up

### DIFF
--- a/src/policydb/config.py
+++ b/src/policydb/config.py
@@ -114,6 +114,7 @@ _DEFAULTS: dict[str, Any] = {
         "Annual Review",
     ],
     "activity_cluster_days": 7,
+    "followup_expiration_buffer_days": 3,
     "follow_up_dispositions": [
         {"label": "Left VM", "default_days": 3, "accountability": "waiting_external"},
         {"label": "No Answer", "default_days": 1, "accountability": "my_action"},

--- a/src/policydb/queries.py
+++ b/src/policydb/queries.py
@@ -2106,6 +2106,81 @@ def get_week_followups(
     return items
 
 
+def get_overdue_for_plan_week(
+    conn: sqlite3.Connection, week_start: str, pin_days: int = 14
+) -> list[dict]:
+    """Return all overdue follow-ups (before week_start) for Plan Week backlog.
+
+    Sorted by expiration urgency (closest expiration first).
+    Items near expiration are marked as pinned (can't be pushed later).
+    """
+    from datetime import date
+
+    # Cut-off: anything with follow_up_date < week_start
+    cutoff = week_start
+
+    rows = conn.execute("""
+        SELECT 'activity' AS source, a.id, a.subject, a.follow_up_date,
+               a.activity_type, a.client_id, a.policy_id,
+               c.name AS client_name,
+               p.policy_type, p.carrier, p.expiration_date, p.renewal_status,
+               CAST(julianday(p.expiration_date) - julianday('now') AS INTEGER) AS days_to_renewal,
+               p.policy_uid, a.disposition
+        FROM activity_log a
+        JOIN clients c ON a.client_id = c.id
+        LEFT JOIN policies p ON a.policy_id = p.id
+        WHERE a.follow_up_done = 0 AND a.follow_up_date IS NOT NULL
+          AND a.follow_up_date < ?
+
+        UNION ALL
+
+        SELECT 'policy' AS source, p.id, ('Renewal: ' || p.policy_type) AS subject,
+               p.follow_up_date, 'Policy Reminder' AS activity_type,
+               p.client_id, p.id AS policy_id,
+               c.name AS client_name,
+               p.policy_type, p.carrier, p.expiration_date, p.renewal_status,
+               CAST(julianday(p.expiration_date) - julianday('now') AS INTEGER) AS days_to_renewal,
+               p.policy_uid, NULL AS disposition
+        FROM policies p
+        JOIN clients c ON p.client_id = c.id
+        WHERE p.follow_up_date IS NOT NULL
+          AND p.follow_up_date < ?
+          AND p.archived = 0
+          AND (p.is_opportunity = 0 OR p.is_opportunity IS NULL)
+          AND NOT EXISTS (
+              SELECT 1 FROM activity_log a2
+              WHERE a2.policy_id = p.id AND a2.follow_up_done = 0
+              AND a2.follow_up_date IS NOT NULL
+              AND a2.follow_up_date <= p.follow_up_date
+          )
+
+        ORDER BY 4 ASC
+    """, (cutoff, cutoff)).fetchall()
+
+    disp_map = {
+        d["label"]: d.get("accountability", "my_action")
+        for d in cfg.get("follow_up_dispositions", [])
+    }
+
+    items = []
+    today = date.today()
+    for r in rows:
+        d = dict(r)
+        dtr = d.get("days_to_renewal")
+        d["pinned"] = bool(dtr is not None and dtr <= pin_days)
+        d["accountability"] = disp_map.get(d.get("disposition") or "", "my_action")
+        d["composite_id"] = f"{d['source']}-{d['id']}"
+        try:
+            fu = date.fromisoformat(d["follow_up_date"])
+            d["days_overdue"] = (today - fu).days
+        except (ValueError, TypeError):
+            d["days_overdue"] = 0
+        items.append(d)
+    # Sort by expiration urgency (closest expiration first), then follow_up_date
+    items.sort(key=lambda i: (i.get("expiration_date") or "9999-12-31", i.get("follow_up_date") or ""))
+    return items
+
+
 def _weighted_load(day_items: list[dict]) -> float:
     """Calculate weighted load for a day's follow-ups.
 
@@ -2121,7 +2196,8 @@ def _weighted_load(day_items: list[dict]) -> float:
 
 
 def spread_followups(
-    items: list[dict], daily_target: int, week_days: list[str]
+    items: list[dict], daily_target: int, week_days: list[str],
+    overdue_items: list[dict] | None = None, buffer_days: int = 3,
 ) -> list[dict]:
     """Compute proposed redistribution of follow-ups across the week.
 
@@ -2129,11 +2205,17 @@ def spread_followups(
     Only moves non-pinned items from days exceeding daily_target (weighted load).
     Fills lightest days first using weighted client-aware load.
 
+    If overdue_items is provided, non-pinned overdue items are also distributed
+    into the week with expiration-aware priority (closest expiration -> earliest day).
+
     Weighting: first item per client = 1.0, additional same-client items = 0.25.
-    This means 5 follow-ups for one client ≈ 2.0 weighted load, while 5 follow-ups
+    This means 5 follow-ups for one client = 2.0 weighted load, while 5 follow-ups
     across 5 clients = 5.0 weighted load.
     """
     from collections import defaultdict
+    from datetime import date, timedelta
+
+    from policydb.utils import cap_followup_date
 
     # Group by date
     by_date: dict[str, list[dict]] = defaultdict(list)
@@ -2164,8 +2246,42 @@ def spread_followups(
                 by_date[d].remove(item)
                 movable_pool.append(item)
 
+    # Add overdue non-pinned items to the movable pool
+    overdue_movable: list[dict] = []
+    if overdue_items:
+        for item in overdue_items:
+            if not item.get("pinned"):
+                overdue_movable.append(item)
+
+    # Sort overdue by expiration urgency — closest expiration first
+    overdue_movable.sort(key=lambda i: i.get("expiration_date") or "9999-12-31")
+
     # Assign each movable item to the lightest day (by weighted load)
     proposals: list[dict] = []
+
+    # First: distribute overdue items (higher priority)
+    for item in overdue_movable:
+        # Find lightest day, but respect expiration cap
+        exp_date = item.get("expiration_date") or ""
+        eligible_days = week_days[:]
+        if exp_date:
+            cap_date, _ = cap_followup_date(week_days[-1], exp_date, buffer_days)
+            eligible_days = [d for d in week_days if d <= cap_date]
+        if not eligible_days:
+            eligible_days = [week_days[0]]  # Force to Monday if all days past cap
+
+        lightest_day = min(eligible_days, key=lambda d: _weighted_load(by_date[d]))
+        by_date[lightest_day].append(item)
+        proposals.append({
+            "composite_id": item["composite_id"],
+            "old_date": item.get("follow_up_date", ""),
+            "new_date": lightest_day,
+            "subject": item.get("subject", ""),
+            "client_name": item.get("client_name", ""),
+            "from_backlog": True,
+        })
+
+    # Then: redistribute overloaded week items
     for item in movable_pool:
         lightest_day = min(week_days, key=lambda d: _weighted_load(by_date[d]))
         by_date[lightest_day].append(item)

--- a/src/policydb/utils.py
+++ b/src/policydb/utils.py
@@ -888,3 +888,38 @@ def csv_response(rows: list[dict], filename: str, columns: list[str] | None = No
         media_type="text/csv",
         headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )
+
+
+# ─── FOLLOW-UP DATE CAPPING ─────────────────────────────────────────────────
+
+
+def cap_followup_date(
+    calculated_date: str,
+    expiration_date: str | None,
+    buffer_days: int = 3,
+) -> tuple[str, bool]:
+    """Cap a follow-up date so it doesn't land on or after policy expiration.
+
+    Returns (capped_date_iso, was_compressed).
+    If expiration_date is None/empty, returns (calculated_date, False).
+    If policy already expired or expires within buffer, caps to today.
+    """
+    from datetime import date as _date, timedelta
+
+    if not expiration_date or not calculated_date:
+        return (calculated_date, False)
+
+    try:
+        calc = _date.fromisoformat(calculated_date)
+        exp = _date.fromisoformat(expiration_date)
+    except (ValueError, TypeError):
+        return (calculated_date, False)
+
+    today = _date.today()
+    cap = exp - timedelta(days=buffer_days)
+    if cap < today:
+        cap = today
+
+    if calc > cap:
+        return (cap.isoformat(), True)
+    return (calculated_date, False)

--- a/src/policydb/web/routes/action_center.py
+++ b/src/policydb/web/routes/action_center.py
@@ -203,6 +203,17 @@ def _followups_ctx(conn, window: int, activity_type: str, q: str,
             item["days_overdue"] = (today - d).days
         except (ValueError, TypeError):
             item["days_overdue"] = 0
+        # Compute days from follow-up date to expiration for proximity warnings
+        exp_val = item.get("expiration_date") or ""
+        if exp_val and fu_date_val:
+            try:
+                exp_d = date.fromisoformat(exp_val[:10])
+                fu_d = date.fromisoformat(fu_date_val[:10])
+                item["days_fu_to_expiry"] = (exp_d - fu_d).days
+            except (ValueError, TypeError):
+                item["days_fu_to_expiry"] = None
+        else:
+            item["days_fu_to_expiry"] = None
         # Mark future my_action items in watching with "my turn" badge
         if bucket == "watching":
             disp = (item.get("disposition") or "").lower()
@@ -363,6 +374,7 @@ def _followups_ctx(conn, window: int, activity_type: str, q: str,
         "activity_types": cfg.get("activity_types", []),
         "renewal_statuses": cfg.get("renewal_statuses", []),
         "dispositions": cfg.get("follow_up_dispositions", []),
+        "followup_expiration_buffer_days": cfg.get("followup_expiration_buffer_days", 3),
     }
 
 

--- a/src/policydb/web/routes/activities.py
+++ b/src/policydb/web/routes/activities.py
@@ -13,7 +13,7 @@ from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 
 from policydb import config as cfg
 from policydb.email_templates import followup_context, render_tokens
-from policydb.utils import round_duration
+from policydb.utils import cap_followup_date, round_duration
 from policydb.queries import (
     get_activities,
     get_activity_by_id,
@@ -28,6 +28,29 @@ from policydb.queries import (
 from policydb.web.app import get_db, templates
 
 router = APIRouter()
+
+
+def _lookup_expiration(conn, source: str, item_id: str) -> str | None:
+    """Look up expiration_date for a follow-up item by source type and ID."""
+    if source == "activity":
+        row = conn.execute(
+            "SELECT p.expiration_date FROM activity_log a "
+            "JOIN policies p ON a.policy_id = p.id "
+            "WHERE a.id = ?", (int(item_id),)
+        ).fetchone()
+        return row["expiration_date"] if row else None
+    elif source == "policy":
+        if item_id.isdigit():
+            row = conn.execute(
+                "SELECT expiration_date FROM policies WHERE id = ?", (int(item_id),)
+            ).fetchone()
+        else:
+            row = conn.execute(
+                "SELECT expiration_date FROM policies WHERE policy_uid = ?", (item_id,)
+            ).fetchone()
+        return row["expiration_date"] if row else None
+    # client/project sources have no expiration
+    return None
 
 
 def _auto_send_rfi_bundle(conn, activity_id: int, *, abandoned: bool = False) -> None:
@@ -535,9 +558,26 @@ def activity_followup(
 
 @router.post("/activities/{activity_id}/snooze", response_class=HTMLResponse)
 def activity_snooze(request: Request, activity_id: int, days: int = 7, conn=Depends(get_db)):
+    # Compute new date in Python so we can cap against expiration
+    row = conn.execute(
+        "SELECT follow_up_date, policy_id FROM activity_log WHERE id=?", (activity_id,)
+    ).fetchone()
+    if row and row["follow_up_date"]:
+        try:
+            old_date = date.fromisoformat(row["follow_up_date"])
+        except (ValueError, TypeError):
+            old_date = date.today()
+    else:
+        old_date = date.today()
+    new_date = (old_date + timedelta(days=days)).isoformat()
+    # Cap against policy expiration
+    exp_date = _lookup_expiration(conn, "activity", str(activity_id))
+    if exp_date:
+        buffer = cfg.get("followup_expiration_buffer_days", 3)
+        new_date, _ = cap_followup_date(new_date, exp_date, buffer)
     conn.execute(
-        "UPDATE activity_log SET follow_up_date = date(follow_up_date, ?) WHERE id=?",
-        (f"+{days} days", activity_id),
+        "UPDATE activity_log SET follow_up_date = ? WHERE id=?",
+        (new_date, activity_id),
     )
     conn.commit()
     # If called from activity list context, return activity row
@@ -669,6 +709,7 @@ def update_disposition(
     source, item_id = composite_id.split("-", 1)
 
     # Resolve default_days from disposition config if no explicit date
+    auto_calculated = False
     if not follow_up_date:
         dispositions = cfg.get("follow_up_dispositions", [])
         default_days = 0
@@ -678,6 +719,14 @@ def update_disposition(
                 break
         if default_days > 0:
             follow_up_date = (date.today() + timedelta(days=default_days)).isoformat()
+            auto_calculated = True
+
+    # Cap auto-calculated dates against policy expiration
+    if auto_calculated and follow_up_date:
+        exp_date = _lookup_expiration(conn, source, item_id)
+        if exp_date:
+            buffer = cfg.get("followup_expiration_buffer_days", 3)
+            follow_up_date, _ = cap_followup_date(follow_up_date, exp_date, buffer)
 
     account_exec = cfg.get("default_account_exec", "Grant")
 
@@ -827,6 +876,13 @@ def bulk_action(
                         fu_date = (date.today() + timedelta(days=dd)).isoformat()
                     break
 
+            # Cap auto-calculated date against policy expiration
+            if fu_date:
+                exp_date = _lookup_expiration(conn, source, item_id)
+                if exp_date:
+                    buffer = cfg.get("followup_expiration_buffer_days", 3)
+                    fu_date, _ = cap_followup_date(fu_date, exp_date, buffer)
+
             if source == "activity":
                 updates = ["disposition = ?"]
                 params: list = [disposition]
@@ -889,6 +945,11 @@ def bulk_action(
 
         elif action == "snooze":
             new_date = (date.today() + timedelta(days=snooze_days)).isoformat()
+            # Cap against policy expiration
+            exp_date = _lookup_expiration(conn, source, item_id)
+            if exp_date:
+                buffer = cfg.get("followup_expiration_buffer_days", 3)
+                new_date, _ = cap_followup_date(new_date, exp_date, buffer)
             if source == "activity":
                 conn.execute(
                     "UPDATE activity_log SET follow_up_date = ? WHERE id = ?",
@@ -936,10 +997,10 @@ def bulk_action(
 
 
 @router.get("/followups/plan", response_class=HTMLResponse)
-def followups_plan(request: Request, week_start: str = "", conn=Depends(get_db)):
+def followups_plan(request: Request, week_start: str = "", catchup: int = 0, conn=Depends(get_db)):
     """Plan Week view — visualize and rebalance follow-up workload."""
     from datetime import date, timedelta
-    from policydb.queries import get_week_followups
+    from policydb.queries import get_week_followups, get_overdue_for_plan_week
     from collections import defaultdict
 
     # Default to current week's Monday
@@ -978,6 +1039,9 @@ def followups_plan(request: Request, week_start: str = "", conn=Depends(get_db))
             "pinned_count": sum(1 for i in day_items if i.get("pinned")),
         })
 
+    # Overdue backlog — items with follow_up_date before this Monday
+    overdue_backlog = get_overdue_for_plan_week(conn, mon.isoformat(), pin_days)
+
     prev_week = (mon - timedelta(days=7)).isoformat()
     next_week = (mon + timedelta(days=7)).isoformat()
     this_monday = (today - timedelta(days=today.weekday())).isoformat()
@@ -993,22 +1057,26 @@ def followups_plan(request: Request, week_start: str = "", conn=Depends(get_db))
         "this_monday": this_monday,
         "daily_target": target,
         "total_items": len(items),
+        "overdue_backlog": overdue_backlog,
+        "catchup": catchup,
     })
 
 
 @router.post("/followups/plan/spread", response_class=HTMLResponse)
 def followups_spread(request: Request, week_start: str = Form(...), conn=Depends(get_db)):
-    """Compute and return proposed spread for the week."""
+    """Compute and return proposed spread for the week (including overdue backlog)."""
     from datetime import date, timedelta
-    from policydb.queries import get_week_followups, spread_followups
+    from policydb.queries import get_week_followups, get_overdue_for_plan_week, spread_followups
 
     mon = date.fromisoformat(week_start)
     week_days = [(mon + timedelta(days=i)).isoformat() for i in range(5)]
     pin_days = cfg.get("pin_renewal_days", 14)
     target = cfg.get("daily_followup_target", 5)
+    buffer = cfg.get("followup_expiration_buffer_days", 3)
 
     items = get_week_followups(conn, week_start, pin_days)
-    proposals = spread_followups(items, target, week_days)
+    overdue = get_overdue_for_plan_week(conn, week_start, pin_days)
+    proposals = spread_followups(items, target, week_days, overdue_items=overdue, buffer_days=buffer)
 
     if not proposals:
         return HTMLResponse("", headers={
@@ -1016,9 +1084,11 @@ def followups_spread(request: Request, week_start: str = Form(...), conn=Depends
         })
 
     # Return proposals as JSON for the JS to preview
+    from_backlog = sum(1 for p in proposals if p.get("from_backlog"))
     return JSONResponse({
         "proposals": proposals,
         "count": len(proposals),
+        "from_backlog": from_backlog,
     })
 
 

--- a/src/policydb/web/routes/policies.py
+++ b/src/policydb/web/routes/policies.py
@@ -25,7 +25,7 @@ from policydb.llm_schemas import (
 )
 from policydb.queries import REVIEW_CYCLE_LABELS, get_all_policies, get_client_by_id, get_opportunity_by_uid, get_policy_by_uid, get_policy_total_hours, get_saved_notes, save_note, delete_saved_note, renew_policy, get_or_create_contact, assign_contact_to_policy, remove_contact_from_policy, set_placement_colleague, get_policy_contacts, get_sub_coverages as _get_sub_coverages, auto_generate_sub_coverages as _auto_generate_sub_coverages
 from rapidfuzz import fuzz
-from policydb.utils import round_duration, normalize_carrier, normalize_coverage_type, normalize_policy_number, format_city, format_state, format_zip
+from policydb.utils import cap_followup_date, round_duration, normalize_carrier, normalize_coverage_type, normalize_policy_number, format_city, format_state, format_zip
 from policydb.web.app import get_db, templates
 
 router = APIRouter(prefix="/policies")
@@ -3611,11 +3611,27 @@ def policy_snooze_followup(
     request: Request, policy_uid: str, days: int = 7, conn=Depends(get_db)
 ):
     """Reschedule a policy follow-up by +N days; returns updated row partial."""
-    from datetime import date as _date
+    from datetime import date as _date, timedelta as _td
     uid = policy_uid.upper()
+    # Compute in Python so we can cap against expiration
+    pol = conn.execute(
+        "SELECT follow_up_date, expiration_date FROM policies WHERE policy_uid=?", (uid,)
+    ).fetchone()
+    if pol and pol["follow_up_date"]:
+        try:
+            old_date = _date.fromisoformat(pol["follow_up_date"])
+        except (ValueError, TypeError):
+            old_date = _date.today()
+    else:
+        old_date = _date.today()
+    new_date = (old_date + _td(days=days)).isoformat()
+    # Cap against expiration
+    if pol and pol["expiration_date"]:
+        buffer = cfg.get("followup_expiration_buffer_days", 3)
+        new_date, _ = cap_followup_date(new_date, pol["expiration_date"], buffer)
     conn.execute(
-        "UPDATE policies SET follow_up_date = date(follow_up_date, ?) WHERE policy_uid=?",
-        (f"+{days} days", uid),
+        "UPDATE policies SET follow_up_date = ? WHERE policy_uid=?",
+        (new_date, uid),
     )
     conn.commit()
     row = conn.execute(
@@ -3682,14 +3698,14 @@ def policy_followup_form(request: Request, policy_uid: str):
     uid = policy_uid.upper()
     return HTMLResponse(
         f'<form hx-post="/policies/{uid}/set-followup"'
-        f' hx-target="#suggested-actions-{uid}" hx-swap="innerHTML"'
+        f' hx-target="#sug-actions-{uid}" hx-swap="innerHTML"'
         f' class="flex gap-1.5 items-center">'
         f'<input type="date" name="follow_up_date" required'
         f' class="border border-gray-300 rounded px-2 py-1 text-xs focus:ring-1 focus:ring-marsh focus:outline-none">'
         f'<button type="submit" class="text-xs bg-marsh text-white px-2 py-1 rounded hover:bg-marsh-light">Set</button>'
         f'<button type="button"'
         f' hx-get="/policies/{uid}/followup-form-cancel"'
-        f' hx-target="#suggested-actions-{uid}" hx-swap="innerHTML"'
+        f' hx-target="#sug-actions-{uid}" hx-swap="innerHTML"'
         f' class="text-xs text-gray-400 hover:underline px-1">✕</button>'
         f'</form>'
     )
@@ -3702,7 +3718,7 @@ def policy_followup_form_cancel(request: Request, policy_uid: str):
     return HTMLResponse(
         f'<div class="flex gap-1.5 items-center">'
         f'<button hx-get="/policies/{uid}/followup-form"'
-        f' hx-target="#suggested-actions-{uid}" hx-swap="innerHTML"'
+        f' hx-target="#sug-actions-{uid}" hx-swap="innerHTML"'
         f' class="text-xs border border-marsh text-marsh bg-white hover:bg-marsh hover:text-white px-2 py-1 rounded transition-colors">'
         f'Schedule Follow-Up</button>'
         f'<a href="/policies/{uid}/edit" class="text-xs text-gray-400 hover:text-marsh hover:underline">Edit →</a>'

--- a/src/policydb/web/routes/settings.py
+++ b/src/policydb/web/routes/settings.py
@@ -117,6 +117,7 @@ SEARCH_INDEX = [
     {"label": "Timeline Engine", "tab": "workflow", "anchor": "section-timeline-engine"},
     {"label": "Follow-Up Dispositions", "tab": "workflow", "anchor": "section-dispositions"},
     {"label": "Follow-Up Urgency Tiers", "tab": "workflow", "anchor": "section-stale-threshold"},
+    {"label": "Expiration Buffer", "tab": "workflow", "anchor": "section-expiration-buffer"},
     {"label": "Alert & Readiness Thresholds", "tab": "readiness", "anchor": "section-thresholds"},
     {"label": "Readiness Score Weights", "tab": "readiness", "anchor": "section-readiness-weights"},
     {"label": "Carrier Aliases", "tab": "carriers", "anchor": "section-carrier-aliases"},
@@ -152,6 +153,7 @@ def _build_tab_context(tab: str, conn) -> dict:
         ctx["renewal_statuses"] = cfg.get("renewal_statuses", [])
         ctx["renewal_milestones"] = cfg.get("renewal_milestones", [])
         ctx["stale_threshold_days"] = cfg.get("stale_threshold_days", 14)
+        ctx["followup_expiration_buffer_days"] = cfg.get("followup_expiration_buffer_days", 3)
         # activity_types needed by mandated activities editor
         if "lists" not in ctx:
             ctx["lists"] = {}
@@ -494,6 +496,15 @@ def save_thresholds(
 def update_stale_threshold(request: Request, value: int = Form(...)):
     full = dict(cfg.load_config())
     full["stale_threshold_days"] = max(1, min(value, 90))
+    cfg.save_config(full)
+    cfg.reload_config()
+    return RedirectResponse("/settings", status_code=303)
+
+
+@router.post("/config/expiration-buffer")
+def update_expiration_buffer(request: Request, value: int = Form(...)):
+    full = dict(cfg.load_config())
+    full["followup_expiration_buffer_days"] = max(1, min(value, 30))
     cfg.save_config(full)
     cfg.reload_config()
     return RedirectResponse("/settings", status_code=303)

--- a/src/policydb/web/templates/action_center/_followup_sections.html
+++ b/src/policydb/web/templates/action_center/_followup_sections.html
@@ -5,7 +5,7 @@
    ══════════════════════════════════════════════════════════════════ #}
 {% macro fu_row(item, bg_class, border_class, dot_color, date_class, section_tag) %}
 {% set row_id = "ac-fu-" ~ item.source ~ "-" ~ item.id %}
-<div class="fu-row {{ bg_class }} rounded-lg {{ border_class }} hover:border-gray-300 transition-colors" data-status="{{ section_tag }}" id="{{ row_id }}">
+<div class="fu-row {{ bg_class }} rounded-lg {{ border_class }} hover:border-gray-300 transition-colors" data-status="{{ section_tag }}" data-exp="{{ item.expiration_date or '' }}" id="{{ row_id }}">
   <div class="flex items-center gap-3 px-4 py-3">
     <input type="checkbox" class="bulk-check accent-[#003865] mr-1" value="{{ item.source }}-{{ item.id }}" onchange="updateBulkCount()">
     {# Color dot — diamond for milestones, circle for regular #}
@@ -79,6 +79,13 @@
     {# Date / info column #}
     <div class="text-right flex-shrink-0">
       <div class="text-xs font-medium {{ date_class }}">{{ item.follow_up_date }}</div>
+      {% if item.days_fu_to_expiry is defined and item.days_fu_to_expiry is not none %}
+        {% if item.days_fu_to_expiry <= 0 %}
+        <div class="text-[10px] font-medium bg-red-100 text-red-700 px-1.5 py-0.5 rounded inline-block mt-0.5">Past expiry</div>
+        {% elif item.days_fu_to_expiry <= 3 %}
+        <div class="text-[10px] font-medium bg-amber-100 text-amber-700 px-1.5 py-0.5 rounded inline-block mt-0.5">Exp in {{ item.days_fu_to_expiry }}d</div>
+        {% endif %}
+      {% endif %}
       {% if item.days_overdue is defined and item.days_overdue > 0 %}
       <div class="text-[10px] font-medium
         {% if item.days_overdue >= 15 %}text-red-600{% elif item.days_overdue >= 4 %}text-orange-500{% else %}text-amber-500{% endif %}">
@@ -149,11 +156,13 @@
             <div class="text-[9px] text-gray-400">Follow-up date</div>
             <div class="flex gap-1 items-center">
               <input type="date" name="follow_up_date" id="disp-date-{{ row_id }}" value="{{ item.follow_up_date }}"
-                class="text-xs border border-gray-200 rounded px-2 py-1 focus:ring-1 focus:ring-[#003865]">
-              <button type="button" onclick="var d=new Date();d.setDate(d.getDate()+1);document.getElementById('disp-date-{{ row_id }}').value=d.toISOString().split('T')[0]" class="text-[9px] border border-gray-200 rounded px-1 py-0.5 text-gray-400 hover:text-[#003865]">+1d</button>
-              <button type="button" onclick="var d=new Date();d.setDate(d.getDate()+3);document.getElementById('disp-date-{{ row_id }}').value=d.toISOString().split('T')[0]" class="text-[9px] border border-gray-200 rounded px-1 py-0.5 text-gray-400 hover:text-[#003865]">+3d</button>
-              <button type="button" onclick="var d=new Date();d.setDate(d.getDate()+7);document.getElementById('disp-date-{{ row_id }}').value=d.toISOString().split('T')[0]" class="text-[9px] border border-gray-200 rounded px-1 py-0.5 text-gray-400 hover:text-[#003865]">+7d</button>
+                class="text-xs border border-gray-200 rounded px-2 py-1 focus:ring-1 focus:ring-[#003865]"
+                onchange="checkDateVsExpiry(this, '{{ row_id }}', 'disp-cap-{{ row_id }}')">
+              <button type="button" onclick="setDispBarDate('disp-date-{{ row_id }}', 1, '{{ row_id }}')" class="text-[9px] border border-gray-200 rounded px-1 py-0.5 text-gray-400 hover:text-[#003865]">+1d</button>
+              <button type="button" onclick="setDispBarDate('disp-date-{{ row_id }}', 3, '{{ row_id }}')" class="text-[9px] border border-gray-200 rounded px-1 py-0.5 text-gray-400 hover:text-[#003865]">+3d</button>
+              <button type="button" onclick="setDispBarDate('disp-date-{{ row_id }}', 7, '{{ row_id }}')" class="text-[9px] border border-gray-200 rounded px-1 py-0.5 text-gray-400 hover:text-[#003865]">+7d</button>
             </div>
+            <span id="disp-cap-{{ row_id }}" class="text-[10px] text-amber-600 hidden"></span>
           </div>
           <div class="flex-1 min-w-32">
             <div class="text-[9px] text-gray-400">Note</div>
@@ -217,8 +226,10 @@
             <button type="button" onclick="setAcFuDate('{{ row_id }}', 7)" class="text-[10px] text-gray-400 hover:text-[#003865] border border-gray-200 hover:border-[#003865] rounded px-1.5 py-0.5 transition-colors">+7d</button>
             <button type="button" onclick="setAcFuDate('{{ row_id }}', 14)" class="text-[10px] text-gray-400 hover:text-[#003865] border border-gray-200 hover:border-[#003865] rounded px-1.5 py-0.5 transition-colors">+14d</button>
             <input type="date" name="new_follow_up_date" id="ac-fu-date-{{ row_id }}"
-              class="text-xs border border-gray-200 rounded px-2 py-1 focus:ring-1 focus:ring-[#003865]">
+              class="text-xs border border-gray-200 rounded px-2 py-1 focus:ring-1 focus:ring-[#003865]"
+              onchange="checkDateVsExpiry(this, '{{ row_id }}', 'ac-fu-cap-{{ row_id }}')">
           </div>
+          <span id="ac-fu-cap-{{ row_id }}" class="text-[10px] text-amber-600 hidden"></span>
         </div>
 
         {# Save / Cancel #}
@@ -241,7 +252,7 @@
    ══════════════════════════════════════════════════════════════════ #}
 {% macro triage_row(item) %}
 {% set row_id = "ac-fu-" ~ item.source ~ "-" ~ item.id %}
-<div class="fu-row bg-gray-50 rounded-lg border border-dashed border-gray-300 hover:border-gray-400 transition-colors" data-status="triage" id="{{ row_id }}">
+<div class="fu-row bg-gray-50 rounded-lg border border-dashed border-gray-300 hover:border-gray-400 transition-colors" data-status="triage" data-exp="{{ item.expiration_date or '' }}" id="{{ row_id }}">
   <div class="flex items-center gap-3 px-4 py-3">
     <input type="checkbox" class="bulk-check accent-[#003865] mr-1" value="{{ item.source }}-{{ item.id }}" onchange="updateBulkCount()">
     {# Color dot — gray open circle #}
@@ -305,11 +316,13 @@
             <div class="text-[9px] text-gray-400">Follow-up date</div>
             <div class="flex gap-1 items-center">
               <input type="date" name="follow_up_date" id="disp-date-{{ row_id }}" value="{{ item.follow_up_date }}"
-                class="text-xs border border-gray-200 rounded px-2 py-1 focus:ring-1 focus:ring-[#003865]">
-              <button type="button" onclick="var d=new Date();d.setDate(d.getDate()+1);document.getElementById('disp-date-{{ row_id }}').value=d.toISOString().split('T')[0]" class="text-[9px] border border-gray-200 rounded px-1 py-0.5 text-gray-400 hover:text-[#003865]">+1d</button>
-              <button type="button" onclick="var d=new Date();d.setDate(d.getDate()+3);document.getElementById('disp-date-{{ row_id }}').value=d.toISOString().split('T')[0]" class="text-[9px] border border-gray-200 rounded px-1 py-0.5 text-gray-400 hover:text-[#003865]">+3d</button>
-              <button type="button" onclick="var d=new Date();d.setDate(d.getDate()+7);document.getElementById('disp-date-{{ row_id }}').value=d.toISOString().split('T')[0]" class="text-[9px] border border-gray-200 rounded px-1 py-0.5 text-gray-400 hover:text-[#003865]">+7d</button>
+                class="text-xs border border-gray-200 rounded px-2 py-1 focus:ring-1 focus:ring-[#003865]"
+                onchange="checkDateVsExpiry(this, '{{ row_id }}', 'disp-cap-{{ row_id }}')">
+              <button type="button" onclick="setDispBarDate('disp-date-{{ row_id }}', 1, '{{ row_id }}')" class="text-[9px] border border-gray-200 rounded px-1 py-0.5 text-gray-400 hover:text-[#003865]">+1d</button>
+              <button type="button" onclick="setDispBarDate('disp-date-{{ row_id }}', 3, '{{ row_id }}')" class="text-[9px] border border-gray-200 rounded px-1 py-0.5 text-gray-400 hover:text-[#003865]">+3d</button>
+              <button type="button" onclick="setDispBarDate('disp-date-{{ row_id }}', 7, '{{ row_id }}')" class="text-[9px] border border-gray-200 rounded px-1 py-0.5 text-gray-400 hover:text-[#003865]">+7d</button>
             </div>
+            <span id="disp-cap-{{ row_id }}" class="text-[10px] text-amber-600 hidden"></span>
           </div>
           <div class="flex-1 min-w-32">
             <div class="text-[9px] text-gray-400">Note</div>
@@ -349,6 +362,9 @@
     <div class="flex items-center gap-2 mb-2">
       <span class="text-white text-xs font-semibold px-2.5 py-0.5 rounded-full bg-red-700">Stale</span>
       <span class="text-gray-400 text-xs">{{ stale | length }} item{{ 's' if stale | length != 1 }} — {{ cfg.get('stale_threshold_days', 14) if cfg is defined else 14 }}+ days overdue</span>
+      {% if stale | length >= 5 %}
+      <a href="/followups/plan?catchup=1" class="ml-auto text-[10px] bg-red-100 text-red-700 px-2.5 py-1 rounded-full hover:bg-red-200 transition-colors font-medium no-print">Plan Catch-Up &rarr;</a>
+      {% endif %}
     </div>
     <div class="space-y-1">
       {% for item in stale %}
@@ -368,6 +384,9 @@
     <div class="flex items-center gap-2 mb-2">
       <span class="text-white text-xs font-semibold px-2.5 py-0.5 rounded-full bg-amber-700">Overdue</span>
       <span class="text-gray-400 text-xs">{{ overdue_bucket | length }} item{{ 's' if overdue_bucket | length != 1 }} overdue</span>
+      {% if overdue_bucket | length >= 5 %}
+      <a href="/followups/plan?catchup=1" class="ml-auto text-[10px] bg-amber-100 text-amber-700 px-2.5 py-1 rounded-full hover:bg-amber-200 transition-colors font-medium no-print">Plan Catch-Up &rarr;</a>
+      {% endif %}
     </div>
     <div class="space-y-1">
       {% for item in overdue_bucket %}

--- a/src/policydb/web/templates/action_center/_followups.html
+++ b/src/policydb/web/templates/action_center/_followups.html
@@ -322,6 +322,53 @@ function toggleTriageDisp(rowId) {
   if (panel) panel.classList.toggle('hidden');
 }
 
+/* ── Expiration buffer (from config) ── */
+var FU_EXP_BUFFER = {{ followup_expiration_buffer_days | default(3) }};
+
+/* ── Cap follow-up date against policy expiration ── */
+function capFollowupDate(rawDateStr, expDateStr, bufferDays) {
+  if (!expDateStr || !rawDateStr) return { date: rawDateStr, compressed: false };
+  var today = new Date(); today.setHours(0,0,0,0);
+  var exp = new Date(expDateStr + 'T00:00:00');
+  var cap = new Date(exp);
+  cap.setDate(cap.getDate() - bufferDays);
+  if (cap < today) cap = today;
+  var calc = new Date(rawDateStr + 'T00:00:00');
+  if (calc > cap) {
+    return { date: cap.toISOString().split('T')[0], compressed: true };
+  }
+  return { date: rawDateStr, compressed: false };
+}
+
+/* ── Get expiration_date from row's data-exp attribute ── */
+function getRowExp(rowId) {
+  var row = document.getElementById(rowId);
+  if (!row) return '';
+  return row.closest('.fu-row') ? row.closest('.fu-row').getAttribute('data-exp') || '' : row.getAttribute('data-exp') || '';
+}
+
+/* ── Show/hide compression indicator near a date input ── */
+function showCapIndicator(rowId, compressed, expDate) {
+  var indicator = document.getElementById('ac-fu-cap-' + rowId);
+  if (!indicator) return;
+  if (compressed && expDate) {
+    indicator.textContent = 'Capped \u2014 expires ' + expDate;
+    indicator.classList.remove('hidden');
+  } else {
+    indicator.classList.add('hidden');
+  }
+  var dateInput = document.getElementById('ac-fu-date-' + rowId);
+  if (dateInput) {
+    if (compressed) {
+      dateInput.classList.add('border-amber-400');
+      dateInput.classList.remove('border-gray-200');
+    } else {
+      dateInput.classList.remove('border-amber-400');
+      dateInput.classList.add('border-gray-200');
+    }
+  }
+}
+
 /* ── Disposition pill selection ── */
 function selectAcDisp(btn, label, days, rowId) {
   btn.closest('.flex-wrap').querySelectorAll('.ac-disp-pill').forEach(function(p) {
@@ -331,24 +378,80 @@ function selectAcDisp(btn, label, days, rowId) {
   btn.classList.add('bg-[#003865]', 'text-white', 'border-[#003865]');
   btn.classList.remove('border-gray-200', 'text-gray-500');
   document.getElementById('ac-disp-val-' + rowId).value = label;
-  // Auto-fill date from disposition default_days
   if (days > 0) {
     var dateInput = document.getElementById('ac-fu-date-' + rowId);
     if (dateInput) {
       var d = new Date();
       d.setDate(d.getDate() + days);
-      dateInput.value = d.toISOString().split('T')[0];
+      var rawDate = d.toISOString().split('T')[0];
+      var expDate = getRowExp(rowId);
+      var result = capFollowupDate(rawDate, expDate, FU_EXP_BUFFER);
+      dateInput.value = result.date;
+      showCapIndicator(rowId, result.compressed, expDate);
     }
   }
 }
 
-/* ── Set follow-up date shortcut ── */
+/* ── Set follow-up date shortcut (with expiration cap) ── */
 function setAcFuDate(rowId, days) {
   var dateInput = document.getElementById('ac-fu-date-' + rowId);
   if (dateInput) {
     var d = new Date();
     d.setDate(d.getDate() + days);
-    dateInput.value = d.toISOString().split('T')[0];
+    var rawDate = d.toISOString().split('T')[0];
+    var expDate = getRowExp(rowId);
+    var result = capFollowupDate(rawDate, expDate, FU_EXP_BUFFER);
+    dateInput.value = result.date;
+    showCapIndicator(rowId, result.compressed, expDate);
+  }
+}
+
+/* ── Set disposition bar date shortcut (with expiration cap) ── */
+function setDispBarDate(inputId, days, rowId) {
+  var dateInput = document.getElementById(inputId);
+  if (dateInput) {
+    var d = new Date();
+    d.setDate(d.getDate() + days);
+    var rawDate = d.toISOString().split('T')[0];
+    var expDate = getRowExp(rowId);
+    var result = capFollowupDate(rawDate, expDate, FU_EXP_BUFFER);
+    dateInput.value = result.date;
+    var indicator = document.getElementById('disp-cap-' + rowId);
+    if (indicator) {
+      if (result.compressed && expDate) {
+        indicator.textContent = 'Capped \u2014 expires ' + expDate;
+        indicator.classList.remove('hidden');
+      } else {
+        indicator.classList.add('hidden');
+      }
+    }
+    if (result.compressed) {
+      dateInput.classList.add('border-amber-400');
+      dateInput.classList.remove('border-gray-200');
+    } else {
+      dateInput.classList.remove('border-amber-400');
+      dateInput.classList.add('border-gray-200');
+    }
+  }
+}
+
+/* ── Manual date entry warning (change event) ── */
+function checkDateVsExpiry(dateInput, rowId, capSpanId) {
+  var expDate = getRowExp(rowId);
+  if (!expDate || !dateInput.value) return;
+  var indicator = document.getElementById(capSpanId);
+  if (!indicator) return;
+  var entered = new Date(dateInput.value + 'T00:00:00');
+  var exp = new Date(expDate + 'T00:00:00');
+  if (entered >= exp) {
+    indicator.textContent = 'Past policy expiration';
+    indicator.classList.remove('hidden');
+    dateInput.classList.add('border-amber-400');
+    dateInput.classList.remove('border-gray-200');
+  } else {
+    indicator.classList.add('hidden');
+    dateInput.classList.remove('border-amber-400');
+    dateInput.classList.add('border-gray-200');
   }
 }
 </script>

--- a/src/policydb/web/templates/followups/_row.html
+++ b/src/policydb/web/templates/followups/_row.html
@@ -3,7 +3,7 @@
 {% set mailto_subject = r.get('mailto_subject') or ('Re: ' ~ r.client_name ~ ' — ' ~ r.subject) %}
 {% set _rfi_uid = r.subject.split('Send RFI: ')[1].split(' ', 1)[0] if r.subject and r.subject.startswith('Send RFI: ') else '' %}
 {% set _ref_tag = build_ref_tag(cn_number=r.get('cn_number', ''), client_id=r.client_id, policy_uid=r.policy_uid|default(''), project_id=r.get('project_id', 0), activity_id=r.id, rfi_uid=_rfi_uid) %}
-<tr class="hover:bg-{{ 'red' if is_overdue else 'amber' }}-50/40" id="{{ row_id }}">
+<tr class="hover:bg-{{ 'red' if is_overdue else 'amber' }}-50/40" id="{{ row_id }}" data-exp="{{ r.get('expiration_date', '') }}">
   <td class="px-3 py-3 w-8 no-print">
     <input type="checkbox" class="followup-check rounded border-gray-300" value="{{ r.source }}-{{ r.id }}"
       onchange="updateBulkBar()">
@@ -351,22 +351,36 @@ function toggleDispositionForm(rowId) {
   });
 }
 
+function _capFuDate(rawDateStr, expDateStr, bufferDays) {
+  if (!expDateStr || !rawDateStr) return rawDateStr;
+  var today = new Date(); today.setHours(0,0,0,0);
+  var exp = new Date(expDateStr + 'T00:00:00');
+  var cap = new Date(exp); cap.setDate(cap.getDate() - bufferDays);
+  if (cap < today) cap = today;
+  var calc = new Date(rawDateStr + 'T00:00:00');
+  return calc > cap ? cap.toISOString().split('T')[0] : rawDateStr;
+}
+function _getRowExp(elId) {
+  var el = document.getElementById(elId);
+  if (!el) return '';
+  var tr = el.closest('tr[data-exp]');
+  return tr ? tr.getAttribute('data-exp') || '' : '';
+}
+
 function selectDisp(btn, label, days, rowId) {
-  // Deselect siblings, select this one
   btn.closest('.flex-wrap').querySelectorAll('.disp-pill').forEach(function(p) {
     p.classList.remove('bg-marsh', 'text-white', 'border-marsh');
     p.classList.add('border-gray-200', 'text-gray-500');
   });
   btn.classList.add('bg-marsh', 'text-white', 'border-marsh');
   btn.classList.remove('border-gray-200', 'text-gray-500');
-  // Set hidden input
   document.getElementById('disp-val-' + rowId).value = label;
-  // Auto-fill date
   var dateInput = document.getElementById('rediary-date-' + rowId);
   if (days > 0 && dateInput) {
     var d = new Date();
     d.setDate(d.getDate() + days);
-    dateInput.value = d.toISOString().split('T')[0];
+    var raw = d.toISOString().split('T')[0];
+    dateInput.value = _capFuDate(raw, _getRowExp(rowId), 3);
   }
 }
 
@@ -375,7 +389,8 @@ function setRediaryDays(rowId, days) {
   if (dateInput) {
     var d = new Date();
     d.setDate(d.getDate() + days);
-    dateInput.value = d.toISOString().split('T')[0];
+    var raw = d.toISOString().split('T')[0];
+    dateInput.value = _capFuDate(raw, _getRowExp(rowId), 3);
   }
 }
 
@@ -395,13 +410,19 @@ function markDoneOnly(btn, activityId, rowId) {
 function setFuDateRow(actId, days) {
   var d = new Date(); d.setDate(d.getDate() + days);
   var el = document.getElementById('fu-date-row-' + actId);
-  if (el) el.value = d.toISOString().slice(0, 10);
+  if (el) {
+    var raw = d.toISOString().slice(0, 10);
+    el.value = _capFuDate(raw, _getRowExp('fu-date-row-' + actId), 3);
+  }
 }
 
 function setFuDateRowById(elId, days) {
   var d = new Date(); d.setDate(d.getDate() + days);
   var el = document.getElementById(elId);
-  if (el) el.value = d.toISOString().slice(0, 10);
+  if (el) {
+    var raw = d.toISOString().slice(0, 10);
+    el.value = _capFuDate(raw, _getRowExp(elId), 3);
+  }
 }
 
 function toggleActivityEdit(rowId, activityId) {

--- a/src/policydb/web/templates/followups/plan.html
+++ b/src/policydb/web/templates/followups/plan.html
@@ -30,7 +30,56 @@
   </div>
 </div>
 
-<div class="grid grid-cols-5 gap-3" id="plan-grid">
+{% if overdue_backlog %}
+{# ── Catch-Up Summary ── #}
+<div class="bg-amber-50 border border-amber-200 rounded-lg px-4 py-2 mb-4 flex items-center gap-3" id="catchup-banner">
+  <span class="text-sm text-amber-700 font-medium">{{ overdue_backlog | length }} overdue item{{ 's' if overdue_backlog | length != 1 }}</span>
+  <span class="text-xs text-amber-600">Drag items into the week or use Spread to distribute them automatically</span>
+</div>
+{% endif %}
+
+<div class="grid {% if overdue_backlog %}grid-cols-6{% else %}grid-cols-5{% endif %} gap-3" id="plan-grid">
+  {% if overdue_backlog %}
+  {# ── Overdue Backlog Column ── #}
+  <div class="card overflow-hidden border-red-200" data-date="backlog"
+    ondragover="event.preventDefault();this.classList.add('ring-2','ring-red-400')"
+    ondragleave="this.classList.remove('ring-2','ring-red-400')"
+    ondrop="handleDrop(event, '');this.classList.remove('ring-2','ring-red-400')">
+    <div class="px-3 py-2 border-b border-red-100 bg-red-50 flex items-center justify-between">
+      <span class="text-xs font-bold text-red-700">Overdue</span>
+      <span class="text-xs font-mono text-red-600 font-bold" id="count-backlog">{{ overdue_backlog | length }}</span>
+    </div>
+    <div class="p-2 space-y-1 min-h-[200px] max-h-[60vh] overflow-y-auto" id="items-backlog">
+      {% for item in overdue_backlog %}
+      <div class="rounded border px-2 py-1.5 text-xs
+        {% if item.pinned %}border-red-200 bg-red-50/30{% else %}border-amber-200 bg-amber-50/30 hover:border-amber-300{% endif %}"
+        id="card-{{ item.composite_id }}"
+        data-composite-id="{{ item.composite_id }}"
+        {% if not item.pinned %}draggable="true" ondragstart="handleDragStart(event, '{{ item.composite_id }}')"{% endif %}>
+        <div class="flex items-start gap-1.5">
+          {% if item.pinned %}
+          <span class="text-red-400 text-[10px] mt-0.5" title="Pinned — expiring soon">&#128274;</span>
+          {% else %}
+          <span class="text-amber-400 cursor-grab text-[10px] mt-0.5" title="Drag to a day">&#9776;</span>
+          {% endif %}
+          <div class="flex-1 min-w-0">
+            <p class="font-medium text-gray-800 truncate text-[11px]">{{ item.subject }}</p>
+            <p class="text-gray-400 truncate">{{ item.client_name }}{% if item.policy_type %} · {{ item.policy_type }}{% endif %}</p>
+            <div class="flex gap-2 mt-0.5">
+              <span class="text-[10px] text-red-600">{{ item.days_overdue }}d overdue</span>
+              {% if item.days_to_renewal is not none %}
+              <span class="text-[10px] {% if item.days_to_renewal <= 3 %}text-red-600 font-medium{% elif item.days_to_renewal <= 7 %}text-amber-600{% else %}text-gray-400{% endif %}">
+                {% if item.days_to_renewal <= 0 %}Expired{% else %}Exp {{ item.days_to_renewal }}d{% endif %}
+              </span>
+              {% endif %}
+            </div>
+          </div>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+  {% endif %}
   {% for col in columns %}
   <div class="card overflow-hidden" data-date="{{ col.date }}"
     ondragover="event.preventDefault();this.classList.add('ring-2','ring-marsh')"
@@ -83,6 +132,8 @@
             </div>
             {% if item.pinned and item.days_to_renewal is not none %}
             <p class="text-red-500 text-[10px]">{{ item.days_to_renewal }}d to renewal</p>
+            {% elif item.days_to_renewal is not none and item.days_to_renewal <= 7 %}
+            <p class="text-[10px] {% if item.days_to_renewal <= 0 %}text-red-600 font-medium{% elif item.days_to_renewal <= 3 %}text-amber-600 font-medium{% else %}text-amber-500{% endif %}">{% if item.days_to_renewal <= 0 %}Expired{% else %}Exp in {{ item.days_to_renewal }}d{% endif %}</p>
             {% endif %}
             {% if item.milestone_name %}
             <p class="text-[10px] text-gray-400 truncate">{{ item.milestone_name }}</p>
@@ -176,7 +227,9 @@ function runSpread() {
       }
     });
     updateCounts();
-    document.getElementById('spread-msg').textContent = data.count + ' item(s) would be moved';
+    var msg = data.count + ' item(s) would be moved';
+    if (data.from_backlog > 0) msg += ' (' + data.from_backlog + ' from overdue backlog)';
+    document.getElementById('spread-msg').textContent = msg;
     document.getElementById('spread-preview').classList.remove('hidden');
   });
 }

--- a/src/policydb/web/templates/settings/_tab_workflow.html
+++ b/src/policydb/web/templates/settings/_tab_workflow.html
@@ -25,6 +25,19 @@
     </form>
   </div>
 
+  {# Expiration Buffer #}
+  <div class="card p-5" id="section-expiration-buffer">
+    <h2 class="font-semibold text-gray-900 text-sm mb-1">Follow-Up Expiration Buffer</h2>
+    <p class="text-xs text-gray-400 mb-3">When a disposition auto-calculates a follow-up date, cap it this many days before policy expiration. Prevents follow-ups from landing on or after the expiration date.</p>
+    <form method="post" action="/settings/config/expiration-buffer" class="flex items-center gap-3">
+      <label class="text-sm font-medium text-gray-700 whitespace-nowrap">Buffer (days before expiration)</label>
+      <input type="number" name="value" value="{{ followup_expiration_buffer_days }}"
+             min="1" max="30" class="w-20 rounded border-gray-300 text-sm px-2 py-1">
+      <button type="submit" class="text-sm text-blue-600 hover:underline">Save</button>
+      <span class="text-xs text-gray-400">e.g. 3 = follow-up capped 3 days before expiration</span>
+    </form>
+  </div>
+
   {# Simple lists #}
   <div class="border-t border-gray-200 pt-6 mt-2">
     <p class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-4">Dropdown Lists</p>


### PR DESCRIPTION
## Summary
- **Follow-up date capping**: Disposition auto-calculated dates are now capped 3 days before policy expiration (configurable in Settings). Prevents follow-ups from landing on or after expiration — the original bug where "Waiting on Colleague" (+5d) would schedule a follow-up on the expiration date itself.
- **Expiry warning badges**: "Past expiry" (red) and "Exp in Xd" (amber) badges on all follow-up rows in Action Center and Plan Week, including manual date entry warnings.
- **Plan Week overdue backlog**: New 6th column shows overdue items sorted by expiration urgency with drag-to-distribute. Spread algorithm extended with expiration-aware priority. "Plan Catch-Up" button on Stale/Overdue section headers.
- **Bug fix**: Suggested activity "Set" button ID mismatch (`suggested-actions-` → `sug-actions-`).

## Test plan
- [ ] Select "Waiting on Colleague" on a policy expiring in 5 days — date should cap to exp-3d, not today+5d
- [ ] Verify "Past expiry" badge on rows where follow-up date >= expiration
- [ ] Verify "Capped — expires {date}" amber indicator appears on compressed dates
- [ ] Test +1d/+3d/+7d shortcuts respect expiration cap
- [ ] Test Plan Week shows overdue backlog column with drag support
- [ ] Test Spread button distributes overdue items with expiration priority
- [ ] Verify Settings > Workflow shows "Follow-Up Expiration Buffer" card (default: 3)
- [ ] Verify dashboard loads (no program_carriers crash after rebase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)