### PR TITLE
feat: Knowledge Base for institutional knowledge

### DIFF
--- a/src/policydb/config.py
+++ b/src/policydb/config.py
@@ -170,6 +170,16 @@ _DEFAULTS: dict[str, Any] = {
     ],
     "renewal_issue_window_days": 120,
     "renewal_issue_health_threshold": "at_risk",
+    # ── Knowledge Base ────────────────────────────────────────────────
+    "kb_categories": [
+        "Glossary",
+        "Procedure",
+        "Coverage",
+        "Carrier Intel",
+        "Underwriting",
+        "Claims",
+        "General",
+    ],
     # ── Anomaly detection ──────────────────────────────────────────────
     "anomaly_thresholds": {
         "renewal_not_started_days": 60,

--- a/src/policydb/db.py
+++ b/src/policydb/db.py
@@ -362,7 +362,7 @@ def init_db(path: Path | None = None) -> None:
     # Back up the database once before running any pending migrations.
     # This gives a clean restore point regardless of which migration fails.
 
-    _KNOWN_MIGRATIONS = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111}
+    _KNOWN_MIGRATIONS = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112}
 
     if _KNOWN_MIGRATIONS - applied:
         _backup_db(conn, db_path)
@@ -1547,6 +1547,15 @@ def init_db(path: Path | None = None) -> None:
         conn.commit()
         logger.info("Migration 111: fixed invalid layer_position values")
 
+    if 112 not in applied:
+        conn.executescript((_MIGRATIONS_DIR / "112_knowledge_base.sql").read_text())
+        conn.execute(
+            "INSERT INTO schema_version (version, description) VALUES (?, ?)",
+            (112, "Create knowledge base tables: articles, documents, attachments, record links"),
+        )
+        conn.commit()
+        logger.info("Migration 112: created knowledge base tables")
+
     # Data hygiene: fix 'None' string corruption in text fields (runs every startup, fast no-op if clean)
     conn.execute("UPDATE clients SET cn_number = NULL WHERE cn_number = 'None'")
 
@@ -2059,6 +2068,38 @@ def next_program_uid(conn: sqlite3.Connection) -> str:
     except (IndexError, ValueError):
         n = 1
     return f"PGM-{n:03d}"
+
+
+def next_kb_article_uid(conn: sqlite3.Connection) -> str:
+    """Generate next KB-NNN uid."""
+    row = conn.execute(
+        "SELECT uid FROM kb_articles WHERE uid LIKE 'KB-%' "
+        "ORDER BY CAST(SUBSTR(uid, 4) AS INTEGER) DESC LIMIT 1"
+    ).fetchone()
+    if row is None:
+        return "KB-001"
+    last = row["uid"]
+    try:
+        n = int(last.split("-")[1]) + 1
+    except (IndexError, ValueError):
+        n = 1
+    return f"KB-{n:03d}"
+
+
+def next_kb_document_uid(conn: sqlite3.Connection) -> str:
+    """Generate next KBD-NNN uid."""
+    row = conn.execute(
+        "SELECT uid FROM kb_documents WHERE uid LIKE 'KBD-%' "
+        "ORDER BY CAST(SUBSTR(uid, 5) AS INTEGER) DESC LIMIT 1"
+    ).fetchone()
+    if row is None:
+        return "KBD-001"
+    last = row["uid"]
+    try:
+        n = int(last.split("-")[1]) + 1
+    except (IndexError, ValueError):
+        n = 1
+    return f"KBD-{n:03d}"
 
 
 def generate_issue_uid() -> str:

--- a/src/policydb/migrations/112_knowledge_base.sql
+++ b/src/policydb/migrations/112_knowledge_base.sql
@@ -1,0 +1,71 @@
+-- Knowledge Base: articles, documents, attachments, record links
+
+CREATE TABLE IF NOT EXISTS kb_articles (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    uid         TEXT    NOT NULL UNIQUE,
+    title       TEXT    NOT NULL,
+    category    TEXT    NOT NULL DEFAULT 'General',
+    content     TEXT    NOT NULL DEFAULT '',
+    source      TEXT    NOT NULL DEFAULT 'authored',
+    tags        TEXT,
+    created_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TRIGGER IF NOT EXISTS kb_articles_updated_at
+AFTER UPDATE ON kb_articles
+BEGIN
+    UPDATE kb_articles SET updated_at = CURRENT_TIMESTAMP WHERE id = NEW.id;
+END;
+
+CREATE INDEX IF NOT EXISTS idx_kb_articles_category ON kb_articles(category);
+CREATE INDEX IF NOT EXISTS idx_kb_articles_uid ON kb_articles(uid);
+
+CREATE TABLE IF NOT EXISTS kb_documents (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    uid         TEXT    NOT NULL UNIQUE,
+    title       TEXT    NOT NULL,
+    category    TEXT    NOT NULL DEFAULT 'General',
+    filename    TEXT    NOT NULL,
+    file_path   TEXT    NOT NULL,
+    file_size   INTEGER NOT NULL DEFAULT 0,
+    mime_type   TEXT    NOT NULL DEFAULT 'application/pdf',
+    description TEXT,
+    tags        TEXT,
+    created_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TRIGGER IF NOT EXISTS kb_documents_updated_at
+AFTER UPDATE ON kb_documents
+BEGIN
+    UPDATE kb_documents SET updated_at = CURRENT_TIMESTAMP WHERE id = NEW.id;
+END;
+
+CREATE INDEX IF NOT EXISTS idx_kb_documents_category ON kb_documents(category);
+CREATE INDEX IF NOT EXISTS idx_kb_documents_uid ON kb_documents(uid);
+
+CREATE TABLE IF NOT EXISTS kb_attachments (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    article_id  INTEGER NOT NULL REFERENCES kb_articles(id) ON DELETE CASCADE,
+    document_id INTEGER NOT NULL REFERENCES kb_documents(id) ON DELETE CASCADE,
+    sort_order  INTEGER NOT NULL DEFAULT 0,
+    added_at    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(article_id, document_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_kb_attach_article ON kb_attachments(article_id);
+CREATE INDEX IF NOT EXISTS idx_kb_attach_document ON kb_attachments(document_id);
+
+CREATE TABLE IF NOT EXISTS kb_record_links (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    entry_type  TEXT    NOT NULL,
+    entry_id    INTEGER NOT NULL,
+    entity_type TEXT    NOT NULL,
+    entity_id   INTEGER NOT NULL,
+    linked_at   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(entry_type, entry_id, entity_type, entity_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_kb_links_entry ON kb_record_links(entry_type, entry_id);
+CREATE INDEX IF NOT EXISTS idx_kb_links_entity ON kb_record_links(entity_type, entity_id);

--- a/src/policydb/queries.py
+++ b/src/policydb/queries.py
@@ -1270,7 +1270,28 @@ def full_text_search(conn: sqlite3.Connection, query: str) -> dict[str, list[sql
            WHERE (a.subject LIKE ? OR a.details LIKE ? OR a.contact_person LIKE ?)""",
         (pattern, pattern, pattern),
     ).fetchall()
-    return {"clients": clients, "policies": policies, "activities": activities}
+    # Knowledge base
+    kb_articles = conn.execute(
+        """SELECT uid, title, category, tags, updated_at
+           FROM kb_articles
+           WHERE title LIKE ? OR content LIKE ? OR tags LIKE ?
+           ORDER BY updated_at DESC LIMIT 10""",
+        (pattern, pattern, pattern),
+    ).fetchall()
+    kb_documents = conn.execute(
+        """SELECT uid, title, category, filename, tags, updated_at
+           FROM kb_documents
+           WHERE title LIKE ? OR description LIKE ? OR filename LIKE ? OR tags LIKE ?
+           ORDER BY updated_at DESC LIMIT 10""",
+        (pattern, pattern, pattern, pattern),
+    ).fetchall()
+    return {
+        "clients": clients,
+        "policies": policies,
+        "activities": activities,
+        "kb_articles": kb_articles,
+        "kb_documents": kb_documents,
+    }
 
 
 # ─── REVIEW QUERIES ───────────────────────────────────────────────────────────

--- a/src/policydb/web/app.py
+++ b/src/policydb/web/app.py
@@ -312,7 +312,7 @@ def get_db() -> Generator[sqlite3.Connection, None, None]:
 
 
 # ── Register routers ──────────────────────────────────────────────────────────
-from policydb.web.routes import dashboard, clients, policies, activities, settings, reconcile, templates as tpl_routes, contacts, review, briefing, meetings, inbox, ref_lookup, compliance, action_center, logs, compose, import_history, geocoder as geocoder_routes, charts as charts_routes, programs as programs_routes, exports as exports_routes, issues as issues_routes, data_health as data_health_routes, anomalies as anomalies_routes  # noqa: E402
+from policydb.web.routes import dashboard, clients, policies, activities, settings, reconcile, templates as tpl_routes, contacts, review, briefing, meetings, inbox, ref_lookup, compliance, action_center, logs, compose, import_history, geocoder as geocoder_routes, charts as charts_routes, programs as programs_routes, exports as exports_routes, issues as issues_routes, data_health as data_health_routes, anomalies as anomalies_routes, kb as kb_routes  # noqa: E402
 
 app.include_router(dashboard.router)
 app.include_router(clients.router)
@@ -339,6 +339,7 @@ app.include_router(programs_routes.router)
 app.include_router(exports_routes.router)
 app.include_router(issues_routes.router)
 app.include_router(anomalies_routes.router)
+app.include_router(kb_routes.router)
 
 # Static files (charts JS/CSS assets)
 STATIC_DIR = Path(__file__).parent / "static"

--- a/src/policydb/web/routes/dashboard.py
+++ b/src/policydb/web/routes/dashboard.py
@@ -241,7 +241,7 @@ def search(request: Request, q: str = "", conn=Depends(get_db)):
     total = sum(len(v) for v in results.values())
     # Detect UID pattern for ref tree banner
     uid_pattern = bool(re.match(
-        r'^(CN?\d{5,}|POL-|COR-\d+|INB-\d+|A-\d+|CN?\d+-RFI\d+)',
+        r'^(CN?\d{5,}|POL-|COR-\d+|INB-\d+|A-\d+|CN?\d+-RFI\d+|KB-|KBD-)',
         q.strip(), re.IGNORECASE
     )) if q.strip() else False
     return templates.TemplateResponse("search.html", {

--- a/src/policydb/web/routes/kb.py
+++ b/src/policydb/web/routes/kb.py
@@ -1,0 +1,791 @@
+"""Knowledge Base routes — articles, documents, attachments, record links."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import shutil
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, File, Form, Query, Request, UploadFile
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse
+
+import policydb.config as cfg
+from policydb.db import DB_PATH, next_kb_article_uid, next_kb_document_uid
+from policydb.web.app import get_db, templates
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/kb")
+
+_KB_FILES_DIR = Path.home() / ".policydb" / "files" / "kb" / "docs"
+
+_ALLOWED_EXTENSIONS = {".pdf", ".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx"}
+
+_MIME_MAP = {
+    ".pdf": "application/pdf",
+    ".doc": "application/msword",
+    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ".xls": "application/vnd.ms-excel",
+    ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ".ppt": "application/vnd.ms-powerpoint",
+    ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+}
+
+# Max upload size: 50 MB
+_MAX_UPLOAD_BYTES = 50 * 1024 * 1024
+
+# Category color map for templates
+CATEGORY_COLORS = {
+    "Glossary": {"bg": "bg-blue-50", "text": "text-blue-700", "border_hex": "#3b82f6"},
+    "Procedure": {"bg": "bg-green-50", "text": "text-green-700", "border_hex": "#22c55e"},
+    "Coverage": {"bg": "bg-purple-50", "text": "text-purple-700", "border_hex": "#a855f7"},
+    "Carrier Intel": {"bg": "bg-amber-50", "text": "text-amber-700", "border_hex": "#f59e0b"},
+    "Underwriting": {"bg": "bg-teal-50", "text": "text-teal-700", "border_hex": "#14b8a6"},
+    "Claims": {"bg": "bg-red-50", "text": "text-red-700", "border_hex": "#ef4444"},
+    "General": {"bg": "bg-gray-100", "text": "text-gray-600", "border_hex": "#9ca3af"},
+}
+
+_DEFAULT_COLORS = {"bg": "bg-gray-100", "text": "text-gray-600", "border_hex": "#9ca3af"}
+
+
+def _get_colors(category: str) -> dict:
+    return CATEGORY_COLORS.get(category, _DEFAULT_COLORS)
+
+
+def _parse_tags(tags_str: str | None) -> list[str]:
+    if not tags_str:
+        return []
+    try:
+        return json.loads(tags_str)
+    except (json.JSONDecodeError, TypeError):
+        return []
+
+
+def _sanitize_filename(name: str, max_len: int = 100) -> str:
+    name = re.sub(r'[/\\:*?"<>|]', '_', name)
+    name = re.sub(r'\s+', '_', name).strip('_')
+    if len(name) > max_len:
+        base, ext = os.path.splitext(name)
+        name = base[:max_len - len(ext)] + ext
+    return name
+
+
+def _file_type_info(mime_type: str, filename: str) -> dict:
+    ext = os.path.splitext(filename)[1].lower()
+    if ext == ".pdf":
+        return {"icon": "pdf", "color": "text-red-500", "label": "PDF"}
+    elif ext in (".doc", ".docx"):
+        return {"icon": "word", "color": "text-blue-500", "label": "Word"}
+    elif ext in (".xls", ".xlsx"):
+        return {"icon": "excel", "color": "text-green-600", "label": "Excel"}
+    elif ext in (".ppt", ".pptx"):
+        return {"icon": "ppt", "color": "text-orange-500", "label": "PowerPoint"}
+    return {"icon": "file", "color": "text-gray-500", "label": "File"}
+
+
+def _format_file_size(size_bytes: int) -> str:
+    if size_bytes < 1024:
+        return f"{size_bytes} B"
+    elif size_bytes < 1024 * 1024:
+        return f"{size_bytes / 1024:.1f} KB"
+    else:
+        return f"{size_bytes / (1024 * 1024):.1f} MB"
+
+
+# ── Index ────────────────────────────────────────────────────────────────────
+
+@router.get("", response_class=HTMLResponse)
+async def kb_index(request: Request, conn=Depends(get_db)):
+    categories = cfg.get("kb_categories", [])
+    articles = conn.execute(
+        "SELECT * FROM kb_articles ORDER BY updated_at DESC"
+    ).fetchall()
+    documents = conn.execute(
+        "SELECT * FROM kb_documents ORDER BY updated_at DESC"
+    ).fetchall()
+
+    # Merge into unified list with type marker
+    entries = []
+    for a in articles:
+        d = dict(a)
+        d["entry_type"] = "article"
+        d["tags_list"] = _parse_tags(d.get("tags"))
+        d["colors"] = _get_colors(d["category"])
+        entries.append(d)
+    for doc in documents:
+        d = dict(doc)
+        d["entry_type"] = "document"
+        d["tags_list"] = _parse_tags(d.get("tags"))
+        d["colors"] = _get_colors(d["category"])
+        d["file_info"] = _file_type_info(d["mime_type"], d["filename"])
+        d["file_size_fmt"] = _format_file_size(d["file_size"])
+        entries.append(d)
+
+    entries.sort(key=lambda e: e.get("updated_at", ""), reverse=True)
+
+    return templates.TemplateResponse("kb/index.html", {
+        "request": request,
+        "entries": entries,
+        "categories": categories,
+        "category_colors": CATEGORY_COLORS,
+        "active": "kb",
+        "total_articles": len(articles),
+        "total_documents": len(documents),
+    })
+
+
+@router.get("/search", response_class=HTMLResponse)
+async def kb_search(
+    request: Request,
+    q: str = Query(""),
+    category: str = Query(""),
+    entry_type: str = Query(""),
+    conn=Depends(get_db),
+):
+    pattern = f"%{q}%"
+    entries = []
+
+    if entry_type != "document":
+        where = "WHERE (title LIKE ? OR content LIKE ? OR tags LIKE ?)"
+        params = [pattern, pattern, pattern]
+        if category:
+            where += " AND category = ?"
+            params.append(category)
+        articles = conn.execute(
+            f"SELECT * FROM kb_articles {where} ORDER BY updated_at DESC",
+            params,
+        ).fetchall()
+        for a in articles:
+            d = dict(a)
+            d["entry_type"] = "article"
+            d["tags_list"] = _parse_tags(d.get("tags"))
+            d["colors"] = _get_colors(d["category"])
+            entries.append(d)
+
+    if entry_type != "article":
+        where = "WHERE (title LIKE ? OR description LIKE ? OR filename LIKE ? OR tags LIKE ?)"
+        params = [pattern, pattern, pattern, pattern]
+        if category:
+            where += " AND category = ?"
+            params.append(category)
+        documents = conn.execute(
+            f"SELECT * FROM kb_documents {where} ORDER BY updated_at DESC",
+            params,
+        ).fetchall()
+        for doc in documents:
+            d = dict(doc)
+            d["entry_type"] = "document"
+            d["tags_list"] = _parse_tags(d.get("tags"))
+            d["colors"] = _get_colors(d["category"])
+            d["file_info"] = _file_type_info(d["mime_type"], d["filename"])
+            d["file_size_fmt"] = _format_file_size(d["file_size"])
+            entries.append(d)
+
+    entries.sort(key=lambda e: e.get("updated_at", ""), reverse=True)
+
+    return templates.TemplateResponse("kb/_search_results.html", {
+        "request": request,
+        "entries": entries,
+        "category_colors": CATEGORY_COLORS,
+    })
+
+
+# ── Articles CRUD ────────────────────────────────────────────────────────────
+
+@router.get("/articles/new", response_class=HTMLResponse)
+async def new_article_form(request: Request, conn=Depends(get_db)):
+    categories = cfg.get("kb_categories", [])
+    return templates.TemplateResponse("kb/article_new.html", {
+        "request": request,
+        "categories": categories,
+        "active": "kb",
+    })
+
+
+@router.post("/articles/new")
+async def create_article(
+    request: Request,
+    title: str = Form(""),
+    category: str = Form("General"),
+    content: str = Form(""),
+    source: str = Form("authored"),
+    conn=Depends(get_db),
+):
+    uid = next_kb_article_uid(conn)
+    conn.execute(
+        "INSERT INTO kb_articles (uid, title, category, content, source, tags) VALUES (?, ?, ?, ?, ?, ?)",
+        (uid, title or "Untitled", category, content, source, "[]"),
+    )
+    conn.commit()
+    logger.info("KB article created: %s — %s", uid, title)
+    return RedirectResponse(f"/kb/articles/{uid}", status_code=303)
+
+
+@router.get("/articles/{uid}", response_class=HTMLResponse)
+async def article_detail(request: Request, uid: str, conn=Depends(get_db)):
+    article = conn.execute("SELECT * FROM kb_articles WHERE uid = ?", (uid,)).fetchone()
+    if not article:
+        return RedirectResponse("/kb", status_code=303)
+
+    article = dict(article)
+    article["tags_list"] = _parse_tags(article.get("tags"))
+    article["colors"] = _get_colors(article["category"])
+
+    # Attachments
+    attachments = conn.execute("""
+        SELECT d.*, ka.id as attach_id FROM kb_attachments ka
+        JOIN kb_documents d ON d.id = ka.document_id
+        WHERE ka.article_id = ?
+        ORDER BY ka.sort_order, ka.added_at
+    """, (article["id"],)).fetchall()
+    attach_list = []
+    for att in attachments:
+        d = dict(att)
+        d["file_info"] = _file_type_info(d["mime_type"], d["filename"])
+        d["file_size_fmt"] = _format_file_size(d["file_size"])
+        attach_list.append(d)
+
+    # Record links
+    record_links = _get_record_links(conn, "article", article["id"])
+
+    categories = cfg.get("kb_categories", [])
+
+    return templates.TemplateResponse("kb/article.html", {
+        "request": request,
+        "article": article,
+        "attachments": attach_list,
+        "record_links": record_links,
+        "categories": categories,
+        "category_colors": CATEGORY_COLORS,
+        "active": "kb",
+    })
+
+
+@router.post("/articles/{uid}/field")
+async def article_save_field(
+    request: Request,
+    uid: str,
+    conn=Depends(get_db),
+):
+    form = await request.form()
+    field = form.get("field", "")
+    value = form.get("value", "")
+
+    allowed = {"title", "category", "content", "source"}
+    if field not in allowed:
+        return JSONResponse({"ok": False, "error": "Invalid field"})
+
+    conn.execute(f"UPDATE kb_articles SET {field} = ? WHERE uid = ?", (value, uid))
+    conn.commit()
+    return JSONResponse({"ok": True, "formatted": value})
+
+
+@router.post("/articles/{uid}/tags")
+async def article_update_tags(
+    request: Request,
+    uid: str,
+    action: str = Form("add"),
+    tag: str = Form(""),
+    conn=Depends(get_db),
+):
+    article = conn.execute("SELECT id, tags FROM kb_articles WHERE uid = ?", (uid,)).fetchone()
+    if not article:
+        return JSONResponse({"ok": False})
+
+    tags = _parse_tags(article["tags"])
+    tag = tag.strip().lower()
+    if not tag:
+        return JSONResponse({"ok": False})
+
+    if action == "add" and tag not in tags:
+        tags.append(tag)
+    elif action == "remove" and tag in tags:
+        tags.remove(tag)
+
+    conn.execute("UPDATE kb_articles SET tags = ? WHERE uid = ?", (json.dumps(tags), uid))
+    conn.commit()
+
+    article_dict = dict(article)
+    article_dict["tags_list"] = tags
+    return templates.TemplateResponse("kb/_tags.html", {
+        "request": request,
+        "entry": article_dict,
+        "entry_type": "article",
+        "uid": uid,
+    })
+
+
+@router.post("/articles/{uid}/delete")
+async def delete_article(uid: str, conn=Depends(get_db)):
+    article = conn.execute("SELECT id FROM kb_articles WHERE uid = ?", (uid,)).fetchone()
+    if article:
+        conn.execute("DELETE FROM kb_attachments WHERE article_id = ?", (article["id"],))
+        conn.execute("DELETE FROM kb_record_links WHERE entry_type = 'article' AND entry_id = ?", (article["id"],))
+        conn.execute("DELETE FROM kb_articles WHERE id = ?", (article["id"],))
+        conn.commit()
+        logger.info("KB article deleted: %s", uid)
+    return RedirectResponse("/kb", status_code=303)
+
+
+# ── Documents CRUD ───────────────────────────────────────────────────────────
+
+@router.post("/documents/upload")
+async def upload_document(
+    request: Request,
+    file: UploadFile = File(...),
+    title: str = Form(""),
+    category: str = Form("General"),
+    conn=Depends(get_db),
+):
+    ext = os.path.splitext(file.filename or "")[1].lower()
+    if ext not in _ALLOWED_EXTENSIONS:
+        return RedirectResponse("/kb?error=invalid_type", status_code=303)
+
+    # Read file content
+    content = await file.read()
+    if len(content) > _MAX_UPLOAD_BYTES:
+        return RedirectResponse("/kb?error=too_large", status_code=303)
+
+    uid = next_kb_document_uid(conn)
+    safe_name = _sanitize_filename(file.filename or "document")
+    stored_name = f"{uid}_{safe_name}"
+
+    # Ensure directory exists
+    _KB_FILES_DIR.mkdir(parents=True, exist_ok=True)
+
+    file_path = _KB_FILES_DIR / stored_name
+    with open(file_path, "wb") as f:
+        f.write(content)
+
+    mime_type = _MIME_MAP.get(ext, "application/octet-stream")
+    display_title = title or os.path.splitext(file.filename or "Document")[0]
+
+    conn.execute(
+        "INSERT INTO kb_documents (uid, title, category, filename, file_path, file_size, mime_type, tags) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (uid, display_title, category, file.filename, str(file_path), len(content), mime_type, "[]"),
+    )
+    conn.commit()
+    logger.info("KB document uploaded: %s — %s (%s)", uid, display_title, _format_file_size(len(content)))
+    return RedirectResponse(f"/kb/documents/{uid}", status_code=303)
+
+
+@router.get("/documents/{uid}", response_class=HTMLResponse)
+async def document_detail(request: Request, uid: str, conn=Depends(get_db)):
+    doc = conn.execute("SELECT * FROM kb_documents WHERE uid = ?", (uid,)).fetchone()
+    if not doc:
+        return RedirectResponse("/kb", status_code=303)
+
+    doc = dict(doc)
+    doc["tags_list"] = _parse_tags(doc.get("tags"))
+    doc["colors"] = _get_colors(doc["category"])
+    doc["file_info"] = _file_type_info(doc["mime_type"], doc["filename"])
+    doc["file_size_fmt"] = _format_file_size(doc["file_size"])
+
+    # Articles referencing this document
+    referencing = conn.execute("""
+        SELECT a.* FROM kb_attachments ka
+        JOIN kb_articles a ON a.id = ka.article_id
+        WHERE ka.document_id = ?
+        ORDER BY a.updated_at DESC
+    """, (doc["id"],)).fetchall()
+    referencing_articles = [dict(r) for r in referencing]
+    for r in referencing_articles:
+        r["colors"] = _get_colors(r["category"])
+
+    record_links = _get_record_links(conn, "document", doc["id"])
+    categories = cfg.get("kb_categories", [])
+
+    return templates.TemplateResponse("kb/document.html", {
+        "request": request,
+        "doc": doc,
+        "referencing_articles": referencing_articles,
+        "record_links": record_links,
+        "categories": categories,
+        "category_colors": CATEGORY_COLORS,
+        "active": "kb",
+    })
+
+
+@router.post("/documents/{uid}/field")
+async def document_save_field(
+    request: Request,
+    uid: str,
+    conn=Depends(get_db),
+):
+    form = await request.form()
+    field = form.get("field", "")
+    value = form.get("value", "")
+
+    allowed = {"title", "category", "description"}
+    if field not in allowed:
+        return JSONResponse({"ok": False, "error": "Invalid field"})
+
+    conn.execute(f"UPDATE kb_documents SET {field} = ? WHERE uid = ?", (value, uid))
+    conn.commit()
+    return JSONResponse({"ok": True, "formatted": value})
+
+
+@router.post("/documents/{uid}/tags")
+async def document_update_tags(
+    request: Request,
+    uid: str,
+    action: str = Form("add"),
+    tag: str = Form(""),
+    conn=Depends(get_db),
+):
+    doc = conn.execute("SELECT id, tags FROM kb_documents WHERE uid = ?", (uid,)).fetchone()
+    if not doc:
+        return JSONResponse({"ok": False})
+
+    tags = _parse_tags(doc["tags"])
+    tag = tag.strip().lower()
+    if not tag:
+        return JSONResponse({"ok": False})
+
+    if action == "add" and tag not in tags:
+        tags.append(tag)
+    elif action == "remove" and tag in tags:
+        tags.remove(tag)
+
+    conn.execute("UPDATE kb_documents SET tags = ? WHERE uid = ?", (json.dumps(tags), uid))
+    conn.commit()
+
+    doc_dict = dict(doc)
+    doc_dict["tags_list"] = tags
+    return templates.TemplateResponse("kb/_tags.html", {
+        "request": request,
+        "entry": doc_dict,
+        "entry_type": "document",
+        "uid": uid,
+    })
+
+
+@router.get("/documents/{uid}/download")
+async def document_download(uid: str, conn=Depends(get_db)):
+    doc = conn.execute("SELECT file_path, filename, mime_type FROM kb_documents WHERE uid = ?", (uid,)).fetchone()
+    if not doc:
+        return RedirectResponse("/kb", status_code=303)
+
+    file_path = Path(doc["file_path"])
+    if not file_path.exists():
+        return RedirectResponse("/kb", status_code=303)
+
+    return FileResponse(
+        path=str(file_path),
+        filename=doc["filename"],
+        media_type=doc["mime_type"],
+    )
+
+
+@router.post("/documents/{uid}/delete")
+async def delete_document(uid: str, conn=Depends(get_db)):
+    doc = conn.execute("SELECT id, file_path FROM kb_documents WHERE uid = ?", (uid,)).fetchone()
+    if doc:
+        # Remove file from disk
+        file_path = Path(doc["file_path"])
+        if file_path.exists():
+            file_path.unlink()
+        conn.execute("DELETE FROM kb_attachments WHERE document_id = ?", (doc["id"],))
+        conn.execute("DELETE FROM kb_record_links WHERE entry_type = 'document' AND entry_id = ?", (doc["id"],))
+        conn.execute("DELETE FROM kb_documents WHERE id = ?", (doc["id"],))
+        conn.commit()
+        logger.info("KB document deleted: %s", uid)
+    return RedirectResponse("/kb", status_code=303)
+
+
+# ── Attachments (article ↔ document) ─────────────────────────────────────────
+
+@router.post("/articles/{uid}/attach")
+async def attach_document(
+    request: Request,
+    uid: str,
+    document_id: int = Form(...),
+    conn=Depends(get_db),
+):
+    article = conn.execute("SELECT id FROM kb_articles WHERE uid = ?", (uid,)).fetchone()
+    if not article:
+        return JSONResponse({"ok": False})
+
+    try:
+        conn.execute(
+            "INSERT OR IGNORE INTO kb_attachments (article_id, document_id) VALUES (?, ?)",
+            (article["id"], document_id),
+        )
+        conn.commit()
+    except Exception:
+        pass
+
+    return await _render_attachments_partial(request, conn, uid, article["id"])
+
+
+@router.post("/articles/{uid}/upload-attach")
+async def upload_and_attach(
+    request: Request,
+    uid: str,
+    file: UploadFile = File(...),
+    category: str = Form("General"),
+    conn=Depends(get_db),
+):
+    article = conn.execute("SELECT id FROM kb_articles WHERE uid = ?", (uid,)).fetchone()
+    if not article:
+        return JSONResponse({"ok": False})
+
+    ext = os.path.splitext(file.filename or "")[1].lower()
+    if ext not in _ALLOWED_EXTENSIONS:
+        return JSONResponse({"ok": False, "error": "Invalid file type"})
+
+    content = await file.read()
+    if len(content) > _MAX_UPLOAD_BYTES:
+        return JSONResponse({"ok": False, "error": "File too large"})
+
+    doc_uid = next_kb_document_uid(conn)
+    safe_name = _sanitize_filename(file.filename or "document")
+    stored_name = f"{doc_uid}_{safe_name}"
+    _KB_FILES_DIR.mkdir(parents=True, exist_ok=True)
+
+    file_path = _KB_FILES_DIR / stored_name
+    with open(file_path, "wb") as f:
+        f.write(content)
+
+    mime_type = _MIME_MAP.get(ext, "application/octet-stream")
+    display_title = os.path.splitext(file.filename or "Document")[0]
+
+    conn.execute(
+        "INSERT INTO kb_documents (uid, title, category, filename, file_path, file_size, mime_type, tags) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (doc_uid, display_title, category, file.filename, str(file_path), len(content), mime_type, "[]"),
+    )
+    doc_row = conn.execute("SELECT id FROM kb_documents WHERE uid = ?", (doc_uid,)).fetchone()
+    conn.execute(
+        "INSERT OR IGNORE INTO kb_attachments (article_id, document_id) VALUES (?, ?)",
+        (article["id"], doc_row["id"]),
+    )
+    conn.commit()
+
+    return await _render_attachments_partial(request, conn, uid, article["id"])
+
+
+@router.post("/articles/{uid}/detach")
+async def detach_document(
+    request: Request,
+    uid: str,
+    document_id: int = Form(...),
+    conn=Depends(get_db),
+):
+    article = conn.execute("SELECT id FROM kb_articles WHERE uid = ?", (uid,)).fetchone()
+    if not article:
+        return JSONResponse({"ok": False})
+
+    conn.execute(
+        "DELETE FROM kb_attachments WHERE article_id = ? AND document_id = ?",
+        (article["id"], document_id),
+    )
+    conn.commit()
+
+    return await _render_attachments_partial(request, conn, uid, article["id"])
+
+
+async def _render_attachments_partial(request, conn, uid, article_id):
+    attachments = conn.execute("""
+        SELECT d.*, ka.id as attach_id FROM kb_attachments ka
+        JOIN kb_documents d ON d.id = ka.document_id
+        WHERE ka.article_id = ?
+        ORDER BY ka.sort_order, ka.added_at
+    """, (article_id,)).fetchall()
+    attach_list = []
+    for att in attachments:
+        d = dict(att)
+        d["file_info"] = _file_type_info(d["mime_type"], d["filename"])
+        d["file_size_fmt"] = _format_file_size(d["file_size"])
+        attach_list.append(d)
+
+    return templates.TemplateResponse("kb/_attachments.html", {
+        "request": request,
+        "attachments": attach_list,
+        "uid": uid,
+    })
+
+
+# ── Record Links ─────────────────────────────────────────────────────────────
+
+def _get_record_links(conn, entry_type: str, entry_id: int) -> list[dict]:
+    rows = conn.execute(
+        "SELECT * FROM kb_record_links WHERE entry_type = ? AND entry_id = ?",
+        (entry_type, entry_id),
+    ).fetchall()
+    links = []
+    for r in rows:
+        d = dict(r)
+        if d["entity_type"] == "client":
+            entity = conn.execute("SELECT id, name FROM clients WHERE id = ?", (d["entity_id"],)).fetchone()
+            if entity:
+                d["entity_name"] = entity["name"]
+                d["entity_url"] = f"/clients/{entity['id']}"
+        elif d["entity_type"] == "policy":
+            entity = conn.execute(
+                "SELECT p.id, p.policy_uid, p.policy_type, p.carrier, c.name as client_name "
+                "FROM policies p LEFT JOIN clients c ON c.id = p.client_id "
+                "WHERE p.id = ?", (d["entity_id"],)
+            ).fetchone()
+            if entity:
+                d["entity_name"] = f"{entity['policy_uid']} — {entity['carrier'] or ''} {entity['policy_type'] or ''}"
+                d["entity_url"] = f"/policies/{entity['policy_uid']}"
+        if "entity_name" in d:
+            links.append(d)
+    return links
+
+
+@router.post("/{entry_type}/{uid}/link")
+async def link_record(
+    request: Request,
+    entry_type: str,
+    uid: str,
+    entity_type: str = Form(...),
+    entity_id: int = Form(...),
+    conn=Depends(get_db),
+):
+    if entry_type == "article":
+        row = conn.execute("SELECT id FROM kb_articles WHERE uid = ?", (uid,)).fetchone()
+    else:
+        row = conn.execute("SELECT id FROM kb_documents WHERE uid = ?", (uid,)).fetchone()
+
+    if not row:
+        return JSONResponse({"ok": False})
+
+    try:
+        conn.execute(
+            "INSERT OR IGNORE INTO kb_record_links (entry_type, entry_id, entity_type, entity_id) VALUES (?, ?, ?, ?)",
+            (entry_type, row["id"], entity_type, entity_id),
+        )
+        conn.commit()
+    except Exception:
+        pass
+
+    record_links = _get_record_links(conn, entry_type, row["id"])
+    return templates.TemplateResponse("kb/_record_links_list.html", {
+        "request": request,
+        "record_links": record_links,
+        "entry_type": entry_type,
+        "uid": uid,
+    })
+
+
+@router.post("/{entry_type}/{uid}/unlink")
+async def unlink_record(
+    request: Request,
+    entry_type: str,
+    uid: str,
+    link_id: int = Form(...),
+    conn=Depends(get_db),
+):
+    conn.execute("DELETE FROM kb_record_links WHERE id = ?", (link_id,))
+    conn.commit()
+
+    if entry_type == "article":
+        row = conn.execute("SELECT id FROM kb_articles WHERE uid = ?", (uid,)).fetchone()
+    else:
+        row = conn.execute("SELECT id FROM kb_documents WHERE uid = ?", (uid,)).fetchone()
+
+    if not row:
+        return JSONResponse({"ok": False})
+
+    record_links = _get_record_links(conn, entry_type, row["id"])
+    return templates.TemplateResponse("kb/_record_links_list.html", {
+        "request": request,
+        "record_links": record_links,
+        "entry_type": entry_type,
+        "uid": uid,
+    })
+
+
+@router.get("/search-entities", response_class=HTMLResponse)
+async def search_entities(
+    request: Request,
+    q: str = Query(""),
+    conn=Depends(get_db),
+):
+    pattern = f"%{q}%"
+    clients = conn.execute(
+        "SELECT id, name FROM clients WHERE name LIKE ? ORDER BY name LIMIT 10",
+        (pattern,),
+    ).fetchall()
+    policies = conn.execute(
+        "SELECT p.id, p.policy_uid, p.policy_type, p.carrier, c.name as client_name "
+        "FROM policies p LEFT JOIN clients c ON c.id = p.client_id "
+        "WHERE p.policy_uid LIKE ? OR p.policy_type LIKE ? OR p.carrier LIKE ? OR c.name LIKE ? "
+        "ORDER BY p.policy_uid LIMIT 10",
+        (pattern, pattern, pattern, pattern),
+    ).fetchall()
+
+    return templates.TemplateResponse("kb/_entity_picker.html", {
+        "request": request,
+        "clients": [dict(c) for c in clients],
+        "policies": [dict(p) for p in policies],
+    })
+
+
+# ── KB links for client/policy pages ─────────────────────────────────────────
+
+@router.get("/for-entity/{entity_type}/{entity_id}", response_class=HTMLResponse)
+async def kb_links_for_entity(
+    request: Request,
+    entity_type: str,
+    entity_id: int,
+    conn=Depends(get_db),
+):
+    rows = conn.execute(
+        "SELECT * FROM kb_record_links WHERE entity_type = ? AND entity_id = ?",
+        (entity_type, entity_id),
+    ).fetchall()
+    links = []
+    for r in rows:
+        d = dict(r)
+        if d["entry_type"] == "article":
+            entry = conn.execute("SELECT uid, title, category FROM kb_articles WHERE id = ?", (d["entry_id"],)).fetchone()
+        else:
+            entry = conn.execute("SELECT uid, title, category FROM kb_documents WHERE id = ?", (d["entry_id"],)).fetchone()
+        if entry:
+            d["entry_uid"] = entry["uid"]
+            d["entry_title"] = entry["title"]
+            d["entry_category"] = entry["category"]
+            d["colors"] = _get_colors(entry["category"])
+            d["entry_url"] = f"/kb/{'articles' if d['entry_type'] == 'article' else 'documents'}/{entry['uid']}"
+            links.append(d)
+
+    return templates.TemplateResponse("kb/_entity_kb_links.html", {
+        "request": request,
+        "kb_links": links,
+        "entity_type": entity_type,
+        "entity_id": entity_id,
+    })
+
+
+# ── Document search (for attach picker) ─────────────────────────────────────
+
+@router.get("/search-documents", response_class=HTMLResponse)
+async def search_documents(
+    request: Request,
+    q: str = Query(""),
+    conn=Depends(get_db),
+):
+    pattern = f"%{q}%"
+    documents = conn.execute(
+        "SELECT id, uid, title, filename, mime_type FROM kb_documents "
+        "WHERE title LIKE ? OR filename LIKE ? ORDER BY updated_at DESC LIMIT 10",
+        (pattern, pattern),
+    ).fetchall()
+
+    results = []
+    for doc in documents:
+        d = dict(doc)
+        d["file_info"] = _file_type_info(d["mime_type"], d["filename"])
+        results.append(d)
+
+    return templates.TemplateResponse("kb/_document_picker.html", {
+        "request": request,
+        "documents": results,
+    })

--- a/src/policydb/web/routes/settings.py
+++ b/src/policydb/web/routes/settings.py
@@ -54,6 +54,7 @@ EDITABLE_LISTS: dict[str, str] = {
     "issue_root_cause_categories": "Issue Root Cause Categories",
     "account_priority_options": "Account Priority Options",
     "service_model_options": "Service Model Options",
+    "kb_categories": "KB Categories",
 }
 
 TAB_LISTS: dict[str, dict[str, str]] = {
@@ -107,6 +108,7 @@ TAB_LISTS: dict[str, dict[str, str]] = {
     "database": {
         "project_stages": "Project Stages",
         "project_types": "Project Types",
+        "kb_categories": "KB Categories",
     },
     "data-health": {},
     "anomalies": {},

--- a/src/policydb/web/templates/base.html
+++ b/src/policydb/web/templates/base.html
@@ -503,7 +503,7 @@
 
             <!-- Tools dropdown -->
             <div class="relative" onmouseenter="openNavDrop(this)" onmouseleave="closeNavDrop(this)">
-              <button class="nav-link flex items-center gap-1 {% if active in ['briefing','reconcile','templates','settings','ref-lookup','review','meetings','charts','manual-charts','exports'] %}bg-marsh-light border-b-2 border-[#c8a96e]{% endif %}">
+              <button class="nav-link flex items-center gap-1 {% if active in ['briefing','reconcile','templates','settings','ref-lookup','review','meetings','charts','manual-charts','exports','kb'] %}bg-marsh-light border-b-2 border-[#c8a96e]{% endif %}">
                 Tools
                 <svg class="w-3 h-3 opacity-60" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
               </button>
@@ -515,6 +515,7 @@
                 <a href="/briefing" class="block px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-100 {% if active == 'briefing' %}font-semibold text-marsh{% endif %}">Briefing</a>
                 <a href="/reconcile" class="block px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-100 {% if active == 'reconcile' %}font-semibold text-marsh{% endif %}">Reconcile</a>
                 <a href="/templates" class="block px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-100 {% if active == 'templates' %}font-semibold text-marsh{% endif %}">Templates</a>
+                <a href="/kb" class="block px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-100 {% if active == 'kb' %}font-semibold text-marsh{% endif %}">Knowledge Base</a>
                 <a href="/settings" class="block px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-100 {% if active == 'settings' %}font-semibold text-marsh{% endif %}">Settings</a>
                 <a href="/logs" class="block px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-100 {% if active == 'logs' %}font-semibold text-marsh{% endif %}">Logs</a>
                 <a href="/ref-lookup" class="block px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-100 {% if active == 'ref-lookup' %}font-semibold text-marsh{% endif %}">Ref Lookup</a>

--- a/src/policydb/web/templates/kb/_attachments.html
+++ b/src/policydb/web/templates/kb/_attachments.html
@@ -1,0 +1,49 @@
+{% if attachments %}
+<div class="space-y-1.5 mb-2">
+  {% for att in attachments %}
+  <div class="flex items-center gap-2 text-xs group">
+    <span class="{{ att.file_info.color }}">
+      <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20">
+        <path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z" clip-rule="evenodd"/>
+      </svg>
+    </span>
+    <a href="/kb/documents/{{ att.uid }}" class="text-gray-700 hover:text-marsh flex-1 min-w-0 truncate">{{ att.title }}</a>
+    <span class="text-[9px] text-gray-400">{{ att.file_size_fmt }}</span>
+    <a href="/kb/documents/{{ att.uid }}/download" class="text-gray-400 hover:text-marsh" title="Download">
+      <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+      </svg>
+    </a>
+    <button class="text-gray-400 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-opacity"
+            hx-post="/kb/articles/{{ uid }}/detach"
+            hx-vals='{"document_id":{{ att.id }}}'
+            hx-target="#attachments-container" hx-swap="innerHTML"
+            title="Detach">&times;</button>
+  </div>
+  {% endfor %}
+</div>
+{% else %}
+<p class="text-[9px] text-gray-400 italic mb-2">No attachments</p>
+{% endif %}
+
+<!-- Attach existing document -->
+<div class="relative">
+  <input type="search" placeholder="Search documents to attach..."
+         class="w-full text-xs border border-gray-200 rounded px-2 py-1.5 focus:ring-1 focus:ring-marsh outline-none"
+         hx-get="/kb/search-documents" hx-trigger="keyup changed delay:300ms"
+         hx-target="#doc-picker-results" name="q" id="attach-search-input">
+  <div id="doc-picker-results"></div>
+</div>
+
+<!-- Upload & attach -->
+<form action="/kb/articles/{{ uid }}/upload-attach" method="post" enctype="multipart/form-data" class="mt-1.5">
+  <label class="flex items-center gap-1 text-[10px] text-gray-500 hover:text-marsh cursor-pointer">
+    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+    </svg>
+    Upload & attach file
+    <input type="file" name="file" class="hidden" accept=".pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx"
+           onchange="this.closest('form').submit()">
+  </label>
+  <input type="hidden" name="category" value="General">
+</form>

--- a/src/policydb/web/templates/kb/_card.html
+++ b/src/policydb/web/templates/kb/_card.html
@@ -1,0 +1,65 @@
+{% set colors = entry.colors %}
+{% set is_doc = entry.entry_type == 'document' %}
+{% set url = '/kb/documents/' ~ entry.uid if is_doc else '/kb/articles/' ~ entry.uid %}
+
+<a href="{{ url }}" class="card block p-4 hover:shadow-md transition-shadow" style="border-left: 4px solid {{ colors.border_hex }}">
+  <!-- Row 1: UID + Title + Category + Timestamp -->
+  <div class="flex items-start gap-2 mb-1.5">
+    {% if is_doc %}
+    <!-- File type icon -->
+    <span class="{{ entry.file_info.color }} mt-0.5">
+      <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+        <path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z" clip-rule="evenodd"/>
+      </svg>
+    </span>
+    {% else %}
+    <!-- Article icon -->
+    <span class="text-marsh mt-0.5">
+      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+      </svg>
+    </span>
+    {% endif %}
+
+    <span class="text-[10px] font-mono bg-gray-100 text-gray-500 rounded px-1.5 py-0.5 flex-shrink-0">{{ entry.uid }}</span>
+
+    <span class="text-gray-900 font-semibold text-sm flex-1 min-w-0 truncate">{{ entry.title }}</span>
+
+    <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium {{ colors.bg }} {{ colors.text }} flex-shrink-0">
+      {{ entry.category }}
+    </span>
+
+    {% if is_doc %}
+    <span class="text-[10px] text-gray-400 flex-shrink-0">{{ entry.file_size_fmt }}</span>
+    {% endif %}
+
+    <span class="text-[10px] text-gray-400 flex-shrink-0 whitespace-nowrap">
+      {{ entry.updated_at[:10] if entry.updated_at else '' }}
+    </span>
+  </div>
+
+  <!-- Row 2: Preview text -->
+  {% if is_doc %}
+  <div class="text-xs text-gray-500 ml-6 mb-1.5 truncate">{{ entry.filename }}</div>
+  {% elif entry.content %}
+  <div class="text-xs text-gray-500 ml-6 mb-1.5 line-clamp-2">{{ entry.content[:200] | replace('\n', ' ') | replace('#', '') | truncate(150) }}</div>
+  {% endif %}
+
+  <!-- Row 3: Tags + Source -->
+  {% if entry.tags_list or entry.get('source') %}
+  <div class="flex items-center gap-1.5 ml-6">
+    {% for tag in entry.tags_list[:4] %}
+    <span class="text-[9px] px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-600 font-medium">{{ tag }}</span>
+    {% endfor %}
+    {% if entry.tags_list | length > 4 %}
+    <span class="text-[9px] text-gray-400">+{{ entry.tags_list | length - 4 }}</span>
+    {% endif %}
+
+    {% if entry.get('source') and entry.source != 'authored' %}
+    <span class="ml-auto text-[9px] px-1.5 py-0.5 rounded-full {% if entry.source == 'llm-assisted' %}bg-blue-50 text-blue-600{% else %}bg-amber-50 text-amber-600{% endif %} font-medium">
+      {{ entry.source }}
+    </span>
+    {% endif %}
+  </div>
+  {% endif %}
+</a>

--- a/src/policydb/web/templates/kb/_document_picker.html
+++ b/src/policydb/web/templates/kb/_document_picker.html
@@ -1,0 +1,18 @@
+{% if documents %}
+<div class="absolute z-20 left-0 right-0 mt-1 bg-white border border-gray-200 rounded-lg shadow-lg max-h-48 overflow-y-auto">
+  {% for doc in documents %}
+  <button type="button" class="w-full text-left px-3 py-1.5 text-xs text-gray-700 hover:bg-gray-50 flex items-center gap-2"
+          hx-post="/kb/articles/{{ uid }}/attach"
+          hx-vals='{"document_id":{{ doc.id }}}'
+          hx-target="#attachments-container" hx-swap="innerHTML">
+    <span class="{{ doc.file_info.color }}">
+      <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
+        <path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z" clip-rule="evenodd"/>
+      </svg>
+    </span>
+    <span class="font-mono text-[10px] text-gray-500">{{ doc.uid }}</span>
+    {{ doc.title }}
+  </button>
+  {% endfor %}
+</div>
+{% endif %}

--- a/src/policydb/web/templates/kb/_entity_kb_links.html
+++ b/src/policydb/web/templates/kb/_entity_kb_links.html
@@ -1,0 +1,23 @@
+{% if kb_links %}
+<div class="space-y-1.5">
+  {% for link in kb_links %}
+  <a href="{{ link.entry_url }}" class="flex items-center gap-2 text-xs text-gray-700 hover:text-marsh">
+    {% if link.entry_type == 'article' %}
+    <svg class="w-3.5 h-3.5 text-marsh flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+    </svg>
+    {% else %}
+    <svg class="w-3.5 h-3.5 text-red-500 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+      <path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z" clip-rule="evenodd"/>
+    </svg>
+    {% endif %}
+    <span class="flex-1 min-w-0 truncate">{{ link.entry_title }}</span>
+    <span class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[9px] font-medium {{ link.colors.bg }} {{ link.colors.text }} flex-shrink-0">
+      {{ link.entry_category }}
+    </span>
+  </a>
+  {% endfor %}
+</div>
+{% else %}
+<p class="text-[9px] text-gray-400 italic">No KB entries linked</p>
+{% endif %}

--- a/src/policydb/web/templates/kb/_entity_picker.html
+++ b/src/policydb/web/templates/kb/_entity_picker.html
@@ -1,0 +1,29 @@
+{% if clients or policies %}
+<div class="absolute z-20 left-0 right-0 mt-1 bg-white border border-gray-200 rounded-lg shadow-lg max-h-48 overflow-y-auto">
+  {% if clients %}
+  <div class="px-2 py-1 text-[9px] font-semibold text-gray-400 uppercase">Clients</div>
+  {% for c in clients %}
+  <button type="button" class="w-full text-left px-3 py-1.5 text-xs text-gray-700 hover:bg-gray-50 flex items-center gap-2"
+          onclick="linkEntity('client', {{ c.id }})">
+    <svg class="w-3 h-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/>
+    </svg>
+    {{ c.name }}
+  </button>
+  {% endfor %}
+  {% endif %}
+  {% if policies %}
+  <div class="px-2 py-1 text-[9px] font-semibold text-gray-400 uppercase {% if clients %}border-t border-gray-100{% endif %}">Policies</div>
+  {% for p in policies %}
+  <button type="button" class="w-full text-left px-3 py-1.5 text-xs text-gray-700 hover:bg-gray-50 flex items-center gap-2"
+          onclick="linkEntity('policy', {{ p.id }})">
+    <svg class="w-3 h-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+    </svg>
+    <span class="font-mono text-[10px] text-gray-500">{{ p.policy_uid }}</span>
+    {{ p.client_name or '' }} — {{ p.carrier or '' }} {{ p.policy_type or '' }}
+  </button>
+  {% endfor %}
+  {% endif %}
+</div>
+{% endif %}

--- a/src/policydb/web/templates/kb/_record_links_list.html
+++ b/src/policydb/web/templates/kb/_record_links_list.html
@@ -1,0 +1,25 @@
+{% if record_links %}
+<div class="space-y-1.5">
+  {% for link in record_links %}
+  <div class="flex items-center gap-2 text-xs group">
+    {% if link.entity_type == 'client' %}
+    <svg class="w-3.5 h-3.5 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/>
+    </svg>
+    {% else %}
+    <svg class="w-3.5 h-3.5 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+    </svg>
+    {% endif %}
+    <a href="{{ link.entity_url }}" class="text-gray-700 hover:text-marsh flex-1 min-w-0 truncate">{{ link.entity_name }}</a>
+    <button class="text-gray-400 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-opacity"
+            hx-post="/kb/{{ entry_type }}/{{ uid }}/unlink"
+            hx-vals='{"link_id":{{ link.id }}}'
+            hx-target="#record-links-container" hx-swap="innerHTML"
+            title="Unlink">&times;</button>
+  </div>
+  {% endfor %}
+</div>
+{% else %}
+<p class="text-[9px] text-gray-400 italic">No linked records</p>
+{% endif %}

--- a/src/policydb/web/templates/kb/_search_results.html
+++ b/src/policydb/web/templates/kb/_search_results.html
@@ -1,0 +1,15 @@
+{% if not entries %}
+<div class="text-center py-16">
+  <svg class="w-12 h-12 mx-auto text-gray-300 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/>
+  </svg>
+  <p class="text-gray-500 text-sm">No knowledge base entries yet.</p>
+  <p class="text-gray-400 text-xs mt-1">Create your first article or upload a reference document.</p>
+</div>
+{% else %}
+<div class="space-y-3">
+  {% for entry in entries %}
+  {% include "kb/_card.html" %}
+  {% endfor %}
+</div>
+{% endif %}

--- a/src/policydb/web/templates/kb/_tags.html
+++ b/src/policydb/web/templates/kb/_tags.html
@@ -1,0 +1,26 @@
+{% set tags_list = entry.tags_list if entry is defined else article.tags_list if article is defined else [] %}
+{% set et = entry_type if entry_type is defined else 'article' %}
+{% set u = uid if uid is defined else (entry.uid if entry is defined else article.uid if article is defined else '') %}
+
+<div class="flex flex-wrap gap-1 mb-2" id="tag-pills">
+  {% for tag in tags_list %}
+  <span class="inline-flex items-center text-[9px] px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-600 font-medium">
+    {{ tag }}
+    <button type="button" class="ml-0.5 text-gray-400 hover:text-red-500"
+            hx-post="/kb/{{ 'articles' if et == 'article' else 'documents' }}/{{ u }}/tags"
+            hx-vals='{"action":"remove","tag":"{{ tag }}"}'
+            hx-target="#tags-container" hx-swap="innerHTML">&times;</button>
+  </span>
+  {% endfor %}
+  {% if not tags_list %}
+  <span class="text-[9px] text-gray-400 italic">No tags</span>
+  {% endif %}
+</div>
+<form hx-post="/kb/{{ 'articles' if et == 'article' else 'documents' }}/{{ u }}/tags"
+      hx-target="#tags-container" hx-swap="innerHTML"
+      onsubmit="return true;">
+  <input type="hidden" name="action" value="add">
+  <input type="text" name="tag" placeholder="Add tag..."
+         class="w-full text-xs border border-gray-200 rounded px-2 py-1 focus:ring-1 focus:ring-marsh outline-none"
+         onkeydown="if(event.key==='Enter'){event.preventDefault(); htmx.trigger(this.closest('form'),'submit');}">
+</form>

--- a/src/policydb/web/templates/kb/article.html
+++ b/src/policydb/web/templates/kb/article.html
@@ -1,0 +1,175 @@
+{% extends "base.html" %}
+{% block title %}{{ article.title }} — Knowledge Base{% endblock %}
+
+{% block content %}
+<div class="max-w-6xl mx-auto">
+
+  <!-- Breadcrumb -->
+  <div class="mb-4 flex items-center gap-2 text-sm text-gray-400">
+    <a href="/kb" class="hover:text-marsh">Knowledge Base</a>
+    <span>&rsaquo;</span>
+    <span class="{{ article.colors.text }}">{{ article.category }}</span>
+    <span>&rsaquo;</span>
+    <span class="text-gray-600">{{ article.title }}</span>
+  </div>
+
+  <div class="lg:grid lg:grid-cols-[1fr_320px] gap-6">
+
+    <!-- Left: Content -->
+    <div>
+      <!-- Header -->
+      <div class="mb-4">
+        <div class="flex items-center gap-2 mb-2">
+          <span class="text-[10px] font-mono bg-gray-100 text-gray-500 rounded px-1.5 py-0.5">{{ article.uid }}</span>
+          {% if article.source != 'authored' %}
+          <span class="text-[9px] px-1.5 py-0.5 rounded-full {% if article.source == 'llm-assisted' %}bg-blue-50 text-blue-600{% else %}bg-amber-50 text-amber-600{% endif %} font-medium">
+            {{ article.source }}
+          </span>
+          {% endif %}
+        </div>
+
+        <!-- Title (contenteditable) -->
+        <div contenteditable="true"
+             class="text-2xl font-bold text-gray-900 outline-none focus:border-b-2 focus:border-marsh pb-1"
+             data-field="title" data-uid="{{ article.uid }}"
+             onblur="saveArticleField(this)">{{ article.title }}</div>
+
+        <!-- Category combobox -->
+        <div class="mt-2 flex items-center gap-2">
+          <span class="text-xs text-gray-400">Category:</span>
+          <select class="text-sm border-0 border-b border-gray-200 focus:border-marsh outline-none py-0.5 px-1 {{ article.colors.text }} font-medium bg-transparent"
+                  onchange="saveArticleFieldVal('{{ article.uid }}', 'category', this.value); location.reload();">
+            {% for cat in categories %}
+            <option value="{{ cat }}" {{ 'selected' if cat == article.category else '' }}>{{ cat }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      </div>
+
+      <!-- Content Editor -->
+      <div class="card p-4 mb-4">
+        <textarea id="article-content" name="content" rows="16"
+                  class="hidden">{{ article.content }}</textarea>
+        <div id="article-editor-wrapper"></div>
+      </div>
+
+      <!-- Delete -->
+      <div class="flex justify-end">
+        <button onclick="confirmDeleteArticle('{{ article.uid }}')" class="text-sm text-red-500 hover:text-red-700">
+          Delete Article
+        </button>
+      </div>
+    </div>
+
+    <!-- Right: Sidebar -->
+    <div class="hidden lg:block">
+      <div class="sticky top-4 space-y-4">
+
+        <!-- Tags -->
+        <div class="card p-3">
+          <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Tags</h3>
+          <div id="tags-container">
+            {% include "kb/_tags.html" with context %}
+          </div>
+        </div>
+
+        <!-- Attachments -->
+        <div class="card p-3">
+          <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Attachments</h3>
+          <div id="attachments-container">
+            {% include "kb/_attachments.html" %}
+          </div>
+        </div>
+
+        <!-- Linked Records -->
+        <div class="card p-3">
+          <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Linked Records</h3>
+          <div id="record-links-container">
+            {% with entry_type='article', uid=article.uid %}
+            {% include "kb/_record_links_list.html" %}
+            {% endwith %}
+          </div>
+          <!-- Link picker -->
+          <div class="mt-2">
+            <div class="relative">
+              <input type="search" placeholder="Search clients/policies..."
+                     class="w-full text-xs border border-gray-200 rounded px-2 py-1.5 focus:ring-1 focus:ring-marsh outline-none"
+                     hx-get="/kb/search-entities" hx-trigger="keyup changed delay:300ms"
+                     hx-target="#entity-picker-results" name="q">
+              <div id="entity-picker-results"></div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<script>
+/* Save contenteditable field */
+function saveArticleField(el) {
+  var field = el.getAttribute('data-field');
+  var uid = el.getAttribute('data-uid');
+  var value = el.innerText.trim();
+  fetch('/kb/articles/' + uid + '/field', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+    body: 'field=' + encodeURIComponent(field) + '&value=' + encodeURIComponent(value)
+  }).then(function(r) { return r.json(); }).then(function(d) {
+    if (d.ok && typeof flashCell === 'function') flashCell(el, '#d1fae5');
+  });
+}
+
+function saveArticleFieldVal(uid, field, value) {
+  fetch('/kb/articles/' + uid + '/field', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+    body: 'field=' + encodeURIComponent(field) + '&value=' + encodeURIComponent(value)
+  });
+}
+
+/* Markdown editor with auto-save */
+(function() {
+  var ta = document.getElementById('article-content');
+  if (!ta || typeof window.initMarkdownEditor !== 'function') return;
+
+  var editor = window.initMarkdownEditor('article-content', {minHeight: '300px'});
+  if (!editor) return;
+
+  var saveTimer;
+  editor.on('change', function() {
+    clearTimeout(saveTimer);
+    saveTimer = setTimeout(function() {
+      var content = editor.getMarkdown();
+      fetch('/kb/articles/{{ article.uid }}/field', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+        body: 'field=content&value=' + encodeURIComponent(content)
+      });
+    }, 800);
+  });
+})();
+
+/* Delete confirmation */
+function confirmDeleteArticle(uid) {
+  if (confirm('Delete this article? This cannot be undone.')) {
+    fetch('/kb/articles/' + uid + '/delete', { method: 'POST' })
+      .then(function() { window.location.href = '/kb'; });
+  }
+}
+
+/* Link entity from picker */
+function linkEntity(entityType, entityId) {
+  fetch('/kb/article/{{ article.uid }}/link', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+    body: 'entity_type=' + entityType + '&entity_id=' + entityId
+  }).then(function(r) { return r.text(); }).then(function(html) {
+    document.getElementById('record-links-container').innerHTML = html;
+    document.getElementById('entity-picker-results').innerHTML = '';
+  });
+}
+</script>
+{% endblock %}

--- a/src/policydb/web/templates/kb/article_new.html
+++ b/src/policydb/web/templates/kb/article_new.html
@@ -1,0 +1,58 @@
+{% extends "base.html" %}
+{% block title %}New Article — Knowledge Base{% endblock %}
+
+{% block content %}
+<div class="max-w-3xl mx-auto">
+  <div class="mb-4">
+    <a href="/kb" class="text-sm text-gray-400 hover:text-marsh">&larr; Knowledge Base</a>
+  </div>
+
+  <div class="card p-6">
+    <h1 class="text-xl font-bold text-gray-900 mb-5">New Article</h1>
+    <form action="/kb/articles/new" method="post">
+      <div class="mb-4">
+        <label class="block text-xs font-medium text-gray-500 mb-1">Title</label>
+        <input type="text" name="title" required autofocus placeholder="e.g. Marshall & Swift Report"
+               class="w-full border border-gray-300 rounded-lg px-3 py-2.5 text-base focus:ring-2 focus:ring-marsh focus:border-marsh outline-none">
+      </div>
+      <div class="grid grid-cols-2 gap-4 mb-4">
+        <div>
+          <label class="block text-xs font-medium text-gray-500 mb-1">Category</label>
+          <select name="category" class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-marsh focus:border-marsh outline-none">
+            {% for cat in categories %}
+            <option value="{{ cat }}">{{ cat }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div>
+          <label class="block text-xs font-medium text-gray-500 mb-1">Source</label>
+          <select name="source" class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-marsh focus:border-marsh outline-none">
+            <option value="authored">Authored</option>
+            <option value="llm-assisted">LLM-Assisted</option>
+            <option value="external">External</option>
+          </select>
+        </div>
+      </div>
+      <div class="mb-5">
+        <label class="block text-xs font-medium text-gray-500 mb-1">Content (Markdown)</label>
+        <textarea name="content" id="new-article-content" rows="12"
+                  placeholder="Paste or write your article content here..."
+                  class="w-full border border-gray-300 rounded-lg px-3 py-2.5 text-sm font-mono focus:ring-2 focus:ring-marsh focus:border-marsh outline-none resize-y"></textarea>
+      </div>
+      <div class="flex justify-end gap-2">
+        <a href="/kb" class="px-4 py-2 text-sm text-gray-600 hover:text-gray-900">Cancel</a>
+        <button type="submit" class="bg-marsh text-white rounded-lg px-5 py-2 text-sm font-medium hover:bg-marsh-light">Create Article</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<script>
+(function() {
+  var ta = document.getElementById('new-article-content');
+  if (ta && typeof window.initMarkdownEditor === 'function') {
+    window.initMarkdownEditor('new-article-content', {minHeight: '250px'});
+  }
+})();
+</script>
+{% endblock %}

--- a/src/policydb/web/templates/kb/document.html
+++ b/src/policydb/web/templates/kb/document.html
@@ -1,0 +1,223 @@
+{% extends "base.html" %}
+{% block title %}{{ doc.title }} — Knowledge Base{% endblock %}
+
+{% block content %}
+<div class="max-w-6xl mx-auto">
+
+  <!-- Breadcrumb -->
+  <div class="mb-4 flex items-center gap-2 text-sm text-gray-400">
+    <a href="/kb" class="hover:text-marsh">Knowledge Base</a>
+    <span>&rsaquo;</span>
+    <span class="{{ doc.colors.text }}">{{ doc.category }}</span>
+    <span>&rsaquo;</span>
+    <span class="text-gray-600">{{ doc.title }}</span>
+  </div>
+
+  <div class="lg:grid lg:grid-cols-[1fr_320px] gap-6">
+
+    <!-- Left: Content -->
+    <div>
+      <!-- Header -->
+      <div class="mb-4">
+        <div class="flex items-center gap-2 mb-2">
+          <span class="text-[10px] font-mono bg-gray-100 text-gray-500 rounded px-1.5 py-0.5">{{ doc.uid }}</span>
+          <span class="{{ doc.file_info.color }}">
+            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+              <path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z" clip-rule="evenodd"/>
+            </svg>
+          </span>
+          <span class="text-xs text-gray-400">{{ doc.file_info.label }}</span>
+        </div>
+
+        <!-- Title (contenteditable) -->
+        <div contenteditable="true"
+             class="text-2xl font-bold text-gray-900 outline-none focus:border-b-2 focus:border-marsh pb-1"
+             data-field="title" data-uid="{{ doc.uid }}"
+             onblur="saveDocField(this)">{{ doc.title }}</div>
+
+        <!-- Category -->
+        <div class="mt-2 flex items-center gap-2">
+          <span class="text-xs text-gray-400">Category:</span>
+          <select class="text-sm border-0 border-b border-gray-200 focus:border-marsh outline-none py-0.5 px-1 {{ doc.colors.text }} font-medium bg-transparent"
+                  onchange="saveDocFieldVal('{{ doc.uid }}', 'category', this.value); location.reload();">
+            {% for cat in categories %}
+            <option value="{{ cat }}" {{ 'selected' if cat == doc.category else '' }}>{{ cat }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      </div>
+
+      <!-- File info bar -->
+      <div class="card p-3 mb-4 flex items-center gap-4">
+        <span class="{{ doc.file_info.color }}">
+          <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20">
+            <path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z" clip-rule="evenodd"/>
+          </svg>
+        </span>
+        <div class="flex-1 min-w-0">
+          <div class="text-sm font-mono text-gray-600 truncate">{{ doc.filename }}</div>
+          <div class="text-xs text-gray-400">{{ doc.file_size_fmt }} &middot; Uploaded {{ doc.created_at[:10] if doc.created_at else '' }}</div>
+        </div>
+        <a href="/kb/documents/{{ doc.uid }}/download"
+           class="bg-marsh text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-marsh-light transition-colors flex items-center gap-1.5">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+          </svg>
+          Download
+        </a>
+      </div>
+
+      <!-- File preview -->
+      {% if doc.mime_type == 'application/pdf' %}
+      <div class="card mb-4 overflow-hidden">
+        <iframe src="/kb/documents/{{ doc.uid }}/download" class="w-full border-0" style="height:600px"></iframe>
+      </div>
+      {% else %}
+      <div class="card p-8 mb-4 text-center">
+        <span class="{{ doc.file_info.color }}">
+          <svg class="w-16 h-16 mx-auto mb-3" fill="currentColor" viewBox="0 0 20 20">
+            <path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z" clip-rule="evenodd"/>
+          </svg>
+        </span>
+        <p class="text-sm text-gray-500">{{ doc.file_info.label }} files cannot be previewed in the browser.</p>
+        <a href="/kb/documents/{{ doc.uid }}/download"
+           class="inline-block mt-3 bg-marsh text-white rounded-lg px-5 py-2 text-sm font-medium hover:bg-marsh-light">
+          Download to View
+        </a>
+      </div>
+      {% endif %}
+
+      <!-- Description editor -->
+      <div class="card p-4 mb-4">
+        <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Notes</h3>
+        <textarea id="doc-description" name="description" rows="6"
+                  class="hidden">{{ doc.description or '' }}</textarea>
+        <div id="doc-editor-wrapper"></div>
+      </div>
+
+      <!-- Referencing articles -->
+      {% if referencing_articles %}
+      <div class="card p-4 mb-4">
+        <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Referenced by Articles</h3>
+        <div class="space-y-1.5">
+          {% for art in referencing_articles %}
+          <a href="/kb/articles/{{ art.uid }}" class="flex items-center gap-2 text-sm text-gray-700 hover:text-marsh">
+            <span class="text-[10px] font-mono bg-gray-100 text-gray-500 rounded px-1.5 py-0.5">{{ art.uid }}</span>
+            {{ art.title }}
+            <span class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[9px] font-medium {{ art.colors.bg }} {{ art.colors.text }}">{{ art.category }}</span>
+          </a>
+          {% endfor %}
+        </div>
+      </div>
+      {% endif %}
+
+      <!-- Delete -->
+      <div class="flex justify-end">
+        <button onclick="confirmDeleteDoc('{{ doc.uid }}')" class="text-sm text-red-500 hover:text-red-700">
+          Delete Document
+        </button>
+      </div>
+    </div>
+
+    <!-- Right: Sidebar -->
+    <div class="hidden lg:block">
+      <div class="sticky top-4 space-y-4">
+
+        <!-- Tags -->
+        <div class="card p-3">
+          <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Tags</h3>
+          <div id="tags-container">
+            {% with entry=doc, entry_type='document', uid=doc.uid %}
+            {% include "kb/_tags.html" %}
+            {% endwith %}
+          </div>
+        </div>
+
+        <!-- Linked Records -->
+        <div class="card p-3">
+          <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Linked Records</h3>
+          <div id="record-links-container">
+            {% with entry_type='document', uid=doc.uid %}
+            {% include "kb/_record_links_list.html" %}
+            {% endwith %}
+          </div>
+          <div class="mt-2">
+            <div class="relative">
+              <input type="search" placeholder="Search clients/policies..."
+                     class="w-full text-xs border border-gray-200 rounded px-2 py-1.5 focus:ring-1 focus:ring-marsh outline-none"
+                     hx-get="/kb/search-entities" hx-trigger="keyup changed delay:300ms"
+                     hx-target="#entity-picker-results" name="q">
+              <div id="entity-picker-results"></div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<script>
+function saveDocField(el) {
+  var field = el.getAttribute('data-field');
+  var uid = el.getAttribute('data-uid');
+  var value = el.innerText.trim();
+  fetch('/kb/documents/' + uid + '/field', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+    body: 'field=' + encodeURIComponent(field) + '&value=' + encodeURIComponent(value)
+  }).then(function(r) { return r.json(); }).then(function(d) {
+    if (d.ok && typeof flashCell === 'function') flashCell(el, '#d1fae5');
+  });
+}
+
+function saveDocFieldVal(uid, field, value) {
+  fetch('/kb/documents/' + uid + '/field', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+    body: 'field=' + encodeURIComponent(field) + '&value=' + encodeURIComponent(value)
+  });
+}
+
+/* Markdown editor for description with auto-save */
+(function() {
+  var ta = document.getElementById('doc-description');
+  if (!ta || typeof window.initMarkdownEditor !== 'function') return;
+
+  var editor = window.initMarkdownEditor('doc-description', {minHeight: '160px'});
+  if (!editor) return;
+
+  var saveTimer;
+  editor.on('change', function() {
+    clearTimeout(saveTimer);
+    saveTimer = setTimeout(function() {
+      var content = editor.getMarkdown();
+      fetch('/kb/documents/{{ doc.uid }}/field', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+        body: 'field=description&value=' + encodeURIComponent(content)
+      });
+    }, 800);
+  });
+})();
+
+function confirmDeleteDoc(uid) {
+  if (confirm('Delete this document? The file will be removed from disk. This cannot be undone.')) {
+    fetch('/kb/documents/' + uid + '/delete', { method: 'POST' })
+      .then(function() { window.location.href = '/kb'; });
+  }
+}
+
+function linkEntity(entityType, entityId) {
+  fetch('/kb/document/{{ doc.uid }}/link', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+    body: 'entity_type=' + entityType + '&entity_id=' + entityId
+  }).then(function(r) { return r.text(); }).then(function(html) {
+    document.getElementById('record-links-container').innerHTML = html;
+    document.getElementById('entity-picker-results').innerHTML = '';
+  });
+}
+</script>
+{% endblock %}

--- a/src/policydb/web/templates/kb/index.html
+++ b/src/policydb/web/templates/kb/index.html
@@ -1,0 +1,116 @@
+{% extends "base.html" %}
+{% block title %}Knowledge Base{% endblock %}
+
+{% block content %}
+<div class="max-w-6xl mx-auto">
+
+  <!-- Header -->
+  <div class="flex items-center justify-between mb-5">
+    <div class="flex items-center gap-3">
+      <h1 class="text-2xl font-bold text-gray-900">Knowledge Base</h1>
+      <span class="text-xs text-gray-400 bg-gray-100 px-2 py-0.5 rounded-full">
+        {{ total_articles }} article{{ 's' if total_articles != 1 else '' }} &middot; {{ total_documents }} document{{ 's' if total_documents != 1 else '' }}
+      </span>
+    </div>
+    <div class="flex items-center gap-2">
+      <a href="/kb/articles/new" class="bg-marsh text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-marsh-light transition-colors">
+        + New Article
+      </a>
+      <button onclick="document.getElementById('upload-modal').classList.remove('hidden')"
+              class="border border-marsh text-marsh rounded-lg px-4 py-2 text-sm font-medium hover:bg-marsh/5 transition-colors">
+        Upload Document
+      </button>
+    </div>
+  </div>
+
+  <!-- Search + Filters -->
+  <div class="mb-5">
+    <div class="flex items-center gap-3 mb-3">
+      <div class="relative flex-1">
+        <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
+        </svg>
+        <input type="search" id="kb-search" placeholder="Search articles and documents..."
+               class="w-full pl-10 pr-4 py-2.5 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-marsh focus:border-marsh outline-none"
+               hx-get="/kb/search" hx-trigger="keyup changed delay:300ms" hx-target="#kb-results"
+               hx-include="#kb-filters" name="q">
+      </div>
+      <div id="kb-filters" class="flex items-center gap-2">
+        <!-- Type toggle -->
+        <button class="btn-filter active" data-type="" onclick="setTypeFilter(this, '')">All</button>
+        <button class="btn-filter" data-type="article" onclick="setTypeFilter(this, 'article')">Articles</button>
+        <button class="btn-filter" data-type="document" onclick="setTypeFilter(this, 'document')">Documents</button>
+        <input type="hidden" name="entry_type" id="kb-type-filter" value="">
+        <input type="hidden" name="category" id="kb-cat-filter" value="">
+      </div>
+    </div>
+
+    <!-- Category pills -->
+    <div class="flex items-center gap-1.5 flex-wrap">
+      <button class="rounded-full px-3 py-1 text-xs font-medium bg-marsh text-white"
+              onclick="setCatFilter(this, '')">All</button>
+      {% for cat in categories %}
+      {% set colors = category_colors.get(cat, {"bg": "bg-gray-100", "text": "text-gray-600"}) %}
+      <button class="rounded-full px-3 py-1 text-xs font-medium border border-gray-200 text-gray-600 hover:border-gray-400 transition-colors"
+              onclick="setCatFilter(this, '{{ cat }}')">{{ cat }}</button>
+      {% endfor %}
+    </div>
+  </div>
+
+  <!-- Results -->
+  <div id="kb-results">
+    {% include "kb/_search_results.html" %}
+  </div>
+
+</div>
+
+<!-- Upload Modal -->
+<div id="upload-modal" class="hidden fixed inset-0 bg-black/30 z-50 flex items-center justify-center" onclick="if(event.target===this)this.classList.add('hidden')">
+  <div class="bg-white rounded-xl shadow-xl w-full max-w-md p-6">
+    <h3 class="text-lg font-semibold text-gray-900 mb-4">Upload Document</h3>
+    <form action="/kb/documents/upload" method="post" enctype="multipart/form-data">
+      <div class="mb-3">
+        <label class="block text-xs font-medium text-gray-500 mb-1">File</label>
+        <input type="file" name="file" required accept=".pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx"
+               class="w-full text-sm border border-gray-300 rounded-lg px-3 py-2 file:mr-3 file:px-3 file:py-1 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-marsh/10 file:text-marsh">
+      </div>
+      <div class="mb-3">
+        <label class="block text-xs font-medium text-gray-500 mb-1">Title (optional — defaults to filename)</label>
+        <input type="text" name="title" placeholder="e.g. Hartford GL Appetite Guide"
+               class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-marsh focus:border-marsh outline-none">
+      </div>
+      <div class="mb-4">
+        <label class="block text-xs font-medium text-gray-500 mb-1">Category</label>
+        <select name="category" class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-marsh focus:border-marsh outline-none">
+          {% for cat in categories %}
+          <option value="{{ cat }}">{{ cat }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="flex justify-end gap-2">
+        <button type="button" onclick="document.getElementById('upload-modal').classList.add('hidden')"
+                class="px-4 py-2 text-sm text-gray-600 hover:text-gray-900">Cancel</button>
+        <button type="submit" class="bg-marsh text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-marsh-light">Upload</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<script>
+function setTypeFilter(btn, val) {
+  document.getElementById('kb-type-filter').value = val;
+  btn.closest('#kb-filters').querySelectorAll('.btn-filter').forEach(function(b) { b.classList.remove('active'); });
+  btn.classList.add('active');
+  htmx.trigger(document.getElementById('kb-search'), 'keyup');
+}
+function setCatFilter(btn, val) {
+  document.getElementById('kb-cat-filter').value = val;
+  var pills = btn.parentElement.querySelectorAll('button');
+  pills.forEach(function(p) {
+    p.className = 'rounded-full px-3 py-1 text-xs font-medium border border-gray-200 text-gray-600 hover:border-gray-400 transition-colors';
+  });
+  btn.className = 'rounded-full px-3 py-1 text-xs font-medium bg-marsh text-white';
+  htmx.trigger(document.getElementById('kb-search'), 'keyup');
+}
+</script>
+{% endblock %}

--- a/src/policydb/web/templates/search.html
+++ b/src/policydb/web/templates/search.html
@@ -61,6 +61,32 @@
 </div>
 {% endif %}
 
+{% if results.kb_articles or results.kb_documents %}
+<div class="bg-white rounded-xl border border-gray-200">
+  <div class="px-5 py-3 border-b border-gray-100 text-xs font-semibold text-gray-500 uppercase tracking-wide">Knowledge Base</div>
+  {% for r in results.kb_articles %}
+  <a href="/kb/articles/{{ r.uid }}" class="flex items-start gap-3 px-5 py-3 border-b border-gray-50 last:border-0 hover:bg-gray-50">
+    <span class="text-[10px] font-mono bg-gray-100 text-gray-500 rounded px-1.5 py-0.5 mt-0.5 shrink-0">{{ r.uid }}</span>
+    <div>
+      <span class="font-medium text-gray-800">{{ r.title }}</span>
+      <span class="text-gray-400 mx-1">&middot;</span>
+      <span class="text-xs text-gray-500">{{ r.category }}</span>
+    </div>
+  </a>
+  {% endfor %}
+  {% for r in results.kb_documents %}
+  <a href="/kb/documents/{{ r.uid }}" class="flex items-start gap-3 px-5 py-3 border-b border-gray-50 last:border-0 hover:bg-gray-50">
+    <span class="text-[10px] font-mono bg-gray-100 text-gray-500 rounded px-1.5 py-0.5 mt-0.5 shrink-0">{{ r.uid }}</span>
+    <div>
+      <span class="font-medium text-gray-800">{{ r.title }}</span>
+      <span class="text-gray-400 mx-1">&middot;</span>
+      <span class="text-xs text-gray-500">{{ r.filename }}</span>
+    </div>
+  </a>
+  {% endfor %}
+</div>
+{% endif %}
+
 {% if not total %}
 <div class="bg-white rounded-xl border border-gray-200 px-5 py-12 text-center text-gray-400">
   No results found for "{{ q }}".


### PR DESCRIPTION
## Summary
- New `/kb` page with articles (markdown) and documents (PDF/Office uploads)
- Category-coded cards with search, type/category filters, and tag system
- Bidirectional record linking between KB entries and clients/policies
- Global search integration — KB entries appear in `/search` results
- Migration 112: `kb_articles`, `kb_documents`, `kb_attachments`, `kb_record_links`
- KB Categories editable in Settings > Database & Admin

## Test plan
- [x] Create article with markdown content — verified KB-001 created
- [x] Add tags, link to client — verified pill display + entity picker
- [x] Category color-coded left borders on index cards
- [x] Global search returns KB entries
- [x] Settings shows editable KB Categories list
- [ ] Upload PDF/Office document and verify preview/download
- [ ] Test attachment linking between articles and documents

🤖 Generated with [Claude Code](https://claude.com/claude-code)