### PR TITLE
feat: program batch actions — editable grid, bulk renew

### DIFF
--- a/src/policydb/queries.py
+++ b/src/policydb/queries.py
@@ -2479,7 +2479,7 @@ def get_schematic_completeness(
                 checks = [
                     ("policy_type", bool(p.get("policy_type"))),
                     ("carrier", bool(p.get("carrier"))),
-                    ("deductible", bool(p.get("deductible") and str(p.get("deductible")) != "0")),
+                    ("deductible", p.get("deductible") is not None),
                 ]
                 for label, ok in checks:
                     total += 1
@@ -2615,7 +2615,8 @@ def get_program_child_policies(conn: sqlite3.Connection, program_id: int) -> lis
         """SELECT p.id, p.policy_uid, p.policy_type, p.carrier, p.policy_number,
                   p.premium, p.limit_amount, p.deductible, p.layer_position,
                   p.renewal_status, p.effective_date, p.expiration_date,
-                  p.attachment_point, p.participation_of, p.coverage_form
+                  p.attachment_point, p.participation_of, p.coverage_form,
+                  p.schematic_column
            FROM policies p
            WHERE p.program_id = ?
              AND p.archived = 0
@@ -2661,7 +2662,9 @@ def get_programs_for_client(conn: sqlite3.Connection, client_id: int) -> list[di
 def get_unassigned_policies(conn: sqlite3.Connection, client_id: int, exclude_program_id: int | None = None) -> list[dict]:
     """Return active policies not assigned to any program (or assigned to archived/missing programs)."""
     rows = conn.execute(
-        """SELECT p.policy_uid, p.policy_type, p.carrier, p.premium, p.limit_amount, p.program_id
+        """SELECT p.policy_uid, p.policy_type, p.carrier, p.premium, p.limit_amount,
+                  p.program_id, p.policy_number, p.effective_date, p.expiration_date,
+                  p.renewal_status, p.deductible
            FROM policies p
            WHERE p.client_id = ? AND p.archived = 0
              AND (p.is_opportunity = 0 OR p.is_opportunity IS NULL)

--- a/src/policydb/web/routes/charts.py
+++ b/src/policydb/web/routes/charts.py
@@ -483,12 +483,14 @@ async def deck_view(
 
     # Check tower completeness for warning banner
     tower_incomplete = None
+    tower_missing = []
     if any(cid.startswith("tower") for cid in selected_charts):
         from policydb.queries import get_schematic_completeness
         completeness = get_schematic_completeness(conn, client_id)
         for c in completeness:
             if c["pct_complete"] < 80:
                 tower_incomplete = c["tower_group"]
+                tower_missing = c.get("missing_fields", [])[:5]  # show up to 5
                 break
 
     return templates.TemplateResponse(
@@ -502,6 +504,7 @@ async def deck_view(
             "chart_titles": chart_titles,
             "chart_types": chart_types,
             "tower_incomplete": tower_incomplete,
+            "tower_missing": tower_missing,
         },
     )
 

--- a/src/policydb/web/routes/programs.py
+++ b/src/policydb/web/routes/programs.py
@@ -17,6 +17,7 @@ from policydb.queries import (
     get_program_by_uid, get_program_child_policies, get_program_aggregates,
     get_unassigned_policies,
     get_program_timeline_milestones, get_program_activities,
+    renew_policy,
 )
 from policydb.web.app import get_db, templates
 
@@ -122,6 +123,8 @@ def program_tab_overview(
         "unassigned": unassigned,
         "aggregates": agg,
         "renewal_statuses": cfg.get("renewal_statuses", []),
+        "policy_types": cfg.get("policy_types", []),
+        "carriers": cfg.get("carriers", []),
     })
 
 
@@ -145,7 +148,8 @@ def program_tab_schematic(
         """SELECT p.id, p.policy_uid, p.policy_type, p.carrier, p.policy_number,
                   p.limit_amount, p.deductible, p.premium, p.coverage_form,
                   p.layer_position, p.attachment_point, p.participation_of,
-                  p.schematic_column, p.is_program, p.tower_group
+                  p.schematic_column, p.is_program, p.tower_group,
+                  p.effective_date, p.expiration_date, p.renewal_status
            FROM policies p
            WHERE p.program_id = ?
              AND p.archived = 0
@@ -196,6 +200,9 @@ def program_tab_schematic(
                     "package_parent_type": p.get("policy_type") or "",
                     "is_package_ghost": True, "sub_coverages": [], "sub_coverages_full": [],
                     "_from_sub_coverage": True, "_sub_coverage_id": sc["id"],
+                    "effective_date": p.get("effective_date") or "",
+                    "expiration_date": p.get("expiration_date") or "",
+                    "renewal_status": p.get("renewal_status") or "",
                 })
 
     has_umbrella = any(p.get("layer_position") == "Umbrella" and not p.get("_from_sub_coverage") for p in excess)
@@ -421,10 +428,13 @@ def unassign_from_program_v2(
 # ---------------------------------------------------------------------------
 
 _CURRENCY_FIELDS = {"limit_amount", "deductible", "premium", "attachment_point", "participation_of"}
+_DATE_FIELDS = {"effective_date", "expiration_date"}
 _UNDERLYING_ALLOWED = {"policy_type", "carrier", "policy_number", "limit_amount",
-                       "deductible", "premium", "coverage_form"}
+                       "deductible", "premium", "coverage_form",
+                       "effective_date", "expiration_date", "renewal_status"}
 _EXCESS_ALLOWED = {"policy_type", "carrier", "policy_number", "limit_amount",
-                   "attachment_point", "participation_of", "premium", "coverage_form", "layer_position"}
+                   "attachment_point", "participation_of", "premium", "coverage_form", "layer_position",
+                   "effective_date", "expiration_date", "renewal_status"}
 
 
 def _parse_and_format_currency(raw: str):
@@ -458,6 +468,9 @@ async def patch_underlying_cell_v2(request: Request, program_uid: str, policy_id
         if err:
             return JSONResponse({"ok": False, "error": err}, status_code=400)
         db_value, display_value = val, formatted
+    elif field in _DATE_FIELDS:
+        db_value = str(value).strip() if value and str(value).strip() else None
+        display_value = db_value or ""
     else:
         db_value = display_value = str(value).strip() if value else ""
     conn.execute(f"UPDATE policies SET {field} = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
@@ -479,6 +492,9 @@ async def patch_excess_cell_v2(request: Request, program_uid: str, policy_id: in
         if err:
             return JSONResponse({"ok": False, "error": err}, status_code=400)
         db_value, display_value = val, formatted
+    elif field in _DATE_FIELDS:
+        db_value = str(value).strip() if value and str(value).strip() else None
+        display_value = db_value or ""
     else:
         db_value = display_value = str(value).strip() if value else ""
     conn.execute(f"UPDATE policies SET {field} = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
@@ -544,6 +560,7 @@ async def add_underlying_v2(request: Request, program_uid: str,
         "tower_group": pgm["name"], "program_uid": program_uid,
         "policy_types": cfg.get("policy_types", []), "carriers": cfg.get("carriers", []),
         "coverage_forms": cfg.get("coverage_forms", []),
+        "renewal_statuses": cfg.get("renewal_statuses", []),
     })
 
 
@@ -572,6 +589,7 @@ async def add_excess_v2(request: Request, program_uid: str,
         "request": request, "p": row_dict, "layer_num": "—",
         "client_id": pgm["client_id"], "tower_group": pgm["name"], "program_uid": program_uid,
         "carriers": cfg.get("carriers", []), "coverage_forms": cfg.get("coverage_forms", []),
+        "renewal_statuses": cfg.get("renewal_statuses", []),
     })
 
 
@@ -600,6 +618,7 @@ async def add_umbrella_v2(request: Request, program_uid: str,
         "request": request, "p": row_dict, "layer_num": "—",
         "client_id": pgm["client_id"], "tower_group": pgm["name"], "program_uid": program_uid,
         "carriers": cfg.get("carriers", []), "coverage_forms": cfg.get("coverage_forms", []),
+        "renewal_statuses": cfg.get("renewal_statuses", []),
     })
 
 
@@ -676,6 +695,142 @@ async def remove_coverage_mapping_v2(program_uid: str, ptc_id: int,
     conn.execute("DELETE FROM program_tower_coverage WHERE id = ?", (ptc_id,))
     conn.commit()
     return JSONResponse({"ok": True})
+
+
+# ---------------------------------------------------------------------------
+# Child policy cell PATCH — used by Overview tab editable grid
+# ---------------------------------------------------------------------------
+
+_CHILD_ALLOWED = {
+    "policy_type", "carrier", "policy_number", "premium", "limit_amount",
+    "deductible", "attachment_point", "effective_date", "expiration_date",
+    "renewal_status", "layer_position", "participation_of",
+}
+
+
+@router.patch("/programs/{program_uid}/child/{policy_id}/cell")
+async def patch_child_cell(request: Request, program_uid: str, policy_id: int,
+                           conn: sqlite3.Connection = Depends(get_db)):
+    """PATCH a single field on a child policy from the overview grid."""
+    _get_program_or_404(conn, program_uid)
+    body = await request.json()
+    field, value = body.get("field", ""), body.get("value", "")
+    if field not in _CHILD_ALLOWED:
+        return JSONResponse({"ok": False, "error": f"Field '{field}' not allowed"}, status_code=400)
+    if field in _CURRENCY_FIELDS:
+        val, formatted, err = _parse_and_format_currency(value)
+        if err:
+            return JSONResponse({"ok": False, "error": err}, status_code=400)
+        db_value, display_value = val, formatted
+    elif field in _DATE_FIELDS:
+        # Pass through ISO date string or clear
+        db_value = str(value).strip() if value and str(value).strip() else None
+        display_value = db_value or ""
+    else:
+        db_value = display_value = str(value).strip() if value else ""
+    conn.execute(f"UPDATE policies SET {field} = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+                 (db_value, policy_id))
+    conn.commit()
+    return JSONResponse({"ok": True, "formatted": display_value})
+
+
+# ---------------------------------------------------------------------------
+# Bulk Renew Program — renews all child policies in one action
+# ---------------------------------------------------------------------------
+
+@router.post("/programs/{program_uid}/renew")
+async def renew_program(request: Request, program_uid: str,
+                        conn: sqlite3.Connection = Depends(get_db)):
+    """Renew all active child policies in the program.
+
+    For each child: call renew_policy() (archives old, creates new term),
+    then set program_id and schematic_column on the new term.
+    Finally, copy tower coverage and tower line mappings from old to new IDs.
+    """
+    pgm = _get_program_or_404(conn, program_uid)
+    children = get_program_child_policies(conn, pgm["id"])
+    if not children:
+        return JSONResponse({"ok": False, "error": "No child policies to renew"}, status_code=400)
+
+    # Map old policy id -> new policy id for tower coverage remapping
+    old_to_new = {}
+    renewed = 0
+    errors = []
+
+    for child in children:
+        try:
+            new_uid = renew_policy(conn, child["policy_uid"])
+            new_row = conn.execute(
+                "SELECT id FROM policies WHERE policy_uid = ?", (new_uid,)
+            ).fetchone()
+            if new_row:
+                new_id = new_row["id"]
+                old_to_new[child["id"]] = new_id
+                # renew_policy does NOT copy program_id or schematic_column — set them
+                conn.execute(
+                    """UPDATE policies SET program_id = ?, tower_group = ?, schematic_column = ?
+                       WHERE id = ?""",
+                    (pgm["id"], pgm["name"], child.get("schematic_column"), new_id),
+                )
+                conn.commit()
+                renewed += 1
+        except Exception as exc:
+            logger.warning("Failed to renew %s in program %s: %s",
+                           child["policy_uid"], program_uid, exc)
+            errors.append(f"{child['policy_uid']}: {exc}")
+
+    # Copy program_tower_coverage rows: remap old excess/underlying IDs to new IDs
+    if old_to_new:
+        old_coverages = conn.execute(
+            """SELECT ptc.* FROM program_tower_coverage ptc
+               WHERE ptc.excess_policy_id IN ({})""".format(
+                ",".join(str(k) for k in old_to_new.keys())
+            )
+        ).fetchall()
+        for cov in old_coverages:
+            new_excess = old_to_new.get(cov["excess_policy_id"])
+            new_underlying = old_to_new.get(cov["underlying_policy_id"]) if cov["underlying_policy_id"] else None
+            if new_excess:
+                try:
+                    conn.execute(
+                        """INSERT OR IGNORE INTO program_tower_coverage
+                           (excess_policy_id, underlying_policy_id, underlying_sub_coverage_id)
+                           VALUES (?, ?, ?)""",
+                        (new_excess, new_underlying or cov["underlying_policy_id"],
+                         cov["underlying_sub_coverage_id"]),
+                    )
+                except Exception:
+                    pass  # skip if constraint fails
+
+        # Copy program_tower_lines rows: remap old source_policy_id to new IDs
+        old_lines = conn.execute(
+            """SELECT * FROM program_tower_lines
+               WHERE source_policy_id IN ({})""".format(
+                ",".join(str(k) for k in old_to_new.keys())
+            )
+        ).fetchall()
+        for line in old_lines:
+            new_source = old_to_new.get(line["source_policy_id"])
+            if new_source:
+                try:
+                    conn.execute(
+                        """INSERT OR IGNORE INTO program_tower_lines
+                           (program_policy_id, source_policy_id, sub_coverage_id,
+                            label, include_in_tower, sort_order)
+                           VALUES (?, ?, ?, ?, ?, ?)""",
+                        (line["program_policy_id"], new_source,
+                         line["sub_coverage_id"], line["label"],
+                         line["include_in_tower"], line["sort_order"]),
+                    )
+                except Exception:
+                    pass
+
+        conn.commit()
+
+    result = {"ok": True, "renewed_count": renewed}
+    if errors:
+        result["errors"] = errors
+    return JSONResponse(result)
 
 
 # ---------------------------------------------------------------------------

--- a/src/policydb/web/templates/charts/_chart_tower.html
+++ b/src/policydb/web/templates/charts/_chart_tower.html
@@ -8,10 +8,14 @@
 #}
 {% from "charts/_chart_base.html" import chart_frame %}
 {% if tower_incomplete is defined and tower_incomplete %}
-<div class="bg-amber-50 border border-amber-200 rounded-lg px-4 py-2 mb-2 flex items-center justify-between">
-  <span class="text-xs text-amber-700">Program data is incomplete — some layers may be missing from the schematic.</span>
-  <a href="/clients/{{ client_id }}/programs/{{ tower_incomplete | urlencode }}" target="_blank"
-     class="text-xs text-marsh hover:underline font-medium">Set up program &rarr;</a>
+<div id="tower-incomplete-banner" class="bg-amber-50 border border-amber-200 rounded-lg px-4 py-2 mb-2 flex items-center justify-between no-print">
+  <div class="flex items-center gap-2">
+    <span class="text-xs text-amber-700">Program data is incomplete{% if tower_missing is defined and tower_missing %}: {{ tower_missing | join(', ') }}{% endif %}</span>
+    <a href="/clients/{{ client_id }}/programs/{{ tower_incomplete | urlencode }}" target="_blank"
+       class="text-xs text-marsh hover:underline font-medium">Set up program &rarr;</a>
+  </div>
+  <button type="button" onclick="this.closest('#tower-incomplete-banner').remove()"
+    class="text-amber-400 hover:text-amber-600 text-sm leading-none ml-2">&times;</button>
 </div>
 {% endif %}
 {% call(area_id) chart_frame("Program Structure", "Tower / layer diagram") %}
@@ -197,9 +201,11 @@
         var blockTop;
         if (u.is_statutory) {
           // Statutory (WC): taller than everything else in the group
-          // Block ends below the arrows — arrows sit on top
-          blockTop = tallestTopY - 20 - ARROW_H;
-          if (blockTop > towerBottom - MIN_BLOCK_H - ARROW_H) blockTop = towerBottom - MIN_BLOCK_H - ARROW_H;
+          // Leave room above for the arrow chevrons
+          blockTop = tallestTopY - 20;
+          if (blockTop > towerBottom - MIN_BLOCK_H) blockTop = towerBottom - MIN_BLOCK_H;
+          // Clamp so arrows (above block) stay within visible area
+          if (blockTop - ARROW_H < towerTop) blockTop = towerTop + ARROW_H;
         } else {
           blockTop = valToY(lim);
           if (blockBottom - blockTop < MIN_BLOCK_H) blockTop = blockBottom - MIN_BLOCK_H;

--- a/src/policydb/web/templates/programs/_child_row.html
+++ b/src/policydb/web/templates/programs/_child_row.html
@@ -1,0 +1,63 @@
+{% set is_pkg = child.sub_coverages | length > 0 %}
+<tr data-row-id="{{ child.id }}" class="matrix-row border-b border-gray-50 hover:bg-gray-50 transition-colors">
+  <td class="px-3 py-2">
+    <a href="/policies/{{ child.policy_uid }}/edit" class="text-marsh hover:underline font-medium text-xs">{{ child.policy_uid }}</a>
+  </td>
+  <td class="px-3 py-2 text-sm text-gray-800 matrix-cell-combo relative"
+      data-field="policy_type" data-placeholder="type"
+      data-options='{{ policy_types | tojson }}' contenteditable="true">{{ child.policy_type or '' }}</td>
+  <td class="px-3 py-2 text-sm text-gray-800 matrix-cell-combo relative"
+      data-field="carrier" data-placeholder="carrier"
+      data-options='{{ carriers | tojson }}' contenteditable="true">{{ child.carrier or '' }}</td>
+  <td class="px-3 py-2 text-sm text-gray-800 matrix-cell-editable"
+      data-field="policy_number" data-placeholder="policy #" contenteditable="true">{{ child.policy_number or '' }}</td>
+  <td class="px-3 py-2 text-sm text-gray-800 text-right tabular-nums matrix-cell-editable"
+      data-field="premium" data-placeholder="$0" contenteditable="true">{% if child.premium %}${{ '{:,.0f}'.format(child.premium) }}{% endif %}</td>
+  <td class="px-3 py-2 text-sm text-gray-800 text-right tabular-nums matrix-cell-editable"
+      data-field="limit_amount" data-placeholder="$0" contenteditable="true">{% if child.limit_amount %}${{ '{:,.0f}'.format(child.limit_amount) }}{% endif %}</td>
+  <td class="px-3 py-2 text-sm text-gray-800 text-right tabular-nums matrix-cell-editable"
+      data-field="deductible" data-placeholder="$0" contenteditable="true">{% if child.deductible and child.deductible != '0' %}${{ '{:,.0f}'.format(child.deductible | float) }}{% endif %}</td>
+  <td class="px-3 py-2 text-sm text-gray-800 text-right tabular-nums matrix-cell-editable"
+      data-field="attachment_point" data-placeholder="$0" contenteditable="true">{% if child.attachment_point %}${{ '{:,.0f}'.format(child.attachment_point) }}{% endif %}</td>
+  <td class="px-2 py-1.5">
+    <input type="date" value="{{ child.effective_date or '' }}"
+           class="text-xs border border-gray-200 rounded px-1.5 py-1 w-[110px] focus:ring-1 focus:ring-marsh focus:border-marsh"
+           onchange="patchChildCell({{ child.id }}, 'effective_date', this.value)">
+  </td>
+  <td class="px-2 py-1.5">
+    <input type="date" value="{{ child.expiration_date or '' }}"
+           class="text-xs border border-gray-200 rounded px-1.5 py-1 w-[110px] focus:ring-1 focus:ring-marsh focus:border-marsh"
+           onchange="patchChildCell({{ child.id }}, 'expiration_date', this.value)">
+  </td>
+  <td class="px-3 py-2 text-sm text-gray-800 matrix-cell-combo relative"
+      data-field="renewal_status" data-placeholder="status"
+      data-options='{{ renewal_statuses | tojson }}' contenteditable="true">{{ child.renewal_status or '' }}</td>
+  <td class="px-3 py-2 text-sm text-gray-800 matrix-cell-combo relative"
+      data-field="layer_position" data-placeholder="layer"
+      data-options='["Primary", "Umbrella", "Excess"]' contenteditable="true">{{ child.layer_position or '' }}</td>
+  <td class="px-3 py-2 text-sm text-gray-800 text-right tabular-nums matrix-cell-editable"
+      data-field="participation_of" data-placeholder="--" contenteditable="true">{% if child.participation_of %}${{ '{:,.0f}'.format(child.participation_of) }}{% endif %}</td>
+  <td class="px-2 py-2 no-print">
+    <button type="button"
+      class="text-xs text-red-400 hover:text-red-600"
+      onclick="unassignPolicy('{{ child.policy_uid }}')"
+      title="Remove from program">&times;</button>
+  </td>
+</tr>
+{# Ghost rows for sub-coverages (read-only) #}
+{% for sc in child.sub_coverages %}
+<tr class="border-b border-gray-50" style="color:#9ca3af; font-style:italic;">
+  <td class="px-3 py-1.5 pl-6">
+    <span class="text-[9px] text-gray-300">&#9492;</span>
+  </td>
+  <td class="px-3 py-1.5 text-xs">
+    <span class="text-[10px] text-indigo-600 bg-indigo-50 px-1.5 py-0.5 rounded-full font-medium mr-1" style="font-style:normal;">Package</span>
+    {{ sc.coverage_type }}
+  </td>
+  <td class="px-3 py-1.5 text-xs">{{ sc.carrier or child.carrier }}</td>
+  <td></td>
+  <td class="px-3 py-1.5 text-right text-xs tabular-nums">{{ sc.premium | currency if sc.premium else '---' }}</td>
+  <td class="px-3 py-1.5 text-right text-xs tabular-nums">{{ sc.limit_amount | currency_short if sc.limit_amount else '---' }}</td>
+  <td colspan="8"></td>
+</tr>
+{% endfor %}

--- a/src/policydb/web/templates/programs/_excess_matrix.html
+++ b/src/policydb/web/templates/programs/_excess_matrix.html
@@ -28,6 +28,9 @@
           <th class="px-3 py-2 font-medium" style="min-width:80px">Policy #</th>
           <th class="px-3 py-2 font-medium" style="min-width:130px">Notation</th>
           <th class="px-3 py-2 font-medium" style="min-width:120px">Covers</th>
+          <th class="px-2 py-2 font-medium" style="min-width:110px">Effective</th>
+          <th class="px-2 py-2 font-medium" style="min-width:110px">Expiration</th>
+          <th class="px-3 py-2 font-medium" style="min-width:100px">Status</th>
           <th class="px-2 py-2 font-medium w-8 no-print"></th>
         </tr>
       </thead>
@@ -36,12 +39,12 @@
         {% set layer_num = loop.index %}
         {% include "programs/_excess_row.html" %}
         {% else %}
-        <tr id="excess-empty"><td colspan="11" class="px-4 py-8 text-center text-gray-400 text-xs">No excess layers yet.</td></tr>
+        <tr id="excess-empty"><td colspan="14" class="px-4 py-8 text-center text-gray-400 text-xs">No excess layers yet.</td></tr>
         {% endfor %}
       </tbody>
       <tfoot>
         <tr class="border-t border-gray-200">
-          <td colspan="11" class="px-3 py-2 flex gap-2">
+          <td colspan="14" class="px-3 py-2 flex gap-2">
             {% if not has_umbrella %}
             <button type="button"
               class="no-print text-xs text-blue-500 border border-dashed border-blue-300 px-3 py-1.5 rounded hover:border-blue-500 hover:text-blue-700 transition-colors"

--- a/src/policydb/web/templates/programs/_excess_row.html
+++ b/src/policydb/web/templates/programs/_excess_row.html
@@ -54,6 +54,19 @@
       {% endif %}
     </div>
   </td>
+  <td class="px-2 py-1.5">
+    <input type="date" value="{{ p.effective_date or '' }}"
+           class="text-xs border border-gray-200 rounded px-1.5 py-1 w-[110px] focus:ring-1 focus:ring-marsh focus:border-marsh"
+           onchange="patchExcessDate('{{ _row_id }}', 'effective_date', this.value)">
+  </td>
+  <td class="px-2 py-1.5">
+    <input type="date" value="{{ p.expiration_date or '' }}"
+           class="text-xs border border-gray-200 rounded px-1.5 py-1 w-[110px] focus:ring-1 focus:ring-marsh focus:border-marsh"
+           onchange="patchExcessDate('{{ _row_id }}', 'expiration_date', this.value)">
+  </td>
+  <td class="px-3 py-2 text-sm text-gray-800 matrix-cell-combo relative"
+      data-field="renewal_status" data-placeholder="status"
+      data-options='{{ renewal_statuses | tojson }}' contenteditable="true">{{ p.renewal_status or '' }}</td>
   <td class="px-2 py-2 no-print">
     <button type="button" onclick="deleteExcessRow(this, {{ p.id }})"
             class="text-red-300 hover:text-red-500 text-xs">&#10005;</button>

--- a/src/policydb/web/templates/programs/_tab_overview.html
+++ b/src/policydb/web/templates/programs/_tab_overview.html
@@ -1,89 +1,67 @@
-{# Program Overview Tab — child policies, assign/unassign #}
+{# Program Overview Tab — editable child policies grid, assign/unassign #}
 
-{# ── Summary Stats ── #}
+{# -- Summary Stats -- #}
 <div class="flex items-center gap-4 text-sm text-gray-500 mb-4">
   <span><strong class="text-gray-700">{{ aggregates.policy_count }}</strong> policies</span>
   <span><strong class="text-gray-700">{{ aggregates.carrier_count }}</strong> carriers</span>
   <span><strong class="text-gray-700">{{ aggregates.total_premium | currency }}</strong> total premium</span>
 </div>
 
-{# ── Child Policies Table ── #}
+{# -- Child Policies Editable Grid -- #}
 <div class="card mb-4">
   <div class="px-4 py-2.5 bg-gray-50 border-b border-gray-100 flex items-center justify-between">
     <span class="text-xs font-bold text-marsh uppercase tracking-wide">Child Policies</span>
-    <span class="text-xs text-gray-400">{{ children | length }} assigned</span>
+    <div class="flex items-center gap-3">
+      <span class="text-xs text-gray-400">{{ children | length }} assigned</span>
+      {% if children %}
+      <button type="button" id="renew-program-btn"
+        class="no-print text-xs font-medium text-white bg-marsh px-3 py-1 rounded hover:bg-marsh/90 transition-colors"
+        onclick="renewProgram()">Renew Program</button>
+      {% endif %}
+    </div>
   </div>
+
+  <style>
+    #children-tbody td[contenteditable][data-placeholder]:empty::before {
+      content: attr(data-placeholder); color: #94a3b8; font-style: italic; pointer-events: none;
+    }
+    #children-tbody td[contenteditable]:focus {
+      outline: none; border-bottom: 2px solid #003865; background: rgba(0,56,101,0.03);
+    }
+    #children-tbody td.matrix-cell-combo { position: relative; }
+  </style>
+
   {% if children %}
   <div class="overflow-x-auto">
-    <table class="w-full text-sm">
+    <table class="w-full text-sm" id="children-table">
       <thead>
-        <tr class="border-b border-gray-100 text-left text-xs text-gray-400">
-          <th class="px-4 py-2 font-medium">Policy</th>
-          <th class="px-4 py-2 font-medium">Type</th>
-          <th class="px-4 py-2 font-medium">Carrier</th>
-          <th class="px-4 py-2 font-medium text-right">Premium</th>
-          <th class="px-4 py-2 font-medium text-right">Limit</th>
-          <th class="px-4 py-2 font-medium">Layer</th>
-          <th class="px-4 py-2 font-medium">Status</th>
-          <th class="px-4 py-2 font-medium no-print"></th>
+        <tr class="text-left text-xs text-gray-400 uppercase tracking-wide border-b border-gray-100 bg-gray-50">
+          <th class="px-3 py-2 font-medium">Policy</th>
+          <th class="px-3 py-2 font-medium" style="min-width:110px">Type</th>
+          <th class="px-3 py-2 font-medium" style="min-width:110px">Carrier</th>
+          <th class="px-3 py-2 font-medium" style="min-width:80px">Policy #</th>
+          <th class="px-3 py-2 font-medium text-right" style="min-width:90px">Premium</th>
+          <th class="px-3 py-2 font-medium text-right" style="min-width:80px">Limit</th>
+          <th class="px-3 py-2 font-medium text-right" style="min-width:80px">Deductible</th>
+          <th class="px-3 py-2 font-medium text-right" style="min-width:80px">Attach Pt</th>
+          <th class="px-3 py-2 font-medium" style="min-width:115px">Effective</th>
+          <th class="px-3 py-2 font-medium" style="min-width:115px">Expiration</th>
+          <th class="px-3 py-2 font-medium" style="min-width:100px">Status</th>
+          <th class="px-3 py-2 font-medium" style="min-width:80px">Layer</th>
+          <th class="px-3 py-2 font-medium text-right" style="min-width:80px">Part Of</th>
+          <th class="px-2 py-2 font-medium w-8 no-print"></th>
         </tr>
       </thead>
-      <tbody>
+      <tbody id="children-tbody" class="divide-y divide-gray-50">
         {% for child in children %}
-        <tr class="border-b border-gray-50 hover:bg-gray-50 transition-colors">
-          <td class="px-4 py-2.5">
-            <a href="/policies/{{ child.policy_uid }}/edit" class="text-marsh hover:underline font-medium text-xs">{{ child.policy_uid }}</a>
-          </td>
-          <td class="px-4 py-2.5 text-gray-600">{{ child.policy_type }}</td>
-          <td class="px-4 py-2.5 text-gray-600">{{ child.carrier }}</td>
-          <td class="px-4 py-2.5 text-right font-medium text-gray-900 tabular-nums">{{ child.premium | currency }}</td>
-          <td class="px-4 py-2.5 text-right text-gray-600 tabular-nums">{{ child.limit_amount | currency_short }}</td>
-          <td class="px-4 py-2.5">
-            {% if child.layer_position == 'Umbrella' %}
-              <span class="text-xs px-2 py-0.5 rounded bg-blue-50 text-blue-700">Umbrella</span>
-            {% elif child.layer_position == 'Excess' %}
-              <span class="text-xs px-2 py-0.5 rounded bg-gray-100 text-gray-600">Excess</span>
-            {% else %}
-              <span class="text-xs text-gray-400">Primary</span>
-            {% endif %}
-          </td>
-          <td class="px-4 py-2.5">
-            <span class="text-xs px-2 py-0.5 rounded
-              {% if child.renewal_status == 'Bound' %}bg-green-50 text-green-700
-              {% elif child.renewal_status == 'In Progress' %}bg-blue-50 text-blue-700
-              {% else %}bg-gray-100 text-gray-600{% endif %}">{{ child.renewal_status or '—' }}</span>
-          </td>
-          <td class="px-4 py-2.5 no-print">
-            <button type="button"
-              class="text-xs text-red-400 hover:text-red-600"
-              onclick="unassignPolicy('{{ child.policy_uid }}')"
-              title="Remove from program">&times;</button>
-          </td>
-        </tr>
-        {# Ghost rows for sub-coverages #}
-        {% for sc in child.sub_coverages %}
-        <tr class="border-b border-gray-50" style="color:#9ca3af; font-style:italic;">
-          <td class="px-4 py-1.5 pl-8">
-            <span class="text-[9px] text-gray-300">└</span>
-          </td>
-          <td class="px-4 py-1.5 text-xs">
-            <span class="text-[10px] text-indigo-600 bg-indigo-50 px-1.5 py-0.5 rounded-full font-medium mr-1" style="font-style:normal;">Package</span>
-            {{ sc.coverage_type }}
-          </td>
-          <td class="px-4 py-1.5 text-xs">{{ sc.carrier or child.carrier }}</td>
-          <td class="px-4 py-1.5 text-right text-xs tabular-nums">{{ sc.premium | currency if sc.premium else '—' }}</td>
-          <td class="px-4 py-1.5 text-right text-xs tabular-nums">{{ sc.limit_amount | currency_short if sc.limit_amount else '—' }}</td>
-          <td class="px-4 py-1.5 text-xs">{{ sc.layer_position or '—' }}</td>
-          <td colspan="2"></td>
-        </tr>
-        {% endfor %}
+        {% include "programs/_child_row.html" %}
         {% endfor %}
       </tbody>
       <tfoot>
         <tr class="border-t border-gray-200">
-          <td colspan="3" class="px-4 py-2 text-xs font-semibold text-gray-500">Totals</td>
-          <td class="px-4 py-2 text-right text-xs font-semibold text-gray-700 tabular-nums">{{ aggregates.total_premium | currency }}</td>
-          <td colspan="4"></td>
+          <td colspan="4" class="px-3 py-2 text-xs font-semibold text-gray-500">Totals</td>
+          <td class="px-3 py-2 text-right text-xs font-semibold text-gray-700 tabular-nums">{{ aggregates.total_premium | currency }}</td>
+          <td colspan="9"></td>
         </tr>
       </tfoot>
     </table>
@@ -95,51 +73,134 @@
   {% endif %}
 </div>
 
-{# ── Assign Policy Panel ── #}
+{# -- Assign Policy Panel -- #}
 {% if unassigned %}
 <div class="card mb-4">
-  <div class="px-4 py-2.5 bg-gray-50 border-b border-gray-100">
-    <span class="text-xs font-bold text-marsh uppercase tracking-wide">Assign Policy</span>
+  <div class="px-4 py-2.5 bg-gray-50 border-b border-gray-100 flex items-center justify-between">
+    <span class="text-xs font-bold text-marsh uppercase tracking-wide">Unassigned Policies</span>
+    <span class="text-xs text-gray-400">{{ unassigned | length }} available</span>
   </div>
-  <div class="p-4">
-    <div class="flex flex-wrap gap-2">
-      {% for pol in unassigned %}
-      <button type="button"
-        class="inline-flex items-center gap-1.5 text-xs border border-gray-200 rounded-lg px-3 py-1.5 text-gray-600 hover:border-marsh hover:text-marsh transition-colors"
-        onclick="assignPolicy('{{ pol.policy_uid }}')">
-        <span class="text-green-500">+</span>
-        {{ pol.policy_type }}
-        {% if pol.carrier %}<span class="text-gray-400">· {{ pol.carrier }}</span>{% endif %}
-        {% if pol.premium %}<span class="text-gray-400">· {{ pol.premium | currency_short }}</span>{% endif %}
-      </button>
-      {% endfor %}
-    </div>
+  <div class="overflow-x-auto">
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="border-b border-gray-100 text-left text-xs text-gray-400">
+          <th class="px-4 py-2 font-medium">Policy</th>
+          <th class="px-4 py-2 font-medium">Type</th>
+          <th class="px-4 py-2 font-medium">Carrier</th>
+          <th class="px-4 py-2 font-medium">Policy #</th>
+          <th class="px-4 py-2 font-medium text-right">Premium</th>
+          <th class="px-4 py-2 font-medium text-right">Limit</th>
+          <th class="px-4 py-2 font-medium">Term</th>
+          <th class="px-4 py-2 font-medium">Status</th>
+          <th class="px-4 py-2 font-medium no-print"></th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for pol in unassigned %}
+        <tr class="border-b border-gray-50 hover:bg-gray-50 transition-colors">
+          <td class="px-4 py-2.5">
+            <a href="/policies/{{ pol.policy_uid }}/edit" class="text-marsh hover:underline font-medium text-xs">{{ pol.policy_uid }}</a>
+          </td>
+          <td class="px-4 py-2.5 text-gray-600">{{ pol.policy_type or '---' }}</td>
+          <td class="px-4 py-2.5 text-gray-600">{{ pol.carrier or '---' }}</td>
+          <td class="px-4 py-2.5 text-gray-500 text-xs font-mono">{{ pol.policy_number or '---' }}</td>
+          <td class="px-4 py-2.5 text-right font-medium text-gray-900 tabular-nums">{{ pol.premium | currency if pol.premium else '---' }}</td>
+          <td class="px-4 py-2.5 text-right text-gray-600 tabular-nums">{{ pol.limit_amount | currency_short if pol.limit_amount else '---' }}</td>
+          <td class="px-4 py-2.5 text-xs text-gray-500 whitespace-nowrap">
+            {% if pol.effective_date and pol.expiration_date %}
+              {{ pol.effective_date[5:].replace('-', '/') }} - {{ pol.expiration_date[5:].replace('-', '/') }}
+            {% elif pol.effective_date %}
+              {{ pol.effective_date[5:].replace('-', '/') }} -
+            {% else %}---{% endif %}
+          </td>
+          <td class="px-4 py-2.5">
+            <span class="text-xs px-2 py-0.5 rounded
+              {% if pol.renewal_status == 'Bound' %}bg-green-50 text-green-700
+              {% elif pol.renewal_status == 'In Progress' %}bg-blue-50 text-blue-700
+              {% else %}bg-gray-100 text-gray-600{% endif %}">{{ pol.renewal_status or '---' }}</span>
+          </td>
+          <td class="px-4 py-2.5 no-print">
+            <button type="button"
+              class="text-xs text-marsh border border-marsh/30 rounded px-2 py-0.5 hover:bg-marsh hover:text-white transition-colors"
+              onclick="assignPolicy('{{ pol.policy_uid }}')">+ Assign</button>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
   </div>
 </div>
 {% endif %}
 
 <script>
-function assignPolicy(policyUid) {
-  fetch('/programs/{{ program.program_uid }}/assign/' + policyUid, {method: 'POST'})
-    .then(function(r) { return r.json(); })
-    .then(function(data) {
-      if (data.ok) {
-        // Reload overview tab
-        htmx.ajax('GET', '/programs/{{ program.program_uid }}/tab/overview',
-                   {target: '.tab-content', swap: 'innerHTML'});
-      }
-    });
-}
+(function() {
+  var _base = '/programs/{{ program.program_uid }}';
 
-function unassignPolicy(policyUid) {
-  if (!confirm('Remove this policy from the program?')) return;
-  fetch('/programs/{{ program.program_uid }}/unassign/' + policyUid, {method: 'POST'})
-    .then(function(r) { return r.json(); })
-    .then(function(data) {
-      if (data.ok) {
-        htmx.ajax('GET', '/programs/{{ program.program_uid }}/tab/overview',
-                   {target: '.tab-content', swap: 'innerHTML'});
-      }
+  // Editable grid for child policies
+  window._childrenMatrix = window.initMatrix({
+    tbodyId: 'children-tbody',
+    idAttr: 'data-row-id',
+    rowClass: 'matrix-row',
+    patchUrl: function(id) { return _base + '/child/' + id + '/cell'; },
+    emptyRowId: null,
+    onSaved: function(rowEl, field, resp) {}
+  });
+
+  // Date field patch helper (date inputs bypass initMatrix)
+  window.patchChildCell = function(policyId, field, value) {
+    fetch(_base + '/child/' + policyId + '/cell', {
+      method: 'PATCH',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({field: field, value: value})
+    }).then(function(r) { return r.json(); }).then(function(data) {
+      if (data.ok && typeof showToast === 'function') showToast('Saved');
     });
-}
+  };
+
+  window.assignPolicy = function(policyUid) {
+    fetch(_base + '/assign/' + policyUid, {method: 'POST'})
+      .then(function(r) { return r.json(); })
+      .then(function(data) {
+        if (data.ok) {
+          htmx.ajax('GET', _base + '/tab/overview',
+                     {target: '.tab-content', swap: 'innerHTML'});
+        }
+      });
+  };
+
+  window.unassignPolicy = function(policyUid) {
+    if (!confirm('Remove this policy from the program?')) return;
+    fetch(_base + '/unassign/' + policyUid, {method: 'POST'})
+      .then(function(r) { return r.json(); })
+      .then(function(data) {
+        if (data.ok) {
+          htmx.ajax('GET', _base + '/tab/overview',
+                     {target: '.tab-content', swap: 'innerHTML'});
+        }
+      });
+  };
+
+  window.renewProgram = function() {
+    if (!confirm('Renew all child policies in this program? This will archive current terms and create new ones with dates advanced by one year.')) return;
+    var btn = document.getElementById('renew-program-btn');
+    if (btn) { btn.disabled = true; btn.textContent = 'Renewing...'; }
+    fetch(_base + '/renew', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'}
+    }).then(function(r) { return r.json(); }).then(function(data) {
+      if (data.ok) {
+        if (typeof showToast === 'function') showToast(data.renewed_count + ' policies renewed');
+        // Reload overview tab to show new terms
+        htmx.ajax('GET', _base + '/tab/overview',
+                   {target: '.tab-content', swap: 'innerHTML'});
+      } else {
+        alert(data.error || 'Renewal failed');
+        if (btn) { btn.disabled = false; btn.textContent = 'Renew Program'; }
+      }
+    }).catch(function() {
+      alert('Network error during renewal');
+      if (btn) { btn.disabled = false; btn.textContent = 'Renew Program'; }
+    });
+  };
+})();
 </script>

--- a/src/policydb/web/templates/programs/_tab_schematic.html
+++ b/src/policydb/web/templates/programs/_tab_schematic.html
@@ -19,20 +19,36 @@
     <h2 class="font-semibold text-gray-900 text-sm">Unassigned Policies
       <span class="text-gray-400 font-normal">({{ unassigned | length }})</span>
     </h2>
-    <span class="text-xs text-gray-400">Click + to add to this program</span>
+    <span class="text-xs text-gray-400">Click + Assign to add to this program</span>
   </div>
-  <div id="unassigned-panel" class="p-4 flex flex-wrap gap-3">
-    {% for u in unassigned %}
-    <div id="unassigned-{{ u.policy_uid }}" class="flex items-center gap-2 px-3 py-2 bg-gray-50 rounded-lg border border-gray-200 text-sm">
-      <div>
-        <span class="font-medium text-gray-700">{{ u.policy_type or 'Unknown' }}</span>
-        {% if u.carrier %}<span class="text-gray-400 text-xs ml-1">{{ u.carrier }}</span>{% endif %}
-        {% if u.premium %}<span class="text-gray-400 text-xs ml-1">· {{ u.premium | currency_short }}</span>{% endif %}
-      </div>
-      <button type="button" onclick="assignPolicy('{{ u.policy_uid }}')"
-              class="ml-1 text-marsh hover:text-marsh/80 font-bold text-base leading-none" title="Assign to program">+</button>
-    </div>
-    {% endfor %}
+  <div id="unassigned-panel" class="overflow-x-auto">
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="border-b border-gray-100 text-left text-xs text-gray-400">
+          <th class="px-4 py-2 font-medium">Type</th>
+          <th class="px-4 py-2 font-medium">Carrier</th>
+          <th class="px-4 py-2 font-medium">Policy #</th>
+          <th class="px-4 py-2 font-medium text-right">Premium</th>
+          <th class="px-4 py-2 font-medium text-right">Limit</th>
+          <th class="px-4 py-2 font-medium no-print"></th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for u in unassigned %}
+        <tr id="unassigned-{{ u.policy_uid }}" class="border-b border-gray-50 hover:bg-gray-50 transition-colors">
+          <td class="px-4 py-2 text-gray-700 font-medium">{{ u.policy_type or 'Unknown' }}</td>
+          <td class="px-4 py-2 text-gray-600">{{ u.carrier or '—' }}</td>
+          <td class="px-4 py-2 text-gray-500 text-xs font-mono">{{ u.policy_number or '—' }}</td>
+          <td class="px-4 py-2 text-right text-gray-600 tabular-nums">{{ u.premium | currency_short if u.premium else '—' }}</td>
+          <td class="px-4 py-2 text-right text-gray-600 tabular-nums">{{ u.limit_amount | currency_short if u.limit_amount else '—' }}</td>
+          <td class="px-4 py-2 no-print">
+            <button type="button" onclick="assignPolicy('{{ u.policy_uid }}')"
+              class="text-xs text-marsh border border-marsh/30 rounded px-2 py-0.5 hover:bg-marsh hover:text-white transition-colors">+ Assign</button>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
   </div>
 </div>
 {% endif %}
@@ -57,6 +73,40 @@
 <script>
 (function() {
   var _base = '/programs/{{ program_uid }}';
+
+  // Date patch helpers for <input type="date"> (bypass initMatrix)
+  window.patchUnderlyingDate = function(policyId, field, value) {
+    fetch(_base + '/underlying/' + policyId + '/cell', {
+      method: 'PATCH',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({field: field, value: value})
+    }).then(function(r) { return r.json(); }).then(function(data) {
+      if (data.ok) {
+        if (typeof showToast === 'function') showToast('Saved');
+        document.body.dispatchEvent(new CustomEvent('tower-updated'));
+      }
+    });
+  };
+
+  window.patchExcessDate = function(rowId, field, value) {
+    var s = String(rowId);
+    var url;
+    if (s.indexOf('sc-') === 0) {
+      url = _base + '/subcoverage/' + s.substring(3) + '/cell';
+    } else {
+      url = _base + '/excess/' + rowId + '/cell';
+    }
+    fetch(url, {
+      method: 'PATCH',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({field: field, value: value})
+    }).then(function(r) { return r.json(); }).then(function(data) {
+      if (data.ok) {
+        if (typeof showToast === 'function') showToast('Saved');
+        document.body.dispatchEvent(new CustomEvent('tower-updated'));
+      }
+    });
+  };
 
   // Underlying matrix
   window._underlyingMatrix = window.initMatrix({
@@ -133,7 +183,9 @@
         var el = document.getElementById('unassigned-' + uid);
         if (el) el.remove();
         var panel = document.getElementById('unassigned-panel');
-        if (panel && panel.children.length === 0) {
+        // Check if any rows remain in the table tbody
+        var tbody = panel ? panel.querySelector('tbody') : null;
+        if (tbody && tbody.children.length === 0) {
           panel.closest('.card').remove();
         }
         showToast('Assigned to program');

--- a/src/policydb/web/templates/programs/_underlying_matrix.html
+++ b/src/policydb/web/templates/programs/_underlying_matrix.html
@@ -26,6 +26,9 @@
           <th class="px-3 py-2 font-medium text-right" style="min-width:90px">Premium</th>
           <th class="px-3 py-2 font-medium" style="min-width:90px">Policy #</th>
           <th class="px-3 py-2 font-medium" style="min-width:80px">Form</th>
+          <th class="px-2 py-2 font-medium" style="min-width:110px">Effective</th>
+          <th class="px-2 py-2 font-medium" style="min-width:110px">Expiration</th>
+          <th class="px-3 py-2 font-medium" style="min-width:100px">Status</th>
           <th class="px-2 py-2 font-medium w-8 no-print"></th>
         </tr>
       </thead>
@@ -33,12 +36,12 @@
         {% for p in underlying %}
         {% include "programs/_underlying_row.html" %}
         {% else %}
-        <tr id="underlying-empty"><td colspan="9" class="px-4 py-8 text-center text-gray-400 text-xs">No underlying lines yet. Add one to get started.</td></tr>
+        <tr id="underlying-empty"><td colspan="12" class="px-4 py-8 text-center text-gray-400 text-xs">No underlying lines yet. Add one to get started.</td></tr>
         {% endfor %}
       </tbody>
       <tfoot>
         <tr class="border-t border-gray-200">
-          <td colspan="9" class="px-3 py-2">
+          <td colspan="12" class="px-3 py-2">
             <button type="button"
               class="no-print text-xs text-gray-400 border border-dashed border-gray-300 px-3 py-1.5 rounded hover:border-marsh hover:text-marsh transition-colors"
               hx-post="/programs/{{ program_uid }}/underlying/add"

--- a/src/policydb/web/templates/programs/_underlying_row.html
+++ b/src/policydb/web/templates/programs/_underlying_row.html
@@ -18,6 +18,19 @@
   <td class="px-3 py-2 text-sm text-gray-800 matrix-cell-combo relative"
       data-field="coverage_form" data-placeholder="form"
       data-options='{{ coverage_forms | tojson }}' contenteditable="true">{{ p.coverage_form or '' }}</td>
+  <td class="px-2 py-1.5">
+    <input type="date" value="{{ p.effective_date or '' }}"
+           class="text-xs border border-gray-200 rounded px-1.5 py-1 w-[110px] focus:ring-1 focus:ring-marsh focus:border-marsh"
+           onchange="patchUnderlyingDate({{ p.id }}, 'effective_date', this.value)">
+  </td>
+  <td class="px-2 py-1.5">
+    <input type="date" value="{{ p.expiration_date or '' }}"
+           class="text-xs border border-gray-200 rounded px-1.5 py-1 w-[110px] focus:ring-1 focus:ring-marsh focus:border-marsh"
+           onchange="patchUnderlyingDate({{ p.id }}, 'expiration_date', this.value)">
+  </td>
+  <td class="px-3 py-2 text-sm text-gray-800 matrix-cell-combo relative"
+      data-field="renewal_status" data-placeholder="status"
+      data-options='{{ renewal_statuses | tojson }}' contenteditable="true">{{ p.renewal_status or '' }}</td>
   <td class="px-2 py-2 no-print">
     <button type="button" onclick="deleteUnderlyingRow(this, {{ p.id }})"
             class="text-red-300 hover:text-red-500 text-xs">&#10005;</button>


### PR DESCRIPTION
## Summary
- **Editable child policies grid** on program Overview tab — 13 inline-editable columns replacing the read-only table, using `initMatrix()` pattern with currency parsing, combobox dropdowns, and date pickers
- **Schematic matrix additions** — Effective Date, Expiration Date, and Renewal Status columns on both underlying and excess matrices
- **Bulk Renew Program** — renews all child policies at once, preserves program assignment, schematic structure, and tower coverage mappings
- **Unassigned policies table** — upgraded from pill buttons to detail table with policy #, term dates, and status
- **Tower chart fixes** — WC bar arrow visibility, deductible completeness accepts $0, dismissable incomplete banner

## Test plan
- [ ] Program Overview tab: verify all cells editable, currency shorthand works (e.g., "1.5m")
- [ ] Schematic tab: verify date/status columns on underlying and excess matrices
- [ ] Bulk renew: test on a multi-policy program, verify new terms created with correct program/schematic structure
- [ ] Unassigned table: verify detail columns and + Assign button
- [ ] Tower chart: verify WC carets visible above bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)