### PR TITLE
fix: add location column to unassigned policies tables

### DIFF
--- a/src/policydb/queries.py
+++ b/src/policydb/queries.py
@@ -2685,8 +2685,10 @@ def get_unassigned_policies(conn: sqlite3.Connection, client_id: int, exclude_pr
     rows = conn.execute(
         """SELECT p.policy_uid, p.policy_type, p.carrier, p.premium, p.limit_amount,
                   p.program_id, p.policy_number, p.effective_date, p.expiration_date,
-                  p.renewal_status, p.deductible
+                  p.renewal_status, p.deductible,
+                  pr.name AS project_name
            FROM policies p
+           LEFT JOIN projects pr ON p.project_id = pr.id
            WHERE p.client_id = ? AND p.archived = 0
              AND (p.is_opportunity = 0 OR p.is_opportunity IS NULL)
              AND (

--- a/src/policydb/web/templates/programs/_tab_overview.html
+++ b/src/policydb/web/templates/programs/_tab_overview.html
@@ -88,6 +88,7 @@
           <th class="px-4 py-2 font-medium">Type</th>
           <th class="px-4 py-2 font-medium">Carrier</th>
           <th class="px-4 py-2 font-medium">Policy #</th>
+          <th class="px-4 py-2 font-medium">Location</th>
           <th class="px-4 py-2 font-medium text-right">Premium</th>
           <th class="px-4 py-2 font-medium text-right">Limit</th>
           <th class="px-4 py-2 font-medium">Term</th>
@@ -104,6 +105,7 @@
           <td class="px-4 py-2.5 text-gray-600">{{ pol.policy_type or '---' }}</td>
           <td class="px-4 py-2.5 text-gray-600">{{ pol.carrier or '---' }}</td>
           <td class="px-4 py-2.5 text-gray-500 text-xs font-mono">{{ pol.policy_number or '---' }}</td>
+          <td class="px-4 py-2.5 text-xs text-gray-500">{{ pol.project_name or '---' }}</td>
           <td class="px-4 py-2.5 text-right font-medium text-gray-900 tabular-nums">{{ pol.premium | currency if pol.premium else '---' }}</td>
           <td class="px-4 py-2.5 text-right text-gray-600 tabular-nums">{{ pol.limit_amount | currency_short if pol.limit_amount else '---' }}</td>
           <td class="px-4 py-2.5 text-xs text-gray-500 whitespace-nowrap">

--- a/src/policydb/web/templates/programs/_tab_schematic.html
+++ b/src/policydb/web/templates/programs/_tab_schematic.html
@@ -28,6 +28,7 @@
           <th class="px-4 py-2 font-medium">Type</th>
           <th class="px-4 py-2 font-medium">Carrier</th>
           <th class="px-4 py-2 font-medium">Policy #</th>
+          <th class="px-4 py-2 font-medium">Location</th>
           <th class="px-4 py-2 font-medium text-right">Premium</th>
           <th class="px-4 py-2 font-medium text-right">Limit</th>
           <th class="px-4 py-2 font-medium no-print"></th>
@@ -39,6 +40,7 @@
           <td class="px-4 py-2 text-gray-700 font-medium">{{ u.policy_type or 'Unknown' }}</td>
           <td class="px-4 py-2 text-gray-600">{{ u.carrier or '—' }}</td>
           <td class="px-4 py-2 text-gray-500 text-xs font-mono">{{ u.policy_number or '—' }}</td>
+          <td class="px-4 py-2 text-xs text-gray-500">{{ u.project_name or '—' }}</td>
           <td class="px-4 py-2 text-right text-gray-600 tabular-nums">{{ u.premium | currency_short if u.premium else '—' }}</td>
           <td class="px-4 py-2 text-right text-gray-600 tabular-nums">{{ u.limit_amount | currency_short if u.limit_amount else '—' }}</td>
           <td class="px-4 py-2 no-print">


### PR DESCRIPTION
## Summary
- Added `project_name` (Location) column to unassigned policies tables on both program Overview and Schematic tabs
- Joined `projects` table in `get_unassigned_policies()` query

🤖 Generated with [Claude Code](https://claude.com/claude-code)