### PR TITLE
feat: one-click Copy Table to clipboard for policy tables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,6 +295,54 @@ The same issue applies anywhere `{{` or `}}` appears inside JavaScript string li
 
 ---
 
+## Copy Table Pattern (Clipboard Rich-Paste)
+
+Reusable pattern for one-click "Copy Table" buttons that put both HTML (for Outlook/rich paste) and plain text (for plain editors) on the clipboard.
+
+### Architecture
+
+1. **Backend function** in `email_templates.py`: `build_policy_table(conn, client_id, project_name, rows)` returns `{"html": ..., "text": ...}`. Also: `_render_policy_table_html(rows)` and `_render_policy_table_text(rows)` for rendering pre-fetched rows.
+2. **API endpoint**: Returns `JSONResponse({"html": ..., "text": ...})` — e.g. `GET /clients/{id}/copy-table?project=...`
+3. **JS function** in `base.html`: `copyPolicyTable(url, btn)` — fetches the endpoint, writes both MIME types via `ClipboardItem`, with `writeText()` fallback.
+
+### Adding a New Copy Table Button
+
+**Template** — add a button that calls `copyPolicyTable(url, btn)`:
+```html
+<button type="button"
+  onclick="copyPolicyTable('/your/endpoint?params=...', this)"
+  class="text-xs text-gray-300 hover:text-marsh" title="Copy table to clipboard">Copy Table</button>
+```
+
+**Route** — return JSON with both formats:
+```python
+from policydb.email_templates import build_policy_table
+result = build_policy_table(conn, client_id, project_name=project)
+return JSONResponse(result)
+```
+
+For custom row sources (e.g. renewal pipeline), build row dicts with keys: `policy_type`, `carrier`, `access_point`, `policy_number`, `effective_date`, `expiration_date`, `premium`, `limit_amount`, `description` — then pass as `rows=` parameter.
+
+### HTML Table Styling (Outlook-Safe)
+
+- **Inline styles only** — Outlook strips `<style>` blocks and CSS classes
+- Header: Marsh navy `#003865`, white text, Noto Sans font
+- Alternating rows: `#FFFFFF` / `#F7F3EE`
+- Borders: `1px solid #B9B6B1`
+- Currency/limit columns: right-aligned
+- Carrier column: `"Carrier via Access Point"` when access_point exists
+
+### Current Deployment Locations
+
+| Location | Endpoint | Template |
+|----------|----------|----------|
+| Project group header | `/clients/{id}/copy-table?project=...` | `_project_header.html` |
+| Client policies section | `/clients/{id}/copy-table` | `_tab_policies.html` |
+| Project detail page | `/clients/{id}/copy-table?project=...` | `project.html` |
+| Renewal pipeline | `/renewals/copy-table?window=...&status=...&client_id=...` | `renewals.html` |
+
+---
+
 ## Config System
 
 `src/policydb/config.py` — `_DEFAULTS` dict merged with `~/.policydb/config.yaml`.

--- a/src/policydb/email_templates.py
+++ b/src/policydb/email_templates.py
@@ -86,6 +86,143 @@ def _linked_account_names(conn: sqlite3.Connection, client_id: int) -> str:
         return ""
 
 
+def _fetch_policy_table_rows(
+    conn: sqlite3.Connection,
+    client_id: int,
+    project_name: str | None = None,
+) -> list[dict]:
+    """Fetch policy rows for the copy-table feature.
+
+    Returns dicts with: policy_type, carrier, access_point, policy_number,
+    effective_date, expiration_date, premium, limit_amount, description.
+    """
+    params: list = [client_id]
+    location_filter = ""
+    if project_name is not None:
+        location_filter = "AND LOWER(TRIM(COALESCE(p.project_name, ''))) = LOWER(TRIM(?))"
+        params.append(project_name)
+
+    rows = conn.execute(
+        f"""SELECT p.policy_type, p.carrier, p.access_point, p.policy_number,
+                   p.effective_date, p.expiration_date, p.premium,
+                   p.limit_amount, p.description
+            FROM policies p
+            WHERE p.client_id = ? AND p.archived = 0
+              AND (p.is_opportunity = 0 OR p.is_opportunity IS NULL)
+              {location_filter}
+            ORDER BY p.policy_type, p.carrier""",
+        params,
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def _carrier_display(carrier: str, access_point: str) -> str:
+    """Format carrier with access point: 'Carrier via Access Point'."""
+    if access_point:
+        return f"{carrier} via {access_point}"
+    return carrier
+
+
+def _render_policy_table_html(rows: list[dict]) -> str:
+    """Render an inline-styled HTML table for Outlook paste."""
+    hdr_bg = "#003865"
+    hdr_text = "#FFFFFF"
+    border = "#B9B6B1"
+    alt_bg = "#F7F3EE"
+    font = "'Noto Sans', Calibri, Arial, sans-serif"
+
+    cell_style = (
+        f"border:1px solid {border}; padding:6px 10px; "
+        f"font-family:{font}; font-size:13px; color:#3D3C37;"
+    )
+    hdr_style = (
+        f"border:1px solid {border}; padding:6px 10px; "
+        f"font-family:{font}; font-size:13px; font-weight:600; "
+        f"color:{hdr_text}; background-color:{hdr_bg};"
+    )
+    right_style = " text-align:right;"
+
+    cols = [
+        ("Policy Type", False),
+        ("Carrier", False),
+        ("Policy #", False),
+        ("Effective", False),
+        ("Expiration", False),
+        ("Premium", True),
+        ("Limit", True),
+        ("Description", False),
+    ]
+
+    parts = ['<table style="border-collapse:collapse; width:100%;">']
+    parts.append("<thead><tr>")
+    for label, is_right in cols:
+        align = right_style if is_right else ""
+        parts.append(f'<th style="{hdr_style}{align}">{label}</th>')
+    parts.append("</tr></thead>")
+    parts.append("<tbody>")
+
+    for i, r in enumerate(rows):
+        row_bg = f" background-color:{alt_bg};" if i % 2 == 1 else ""
+        carrier_text = _carrier_display(r.get("carrier") or "", r.get("access_point") or "")
+        cells = [
+            (r.get("policy_type") or "", False),
+            (carrier_text, False),
+            (r.get("policy_number") or "", False),
+            (_fmt_date(r.get("effective_date")), False),
+            (_fmt_date(r.get("expiration_date")), False),
+            (_fmt_currency(r.get("premium")), True),
+            (_fmt_currency(r.get("limit_amount")), True),
+            (r.get("description") or "", False),
+        ]
+        parts.append("<tr>")
+        for val, is_right in cells:
+            align = right_style if is_right else ""
+            parts.append(f'<td style="{cell_style}{row_bg}{align}">{val}</td>')
+        parts.append("</tr>")
+
+    parts.append("</tbody></table>")
+    return "".join(parts)
+
+
+def _render_policy_table_text(rows: list[dict]) -> str:
+    """Render a tab-separated plain-text table for non-rich paste targets."""
+    header = "Policy Type\tCarrier\tPolicy #\tEffective\tExpiration\tPremium\tLimit\tDescription"
+    lines = [header]
+    for r in rows:
+        carrier_text = _carrier_display(r.get("carrier") or "", r.get("access_point") or "")
+        line = "\t".join([
+            r.get("policy_type") or "",
+            carrier_text,
+            r.get("policy_number") or "",
+            _fmt_date(r.get("effective_date")),
+            _fmt_date(r.get("expiration_date")),
+            _fmt_currency(r.get("premium")),
+            _fmt_currency(r.get("limit_amount")),
+            r.get("description") or "",
+        ])
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def build_policy_table(
+    conn: sqlite3.Connection,
+    client_id: int,
+    project_name: str | None = None,
+    rows: list[dict] | None = None,
+) -> dict:
+    """Public API: return {"html": ..., "text": ...} for clipboard copy.
+
+    Pass *rows* directly (e.g. from renewal pipeline) or let the function
+    query by *client_id* and optional *project_name*.
+    """
+    if rows is None:
+        rows = _fetch_policy_table_rows(conn, client_id, project_name)
+    return {
+        "html": _render_policy_table_html(rows),
+        "text": _render_policy_table_text(rows),
+    }
+
+
 def _build_policy_list_tokens(conn: sqlite3.Connection, client_id: int, project_name: str | None = None) -> dict:
     """Build formatted policy list and coverage summary tokens.
 
@@ -150,11 +287,16 @@ def _build_policy_list_tokens(conn: sqlite3.Connection, client_id: int, project_
 
     total = sum(float(r["premium"] or 0) for r in policies)
 
+    # -- policy_table: tab-separated table for compose textarea --
+    table_rows = _fetch_policy_table_rows(conn, client_id, project_name)
+    policy_table_text = _render_policy_table_text(table_rows) if table_rows else ""
+
     return {
         "policy_list": "\n".join(lines),
         "coverage_summary": "\n".join(summary_lines),
         "client_total_premium": _fmt_currency(total),
         "client_policy_count": str(len(policies)),
+        "policy_table": policy_table_text,
     }
 
 
@@ -830,6 +972,7 @@ CONTEXT_TOKEN_GROUPS: dict[str, list[tuple[str, list[tuple[str, str]]]]] = {
             ("placement_emails", "Placement Emails (list)"),
             ("policy_list", "Policy List (location)"),
             ("coverage_summary", "Coverage Summary (location)"),
+            ("policy_table", "Policy Table (tab-separated)"),
         ]),
         ("COPE", [
             ("construction_type", "Construction Type"),
@@ -865,6 +1008,7 @@ CONTEXT_TOKEN_GROUPS: dict[str, list[tuple[str, list[tuple[str, str]]]]] = {
         ("Book of Business", [
             ("policy_list", "Policy List"),
             ("coverage_summary", "Coverage Summary"),
+            ("policy_table", "Policy Table (tab-separated)"),
             ("client_total_premium", "Total Premium"),
             ("client_policy_count", "Policy Count"),
             ("rfi_due_dates", "RFI Due Dates"),

--- a/src/policydb/web/routes/activities.py
+++ b/src/policydb/web/routes/activities.py
@@ -1382,6 +1382,39 @@ def renewals_export(window: int = 180, fmt: str = "xlsx", conn=Depends(get_db)):
     )
 
 
+@router.get("/renewals/copy-table")
+def renewals_copy_table(window: int = 180, status: str = "", client_id: int = 0, conn=Depends(get_db)):
+    """Return HTML + plain-text renewal pipeline table for clipboard copy."""
+    from fastapi.responses import JSONResponse
+    from policydb.email_templates import build_policy_table
+    excluded = cfg.get("renewal_statuses_excluded", [])
+    filter_client_ids = [client_id] if client_id else None
+    pipeline = get_renewal_pipeline(
+        conn,
+        window_days=window,
+        renewal_status=status or None,
+        excluded_statuses=excluded,
+        client_ids=filter_client_ids,
+    )
+    # Convert pipeline rows to the standard table row format
+    rows = []
+    for r in pipeline:
+        rd = dict(r)
+        rows.append({
+            "policy_type": rd.get("policy_type") or "",
+            "carrier": rd.get("carrier") or "",
+            "access_point": rd.get("access_point") or "",
+            "policy_number": rd.get("policy_number") or "",
+            "effective_date": rd.get("effective_date") or "",
+            "expiration_date": rd.get("expiration_date") or "",
+            "premium": rd.get("premium"),
+            "limit_amount": rd.get("limit_amount"),
+            "description": rd.get("description") or "",
+        })
+    result = build_policy_table(conn, client_id=0, rows=rows)
+    return JSONResponse(result)
+
+
 _RENEWAL_SORT_FIELDS = {
     "client_name", "carrier", "expiration_date", "days_to_renewal",
     "premium", "renewal_status", "follow_up_date",

--- a/src/policydb/web/routes/clients.py
+++ b/src/policydb/web/routes/clients.py
@@ -3307,6 +3307,15 @@ def export_project(client_id: int, project: str = "", conn=Depends(get_db)):
     )
 
 
+@router.get("/{client_id}/copy-table")
+def copy_table(client_id: int, project: str | None = None, conn=Depends(get_db)):
+    """Return HTML + plain-text policy table for clipboard copy."""
+    from fastapi.responses import JSONResponse
+    from policydb.email_templates import build_policy_table
+    result = build_policy_table(conn, client_id, project_name=project or None)
+    return JSONResponse(result)
+
+
 # ─── Quick CSV exports per section ────────────────────────────────────────────
 
 def _safe_filename(client_name: str, section: str) -> str:

--- a/src/policydb/web/templates/base.html
+++ b/src/policydb/web/templates/base.html
@@ -706,6 +706,32 @@ function copyRefTag(btn, tag) {
   });
 }
 
+function copyPolicyTable(url, btn) {
+  var orig = btn.textContent;
+  btn.textContent = '…';
+  fetch(url).then(function(r) { return r.json(); }).then(function(data) {
+    var htmlBlob = new Blob([data.html], {type: 'text/html'});
+    var textBlob = new Blob([data.text], {type: 'text/plain'});
+    if (typeof ClipboardItem !== 'undefined') {
+      navigator.clipboard.write([new ClipboardItem({'text/html': htmlBlob, 'text/plain': textBlob})]).then(function() {
+        btn.textContent = 'Copied ✓';
+        btn.classList.add('text-green-600');
+        setTimeout(function() { btn.textContent = orig; btn.classList.remove('text-green-600'); }, 1500);
+      });
+    } else {
+      navigator.clipboard.writeText(data.text).then(function() {
+        btn.textContent = 'Copied ✓';
+        btn.classList.add('text-green-600');
+        setTimeout(function() { btn.textContent = orig; btn.classList.remove('text-green-600'); }, 1500);
+      });
+    }
+  }).catch(function() {
+    btn.textContent = 'Error';
+    btn.classList.add('text-red-600');
+    setTimeout(function() { btn.textContent = orig; btn.classList.remove('text-red-600'); }, 1500);
+  });
+}
+
 /* confirmAction is defined via window.confirmAction in the IIFE above */
 </script>
 

--- a/src/policydb/web/templates/clients/_project_header.html
+++ b/src/policydb/web/templates/clients/_project_header.html
@@ -26,6 +26,10 @@
         class="text-xs text-gray-300 hover:text-marsh" title="Compose with template">✉ Compose</button>
       <span class="text-gray-200">|</span>
       <button type="button"
+        onclick="copyPolicyTable('/clients/{{ client.id }}/copy-table?project={{ project_name | urlencode }}', this)"
+        class="text-xs text-gray-300 hover:text-marsh" title="Copy policy table to clipboard">Copy Table</button>
+      <span class="text-gray-200">|</span>
+      <button type="button"
         hx-get="/clients/{{ client.id }}/project/log-form?project={{ project_name | urlencode }}"
         hx-target="closest .proj-hdr-wrap"
         hx-swap="outerHTML"

--- a/src/policydb/web/templates/clients/_tab_policies.html
+++ b/src/policydb/web/templates/clients/_tab_policies.html
@@ -12,6 +12,9 @@
   <div class="flex items-center justify-between mb-3">
     <h2 class="font-semibold text-gray-900 text-lg">Policies</h2>
     <div class="flex gap-3 no-print">
+      <button type="button"
+        onclick="copyPolicyTable('/clients/{{ client.id }}/copy-table', this)"
+        class="text-xs text-gray-400 hover:text-marsh" title="Copy all policies as table">Copy Table</button>
       <button type="button" onclick="toggleNewProgramForm()" class="text-xs text-marsh hover:underline">+ New Program</button>
       <a href="/policies/new?client={{ client.id }}&opp=1" class="text-xs text-amber-600 hover:underline">+ Opportunity</a>
       <a href="/policies/new?client={{ client.id }}" class="text-xs text-marsh hover:underline">+ Add Policy</a>

--- a/src/policydb/web/templates/clients/project.html
+++ b/src/policydb/web/templates/clients/project.html
@@ -27,6 +27,9 @@
         <span id="proj-save-ts" class="text-xs text-gray-400">
           {% if project.updated_at_fmt %}saved {{ project.updated_at_fmt }}{% endif %}
         </span>
+        <button type="button"
+           onclick="copyPolicyTable('/clients/{{ client.id }}/copy-table?project={{ project.name | urlencode }}', this)"
+           class="text-xs bg-gray-100 hover:bg-gray-200 text-gray-600 px-2.5 py-1 rounded transition-colors no-print">Copy Table</button>
         <a href="/clients/{{ client.id }}/projects/{{ project.id }}/pdf"
            class="text-xs bg-gray-100 hover:bg-gray-200 text-gray-600 px-2.5 py-1 rounded transition-colors no-print">Export PDF ↓</a>
       </div>

--- a/src/policydb/web/templates/renewals.html
+++ b/src/policydb/web/templates/renewals.html
@@ -17,6 +17,9 @@
       <span class="border-l border-gray-200 h-6 mx-1"></span>
       <a href="/renewals/calendar" class="btn-filter">Calendar</a>
       <span class="border-l border-gray-200 h-6 mx-1"></span>
+      <button type="button"
+        onclick="copyPolicyTable('/renewals/copy-table?window={{ window }}&status={{ status | urlencode }}&client_id={{ client_id or '' }}', this)"
+        class="border border-gray-300 hover:border-marsh text-gray-700 hover:text-marsh text-sm font-medium px-3 py-1.5 rounded-lg transition-colors">Copy Table</button>
       <a href="/renewals/export?window={{ window }}&fmt=csv" class="border border-gray-300 hover:border-marsh text-gray-700 hover:text-marsh text-sm font-medium px-3 py-1.5 rounded-lg transition-colors">CSV ↓</a>
       <a href="/renewals/export?window={{ window }}&fmt=xlsx" class="border border-green-600 hover:bg-green-600 text-green-700 hover:text-white text-sm font-medium px-3 py-1.5 rounded-lg transition-colors">XLSX ↓</a>
     </div>


### PR DESCRIPTION
## Summary
- Adds "Copy Table" button across 4 locations (client policies tab, project group header, project detail page, renewal pipeline) that copies a formatted HTML+text policy table to clipboard
- Inline-styled HTML for Outlook compatibility; plain-text tab-separated fallback
- Carrier column auto-formats as "Carrier via Access Point" when access_point is set
- New `{{policy_table}}` email template token for compose panel
- Documented reusable pattern in CLAUDE.md for future deployment

## Test plan
- [ ] Click Copy Table on client policies tab header — paste into Outlook/rich editor
- [ ] Click Copy Table on project group action bar — verify scoped to that project
- [ ] Click Copy Table on project detail page — verify same output
- [ ] Click Copy Table on renewal pipeline — verify filtered by current window/status
- [ ] Paste into plain text editor — verify tab-separated format
- [ ] Verify "Carrier via Access Point" format on policies with access_point set

🤖 Generated with [Claude Code](https://claude.com/claude-code)