### PR TITLE
fix: promote umbrella sub-coverage ghost rows even without limit_amount

### DIFF
--- a/src/policydb/charts.py
+++ b/src/policydb/charts.py
@@ -360,21 +360,22 @@ def get_tower_data(conn: sqlite3.Connection, client_id: int) -> list[dict]:
         for entry in grp["underlying"]:
             subs = entry.pop("_sub_coverages", None)
             if subs:
-                subs_with_limits = [s for s in subs if s.get("limit_amount")]
                 # Separate excess-type sub-coverages from underlying-type
-                excess_subs = [s for s in subs_with_limits if _is_excess_sub_cov(s.get("coverage_type", ""))]
+                excess_subs = [s for s in subs if _is_excess_sub_cov(s.get("coverage_type", ""))]
+                subs_with_limits = [s for s in subs if s.get("limit_amount")]
                 underlying_subs = [s for s in subs_with_limits if not _is_excess_sub_cov(s.get("coverage_type", ""))]
 
-                # Promote excess-type sub-coverages to the layers list
+                # Promote excess-type sub-coverages to the layers list (even without limit)
                 for sc in excess_subs:
+                    sc_lim = sc.get("limit_amount") or 0
                     sc_att = sc.get("attachment_point") or 0
                     grp["layers"].append({
                         "policy_type": sc["coverage_type"],
                         "carrier": entry["carrier"],
-                        "limit": sc["limit_amount"],
+                        "limit": sc_lim,
                         "attachment_point": sc_att,
                         "participation_of": None,
-                        "notation": _layer_notation(sc["limit_amount"], sc_att, None),
+                        "notation": _layer_notation(sc_lim, sc_att, None) if sc_lim else "",
                         "layer_position": "Umbrella" if "umbrella" in (sc["coverage_type"] or "").lower() else "Excess",
                         "is_umbrella": "umbrella" in (sc["coverage_type"] or "").lower(),
                         "premium": 0,

--- a/src/policydb/web/routes/programs.py
+++ b/src/policydb/web/routes/programs.py
@@ -170,16 +170,18 @@ def program_tab_schematic(
         p["is_package_ghost"] = bool(subs)
 
     # Promote umbrella/excess sub-coverages from underlying packages to excess
+    # Note: promote even if limit_amount is not yet set — the ghost row should appear
+    # so users can see the sub-coverage in the schematic and fill in details later
     _EXCESS_SC_KEYWORDS = ("umbrella", "excess")
     for p in list(underlying):
         for sc in p.get("sub_coverages_full", []):
             sc_type = (sc.get("coverage_type") or "").lower()
-            if any(kw in sc_type for kw in _EXCESS_SC_KEYWORDS) and sc.get("limit_amount"):
+            if any(kw in sc_type for kw in _EXCESS_SC_KEYWORDS):
                 excess.append({
                     "id": p["id"], "policy_uid": p["policy_uid"],
                     "policy_type": sc["coverage_type"], "carrier": p.get("carrier") or "",
                     "policy_number": p.get("policy_number") or "",
-                    "limit_amount": sc["limit_amount"], "deductible": sc.get("deductible") or 0,
+                    "limit_amount": sc.get("limit_amount") or 0, "deductible": sc.get("deductible") or 0,
                     "premium": 0, "coverage_form": sc.get("coverage_form") or "",
                     "layer_position": "Umbrella" if "umbrella" in sc_type else "Excess",
                     "attachment_point": sc.get("attachment_point") or 0,


### PR DESCRIPTION
## Summary
- Removed the `limit_amount` gate from umbrella/excess sub-coverage promotion logic in both the schematic tab (`programs.py`) and tower chart (`charts.py`)
- Ghost rows now appear immediately when an umbrella sub-coverage is added to a package policy, showing `$0` until the user fills in the limit
- Handles NULL `limit_amount` safely with fallback to 0

## Test plan
- [ ] Add an "Umbrella / Excess" sub-coverage to a GL package policy **without** setting a limit
- [ ] Navigate to program schematic tab — ghost row should appear with PKG badge and `$0` limit
- [ ] Fill in the limit on the sub-coverage — ghost row should update to show the value
- [ ] Verify Schematic Preview chart still renders correctly
- [ ] Verify Overview tab still displays sub-coverages

🤖 Generated with [Claude Code](https://claude.com/claude-code)