### PR TITLE
fix: schematic coverage lines and ghost row edits

### DIFF
--- a/src/policydb/web/routes/programs.py
+++ b/src/policydb/web/routes/programs.py
@@ -179,14 +179,16 @@ def program_tab_schematic(
             if any(kw in sc_type for kw in _EXCESS_SC_KEYWORDS):
                 excess.append({
                     "id": p["id"], "policy_uid": p["policy_uid"],
-                    "policy_type": sc["coverage_type"], "carrier": p.get("carrier") or "",
-                    "policy_number": p.get("policy_number") or "",
+                    "policy_type": sc["coverage_type"],
+                    "carrier": sc.get("carrier") or p.get("carrier") or "",
+                    "policy_number": sc.get("policy_number") or p.get("policy_number") or "",
                     "limit_amount": sc.get("limit_amount") or 0, "deductible": sc.get("deductible") or 0,
-                    "premium": 0, "coverage_form": sc.get("coverage_form") or "",
+                    "premium": sc.get("premium") or 0, "coverage_form": sc.get("coverage_form") or "",
                     "layer_position": "Umbrella" if "umbrella" in sc_type else "Excess",
                     "attachment_point": sc.get("attachment_point") or 0,
-                    "participation_of": None, "schematic_column": None,
+                    "participation_of": sc.get("participation_of"), "schematic_column": None,
                     "is_program": 0, "tower_group": tg,
+                    "package_parent_type": p.get("policy_type") or "",
                     "is_package_ghost": True, "sub_coverages": [], "sub_coverages_full": [],
                     "_from_sub_coverage": True, "_sub_coverage_id": sc["id"],
                 })
@@ -212,12 +214,30 @@ def program_tab_schematic(
         for cr in cov_rows:
             coverage_map.setdefault(cr["excess_policy_id"], []).append(dict(cr))
 
-    # Available tower lines for coverage selector
-    tower_lines = conn.execute(
-        "SELECT * FROM program_tower_lines WHERE program_id = ?",
-        (program_id,),
-    ).fetchall()
-    available_lines = [dict(tl) for tl in tower_lines]
+    # Build available tower lines dynamically from underlying policies + subcoverages
+    available_lines = []
+    for p in underlying:
+        if p.get("is_program"):
+            continue
+        # Add the policy itself as a line
+        available_lines.append({
+            "policy_id": p["id"],
+            "sub_coverage_id": None,
+            "label": p.get("policy_type") or p.get("policy_uid") or "Unknown",
+        })
+        # Add non-excess/umbrella subcoverages as separate lines
+        for sc in p.get("sub_coverages_full", []):
+            sc_type = (sc.get("coverage_type") or "").lower()
+            if not any(kw in sc_type for kw in _EXCESS_SC_KEYWORDS):
+                available_lines.append({
+                    "policy_id": p["id"],
+                    "sub_coverage_id": sc["id"],
+                    "label": sc.get("coverage_type") or "Sub-coverage",
+                })
+
+    # Attach covered_lines from coverage_map to each excess row
+    for p in excess:
+        p["covered_lines"] = coverage_map.get(p["id"], [])
 
     # Unassigned policies
     unassigned = get_unassigned_policies(conn, client_id)
@@ -461,6 +481,38 @@ async def patch_excess_cell_v2(request: Request, program_uid: str, policy_id: in
     row = conn.execute("SELECT limit_amount, attachment_point, participation_of FROM policies WHERE id = ?",
                        (policy_id,)).fetchone()
     notation = _layer_notation(row["limit_amount"], row["attachment_point"], row["participation_of"]) if row else ""
+    return JSONResponse({"ok": True, "formatted": display_value, "notation": notation})
+
+
+@router.patch("/programs/{program_uid}/subcoverage/{sc_id}/cell")
+async def patch_subcoverage_cell(request: Request, program_uid: str, sc_id: int,
+                                 conn: sqlite3.Connection = Depends(get_db)):
+    """Patch a sub-coverage field from the schematic excess matrix (ghost rows)."""
+    _get_program_or_404(conn, program_uid)
+    body = await request.json()
+    field, value = body.get("field", ""), body.get("value", "")
+    _SC_ALLOWED = {"limit_amount", "deductible", "attachment_point", "premium",
+                   "participation_of", "carrier", "policy_number", "coverage_form"}
+    if field not in _SC_ALLOWED:
+        return JSONResponse({"ok": False, "error": f"Field '{field}' not allowed"}, status_code=400)
+    if field in _CURRENCY_FIELDS:
+        val, formatted, err = _parse_and_format_currency(value)
+        if err:
+            return JSONResponse({"ok": False, "error": err}, status_code=400)
+        db_value, display_value = val, formatted
+    else:
+        db_value = display_value = str(value).strip() if value else ""
+    conn.execute(f"UPDATE policy_sub_coverages SET {field} = ? WHERE id = ?",
+                 (db_value, sc_id))
+    conn.commit()
+    sc = conn.execute("SELECT limit_amount, attachment_point, participation_of FROM policy_sub_coverages WHERE id = ?",
+                      (sc_id,)).fetchone()
+    notation = ""
+    if sc:
+        lim = sc["limit_amount"] or 0
+        att = sc["attachment_point"] or 0
+        po = sc["participation_of"]
+        notation = _layer_notation(lim, att, po) if lim else ""
     return JSONResponse({"ok": True, "formatted": display_value, "notation": notation})
 
 

--- a/src/policydb/web/templates/programs/_excess_row.html
+++ b/src/policydb/web/templates/programs/_excess_row.html
@@ -1,6 +1,8 @@
 {% set is_umb = p.layer_position and 'umbrella' in p.layer_position.lower() %}
-{% set is_pkg = p.is_package_ghost is defined and p.is_package_ghost %}
-<tr data-row-id="{{ p.id }}" class="matrix-row hover:bg-gray-50 transition-colors {{ 'bg-blue-50' if is_umb and not is_pkg }}{{ ' border-l-2 border-l-indigo-400' if is_pkg }}">
+{% set is_pkg = p._from_sub_coverage is defined and p._from_sub_coverage %}
+{% set _sc_id = p._sub_coverage_id if is_pkg else '' %}
+{% set _row_id = 'sc-' ~ _sc_id if _sc_id else p.id %}
+<tr data-row-id="{{ _row_id }}" class="matrix-row hover:bg-gray-50 transition-colors {{ 'bg-blue-50' if is_umb and not is_pkg }}{{ ' border-l-2 border-l-indigo-400' if is_pkg }}">
   <td class="px-2 py-2 text-xs text-gray-400 font-mono">{{ layer_num }}</td>
   <td class="px-2 py-2">
     {% if is_pkg %}
@@ -12,7 +14,7 @@
     {% endif %}
   </td>
   <td class="px-3 py-2 text-sm text-gray-800 matrix-cell-editable"
-      data-field="carrier" data-placeholder="carrier" contenteditable="true">{{ p.carrier or '' }}{% if is_pkg %}<div class="text-[10px] text-indigo-500 italic" contenteditable="false">via {{ p.package_parent_type }}</div>{% endif %}</td>
+      data-field="carrier" data-placeholder="carrier" contenteditable="true">{{ p.carrier or '' }}{% if is_pkg %}<div class="text-[10px] text-indigo-500 italic" contenteditable="false">via {{ p.package_parent_type or p.policy_type or '' }}</div>{% endif %}</td>
   <td class="px-3 py-2 text-sm text-gray-800 text-right tabular-nums matrix-cell-editable"
       data-field="limit_amount" data-placeholder="$0" contenteditable="true">{% if p.limit_amount %}${{ '{:,.0f}'.format(p.limit_amount) }}{% endif %}</td>
   <td class="px-3 py-2 text-sm text-gray-800 text-right tabular-nums matrix-cell-editable"

--- a/src/policydb/web/templates/programs/_tab_schematic.html
+++ b/src/policydb/web/templates/programs/_tab_schematic.html
@@ -76,7 +76,11 @@
     tbodyId: 'excess-tbody',
     idAttr: 'data-row-id',
     rowClass: 'matrix-row',
-    patchUrl: function(id) { return _base + '/excess/' + id + '/cell'; },
+    patchUrl: function(id) {
+      var s = String(id);
+      if (s.indexOf('sc-') === 0) return _base + '/subcoverage/' + s.substring(3) + '/cell';
+      return _base + '/excess/' + id + '/cell';
+    },
     addRowUrl: _base + '/excess/add',
     emptyRowId: 'excess-empty',
     onSaved: function(rowEl, field, resp) {


### PR DESCRIPTION
## Summary
- **Coverage toggle buttons (Covers column) were always empty** — `program_tower_lines` table was never populated (zero INSERT statements in codebase). Replaced static table query with dynamic generation from underlying policies + subcoverages.
- **covered_lines not attached to excess rows** — template expected `p.covered_lines` but only top-level `coverage_map` dict was passed as context.
- **Ghost row (PKG) edits saved to wrong table** — editing limit/carrier/etc on a promoted umbrella subcoverage row updated the parent policy instead of `policy_sub_coverages`. Added new `/subcoverage/{sc_id}/cell` endpoint and routed ghost rows via `sc-{id}` row IDs.
- **Ghost row "via" label** — added `package_parent_type` to promotion code so PKG rows show "via General Liability Package" instead of empty.

## Test plan
- [x] Navigate to PGM-001 schematic — verify all excess rows show coverage toggle pills
- [x] Verify PKG ghost row (row 11) shows $4M limit and "via General Liability Package"
- [x] PATCH `/programs/PGM-001/subcoverage/7/cell` with limit_amount — verify `policy_sub_coverages` updated, not parent policy
- [x] Verify parent policy limit unchanged after ghost row edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)