### PR TITLE
fix: tower chart, AI import, and Fill Blitz bugs

### DIFF
--- a/src/policydb/db.py
+++ b/src/policydb/db.py
@@ -362,7 +362,7 @@ def init_db(path: Path | None = None) -> None:
     # Back up the database once before running any pending migrations.
     # This gives a clean restore point regardless of which migration fails.
 
-    _KNOWN_MIGRATIONS = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110}
+    _KNOWN_MIGRATIONS = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111}
 
     if _KNOWN_MIGRATIONS - applied:
         _backup_db(conn, db_path)
@@ -1538,8 +1538,8 @@ def init_db(path: Path | None = None) -> None:
         conn.commit()
         logger.info("Migration 110: added review_override_reason columns")
 
-    if current_version < 111:
-        _run_sql_file(conn, "111_fix_layer_position.sql")
+    if 111 not in applied:
+        conn.executescript((_MIGRATIONS_DIR / "111_fix_layer_position.sql").read_text())
         conn.execute(
             "INSERT INTO schema_version (version, description) VALUES (?, ?)",
             (111, "Fix invalid layer_position values to Primary"),

--- a/src/policydb/web/routes/data_health.py
+++ b/src/policydb/web/routes/data_health.py
@@ -115,15 +115,23 @@ def blitz_save(
     if field not in valid_fields:
         return JSONResponse({"error": "Invalid field"}, status_code=400)
 
+    save_value = value.strip()
+    # Parse currency fields through the standard parser
+    if field in ("premium", "limit_amount", "deductible", "attachment_point"):
+        from policydb.utils import parse_currency_with_magnitude
+        parsed = parse_currency_with_magnitude(save_value)
+        if parsed is not None:
+            save_value = parsed
+
     if table == "policies":
         conn.execute(
             f"UPDATE policies SET {field} = ? WHERE policy_uid = ?",
-            (value.strip(), record_id),
+            (save_value, record_id),
         )
     else:
         conn.execute(
             f"UPDATE clients SET {field} = ? WHERE id = ?",
-            (value.strip(), int(record_id)),
+            (save_value, int(record_id)),
         )
     conn.commit()
 

--- a/src/policydb/web/routes/policies.py
+++ b/src/policydb/web/routes/policies.py
@@ -1539,6 +1539,20 @@ def _ai_import_parse_inner(request: Request, conn, uid: str, result: dict):
             _tower_layers.append(dict(tr) | {"ground_up": ground_up, "is_current": tr["policy_uid"] == uid})
 
     logger.debug("AI import parse inner: rendering _tab_details.html template")
+
+    # Follow-up date contextual badge
+    follow_up_delta = None
+    follow_up_overdue = False
+    if merged.get("follow_up_date"):
+        try:
+            fu = date.fromisoformat(merged["follow_up_date"])
+            follow_up_delta = (fu - date.today()).days
+            follow_up_overdue = follow_up_delta < 0
+        except (ValueError, TypeError):
+            pass
+
+    _exp_ctx = _exposure_card_context(conn, merged)
+
     html = templates.TemplateResponse("policies/_tab_details.html", {
         "request": request,
         "policy": merged,
@@ -1551,6 +1565,9 @@ def _ai_import_parse_inner(request: Request, conn, uid: str, result: dict):
         "tower_layers": _tower_layers,
         "cycle_labels": _RCL,
         "sub_coverages": _get_sub_coverages(conn, merged["id"]),
+        "follow_up_delta": follow_up_delta,
+        "follow_up_overdue": follow_up_overdue,
+        **_exp_ctx,
         "program_linked_policies": [],
         "linkable_policies": [],
         "program_carrier_rows": [],
@@ -2164,7 +2181,7 @@ def policy_tab_details(request: Request, policy_uid: str, conn=Depends(get_db)):
 @router.get("/{policy_uid}/tab/activity", response_class=HTMLResponse)
 def policy_tab_activity(request: Request, policy_uid: str, conn=Depends(get_db)):
     uid = policy_uid.upper()
-    policy_dict, _ = _policy_base(conn, uid)
+    policy_dict, _client_info = _policy_base(conn, uid)
     if not policy_dict:
         return HTMLResponse("Not found", status_code=404)
 
@@ -2267,6 +2284,9 @@ def policy_tab_activity(request: Request, policy_uid: str, conn=Depends(get_db))
         "dispositions": cfg.get("follow_up_dispositions", []),
         "linked_meetings": linked_meetings,
         "linked_decisions": linked_decisions,
+        "client": _client_info,
+        "issue_severities": cfg.get("issue_severities", []),
+        "all_clients": [{"id": _client_info["id"], "name": _client_info["name"]}],
     })
 
 
@@ -2529,6 +2549,8 @@ def policy_tab_pulse(
         "mailto_subject": _renew_mailto_subject(conn, policy_uid),
         "today": _today.isoformat(),
         "days_since_review": days_since_review,
+        "issue_severities": cfg.get("issue_severities", []),
+        "all_clients": [{"id": client_info["id"], "name": client_info["name"]}],
     })
 
 

--- a/src/policydb/web/templates/charts/_chart_tower.html
+++ b/src/policydb/web/templates/charts/_chart_tower.html
@@ -172,26 +172,34 @@
       });
 
       // ── Primary blocks — positioned by dollar value on Y-axis ──
-      // Find tallest non-statutory primary for WC sizing reference
-      var maxNonStatTopY = towerBottom;
+      // Find tallest element in this tower group for WC sizing reference
+      // (must exceed umbrella/excess top, not just primary peers)
+      var tallestTopY = towerBottom;
       under.forEach(function(u) {
         if (!u.is_statutory) {
           var top = valToY(u.limit || 0);
-          if (top < maxNonStatTopY) maxNonStatTopY = top;
+          if (top < tallestTopY) tallestTopY = top;
         }
       });
+      layers.forEach(function(l) {
+        var layerTopVal = (l.attachment_point || 0) + (l.limit || 0);
+        var top = valToY(layerTopVal);
+        if (top < tallestTopY) tallestTopY = top;
+      });
+
+      var ARROW_H = 14; // height reserved for upward arrows above statutory block
 
       under.forEach(function(u, ci) {
         var cx = curX + ci * colW;
         var lim = u.limit || 0;
-        var ARROW_H = 12; // height reserved for upward arrows on statutory
 
         var blockBottom = towerBottom; // all primaries start at $0
         var blockTop;
         if (u.is_statutory) {
-          // Statutory (WC): slightly taller than tallest non-statutory + arrows at top
-          blockTop = maxNonStatTopY - 30; // 30px taller than tallest peer
-          if (blockTop > towerBottom - MIN_BLOCK_H) blockTop = towerBottom - MIN_BLOCK_H - 30;
+          // Statutory (WC): taller than everything else in the group
+          // Block ends below the arrows — arrows sit on top
+          blockTop = tallestTopY - 20 - ARROW_H;
+          if (blockTop > towerBottom - MIN_BLOCK_H - ARROW_H) blockTop = towerBottom - MIN_BLOCK_H - ARROW_H;
         } else {
           blockTop = valToY(lim);
           if (blockBottom - blockTop < MIN_BLOCK_H) blockTop = blockBottom - MIN_BLOCK_H;
@@ -202,22 +210,23 @@
         g.append('rect').attr('x', cx).attr('y', blockTop).attr('width', colW).attr('height', pH)
           .attr('fill', C.primary).attr('stroke', C.primaryBd).attr('stroke-width', 0.5);
 
-        // Statutory: upward arrows at top indicating "continues"
+        // Statutory: upward arrows ABOVE the block indicating "continues"
         if (u.is_statutory) {
           var arrowMidX = cx + colW / 2;
-          var arrowY = blockTop + 3;
-          // Three small upward chevrons
+          var arrowBaseY = blockTop; // arrows sit on top of the block
+          // Three small upward chevrons above the block
           [-colW*0.2, 0, colW*0.2].forEach(function(offset) {
             var ax = arrowMidX + offset;
+            var ay = arrowBaseY - 4; // small gap above block
             g.append('path')
-              .attr('d', 'M' + (ax-5) + ',' + (arrowY+6) + ' L' + ax + ',' + arrowY + ' L' + (ax+5) + ',' + (arrowY+6))
+              .attr('d', 'M' + (ax-5) + ',' + ay + ' L' + ax + ',' + (ay-8) + ' L' + (ax+5) + ',' + ay)
               .attr('fill', 'none').attr('stroke', C.primaryBd).attr('stroke-width', 1.5)
               .attr('stroke-linecap', 'round');
           });
         }
 
-        // Carrier
-        var textY = u.is_statutory ? blockTop + ARROW_H + pH/2 - ARROW_H/2 - 3 : blockTop + pH/2 - 3;
+        // Carrier — centered in block (arrows are now outside)
+        var textY = blockTop + pH/2 - 3;
         g.append('text').attr('x', cx + colW/2).attr('y', textY)
           .attr('text-anchor', 'middle').style('font-size', '9px').style('font-weight', '600')
           .attr('fill', C.textDk).text(tr(u.carrier, 16));
@@ -235,7 +244,7 @@
 
         // Package badge ("via BOP", "via WC")
         if (u.is_package && u.package_parent_type) {
-          g.append('text').attr('x', cx + colW - 3).attr('y', blockTop + (u.is_statutory ? ARROW_H + 3 : 9))
+          g.append('text').attr('x', cx + colW - 3).attr('y', blockTop + 9)
             .attr('text-anchor', 'end').style('font-size', '6px').style('font-style', 'italic')
             .attr('fill', C.pkgBadge).text('via ' + tr(u.package_parent_type, 12));
         }


### PR DESCRIPTION
## Summary
- **Tower chart**: WC statutory bar now extends above umbrella/excess layers; carets positioned above the block instead of inside it
- **AI import**: Added missing `follow_up_delta`, `follow_up_overdue`, and exposure card context — fixes "follow_up_delta undefined" error when pasting JSON
- **Fill Blitz**: Currency fields parsed through `parse_currency_with_magnitude()` before saving — fixes nonresponsive save for opportunity estimated premium
- **Migration 111**: Wired into `_KNOWN_MIGRATIONS` set

## Test plan
- [ ] Verify tower chart WC bar extends above umbrella layer with carets on top
- [ ] Verify AI import parse works without errors on any policy
- [ ] Verify Fill Blitz Save & Next works for opportunity premium fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)