### PR TITLE
feat: wire KB article sources to Settings

### DIFF
--- a/src/policydb/config.py
+++ b/src/policydb/config.py
@@ -180,6 +180,11 @@ _DEFAULTS: dict[str, Any] = {
         "Claims",
         "General",
     ],
+    "kb_article_sources": [
+        "Authored",
+        "LLM-Assisted",
+        "External",
+    ],
     # ── Anomaly detection ──────────────────────────────────────────────
     "anomaly_thresholds": {
         "renewal_not_started_days": 60,

--- a/src/policydb/web/routes/kb.py
+++ b/src/policydb/web/routes/kb.py
@@ -198,9 +198,11 @@ async def kb_search(
 @router.get("/articles/new", response_class=HTMLResponse)
 async def new_article_form(request: Request, conn=Depends(get_db)):
     categories = cfg.get("kb_categories", [])
+    sources = cfg.get("kb_article_sources", [])
     return templates.TemplateResponse("kb/article_new.html", {
         "request": request,
         "categories": categories,
+        "sources": sources,
         "active": "kb",
     })
 
@@ -252,6 +254,7 @@ async def article_detail(request: Request, uid: str, conn=Depends(get_db)):
     record_links = _get_record_links(conn, "article", article["id"])
 
     categories = cfg.get("kb_categories", [])
+    sources = cfg.get("kb_article_sources", [])
 
     return templates.TemplateResponse("kb/article.html", {
         "request": request,
@@ -259,6 +262,7 @@ async def article_detail(request: Request, uid: str, conn=Depends(get_db)):
         "attachments": attach_list,
         "record_links": record_links,
         "categories": categories,
+        "sources": sources,
         "category_colors": CATEGORY_COLORS,
         "active": "kb",
     })

--- a/src/policydb/web/routes/settings.py
+++ b/src/policydb/web/routes/settings.py
@@ -55,6 +55,7 @@ EDITABLE_LISTS: dict[str, str] = {
     "account_priority_options": "Account Priority Options",
     "service_model_options": "Service Model Options",
     "kb_categories": "KB Categories",
+    "kb_article_sources": "KB Article Sources",
 }
 
 TAB_LISTS: dict[str, dict[str, str]] = {
@@ -109,6 +110,7 @@ TAB_LISTS: dict[str, dict[str, str]] = {
         "project_stages": "Project Stages",
         "project_types": "Project Types",
         "kb_categories": "KB Categories",
+        "kb_article_sources": "KB Article Sources",
     },
     "data-health": {},
     "anomalies": {},

--- a/src/policydb/web/templates/kb/article.html
+++ b/src/policydb/web/templates/kb/article.html
@@ -35,14 +35,25 @@
              onblur="saveArticleField(this)">{{ article.title }}</div>
 
         <!-- Category combobox -->
-        <div class="mt-2 flex items-center gap-2">
-          <span class="text-xs text-gray-400">Category:</span>
-          <select class="text-sm border-0 border-b border-gray-200 focus:border-marsh outline-none py-0.5 px-1 {{ article.colors.text }} font-medium bg-transparent"
-                  onchange="saveArticleFieldVal('{{ article.uid }}', 'category', this.value); location.reload();">
-            {% for cat in categories %}
-            <option value="{{ cat }}" {{ 'selected' if cat == article.category else '' }}>{{ cat }}</option>
-            {% endfor %}
-          </select>
+        <div class="mt-2 flex items-center gap-3 flex-wrap">
+          <div class="flex items-center gap-2">
+            <span class="text-xs text-gray-400">Category:</span>
+            <select class="text-sm border-0 border-b border-gray-200 focus:border-marsh outline-none py-0.5 px-1 {{ article.colors.text }} font-medium bg-transparent"
+                    onchange="saveArticleFieldVal('{{ article.uid }}', 'category', this.value); location.reload();">
+              {% for cat in categories %}
+              <option value="{{ cat }}" {{ 'selected' if cat == article.category else '' }}>{{ cat }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="flex items-center gap-2">
+            <span class="text-xs text-gray-400">Source:</span>
+            <select class="text-sm border-0 border-b border-gray-200 focus:border-marsh outline-none py-0.5 px-1 text-gray-600 font-medium bg-transparent"
+                    onchange="saveArticleFieldVal('{{ article.uid }}', 'source', this.value);">
+              {% for src in sources %}
+              <option value="{{ src | lower | replace(' ', '-') }}" {{ 'selected' if src | lower | replace(' ', '-') == article.source else '' }}>{{ src }}</option>
+              {% endfor %}
+            </select>
+          </div>
         </div>
       </div>
 

--- a/src/policydb/web/templates/kb/article_new.html
+++ b/src/policydb/web/templates/kb/article_new.html
@@ -27,9 +27,9 @@
         <div>
           <label class="block text-xs font-medium text-gray-500 mb-1">Source</label>
           <select name="source" class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-marsh focus:border-marsh outline-none">
-            <option value="authored">Authored</option>
-            <option value="llm-assisted">LLM-Assisted</option>
-            <option value="external">External</option>
+            {% for src in sources %}
+            <option value="{{ src | lower | replace(' ', '-') }}">{{ src }}</option>
+            {% endfor %}
           </select>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Added `kb_article_sources` config list (Authored, LLM-Assisted, External) to `_DEFAULTS`
- Wired to `EDITABLE_LISTS` and `TAB_LISTS` under Database & Admin tab in Settings
- Article new form now reads source options from config instead of hardcoded `<option>` tags
- Article detail page now shows an inline Source selector alongside the Category dropdown

## Test plan
- [ ] Settings > Database & Admin shows "KB Article Sources" list with 3 items
- [ ] Add/remove/reorder sources in Settings
- [ ] New article form shows updated source options
- [ ] Article detail page shows Source dropdown, changing it saves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)