### PR TITLE
feat: LLM import extracts sub-coverages for user confirmation

### DIFF
--- a/docs/superpowers/specs/2026-03-30-llm-import-sub-coverages-design.md
+++ b/docs/superpowers/specs/2026-03-30-llm-import-sub-coverages-design.md
@@ -1,0 +1,145 @@
+# LLM Import — Sub-Coverage Extraction & Confirmation
+
+**Date:** 2026-03-30
+**Status:** Approved
+
+## Summary
+
+Enhance the single-policy AI import flow to also extract sub-coverages (coverage types, limits, deductibles) from the LLM response, present them in a confirmation panel, and allow the user to selectively apply them to the policy.
+
+## Current State
+
+- `POLICY_EXTRACTION_SCHEMA` extracts policy-level fields and locations/COPE — no sub-coverages.
+- `POLICY_BULK_IMPORT_SCHEMA` already defines a `sub_coverages` nested group (coverage_type, limit, deductible, notes).
+- The `_ai_review_panel.html` shows Section A (policy field diffs) and Section B (location/COPE diffs) — no sub-coverage section.
+- Sub-coverage CRUD endpoints already exist: `POST /policies/{uid}/sub-coverages`, `PATCH /policies/{uid}/sub-coverages/{id}`, `DELETE`.
+- DB table `policy_sub_coverages` supports 13+ columns; we extract the essential 5.
+
+## Design
+
+### 1. Schema Change (`llm_schemas.py`)
+
+Add `sub_coverages` to `POLICY_EXTRACTION_SCHEMA["nested_groups"]`:
+
+```python
+"sub_coverages": {
+    "type": "array",
+    "optional": True,
+    "description": (
+        "Sub-coverages, endorsements, or coverage parts within this policy. "
+        "Use for: package/BOP policies with multiple lines, Workers Comp "
+        "with Employers Liability, or any policy listing multiple coverage "
+        "sections with separate limits or deductibles."
+    ),
+    "fields": [
+        {
+            "key": "coverage_type",
+            "label": "Coverage Type",
+            "type": "string",
+            "required": True,
+            "description": "The sub-line coverage type (e.g., General Liability, Property, Employers Liability)",
+            "config_values": "policy_types",
+            "config_mode": "prefer",
+            "normalizer": "normalize_coverage_type",
+        },
+        {
+            "key": "limit_amount",
+            "label": "Limit",
+            "type": "number",
+            "required": False,
+            "description": "Per-occurrence or aggregate limit for this sub-coverage",
+            "normalizer": "parse_currency_with_magnitude",
+        },
+        {
+            "key": "deductible",
+            "label": "Deductible / Retention",
+            "type": "number",
+            "required": False,
+            "description": "Deductible or self-insured retention for this sub-coverage",
+            "normalizer": "parse_currency_with_magnitude",
+        },
+        {
+            "key": "coverage_form",
+            "label": "Coverage Form",
+            "type": "string",
+            "required": False,
+            "description": "Coverage trigger form (e.g., Occurrence, Claims-Made)",
+            "config_values": "coverage_forms",
+            "config_mode": "strict",
+        },
+        {
+            "key": "notes",
+            "label": "Notes",
+            "type": "string",
+            "required": False,
+            "description": "Any additional notes about this sub-coverage",
+        },
+    ],
+}
+```
+
+No changes to prompt generation or JSON template code — the generic `nested_groups` handling in `generate_extraction_prompt()`, `generate_json_template()`, and `parse_llm_json()` already handles arbitrary nested groups.
+
+### 2. Parse Logic (`policies.py` — `_ai_import_parse_inner`)
+
+After the location diff block, add sub-coverage diff logic:
+
+1. Extract `sub_coverages_parsed = result["parsed"].get("sub_coverages", [])`
+2. Load existing: `existing_subs = _get_sub_coverages(conn, merged["id"])`
+3. For each extracted sub-coverage:
+   - Fuzzy-match `coverage_type` against existing sub-coverages using `fuzz.ratio()` (threshold ≥ 75)
+   - If matched: build per-field diffs (`limit_amount`, `deductible`, `coverage_form`, `notes`) — same `{field, label, current, extracted, is_fill}` pattern
+   - If no match: mark as `match_type: "new"`, all fields are fills
+4. Build `ai_sub_coverage_data` list, each entry:
+   ```python
+   {
+       "index": int,
+       "coverage_type": str,       # extracted coverage type
+       "extracted": dict,          # all extracted fields
+       "existing": dict | None,    # matched existing sub-coverage row
+       "existing_id": int | None,  # DB id if updating
+       "diffs": list[dict],        # per-field diffs
+       "match_type": "matched" | "new",
+       "match_score": int,
+   }
+   ```
+5. Pass `ai_sub_coverage_data` to template context.
+
+### 3. Review Panel UI (`_ai_review_panel.html`)
+
+Add Section C after locations. Purple/violet theme to distinguish from policy (indigo) and location (emerald):
+
+- **Card**: `border-violet-200 bg-violet-50/20`
+- **Header**: "Sub-Coverages" with count badge
+- **Per sub-coverage**: coverage type as header, match badge if updating, per-field diff rows with checkboxes (pre-checked for fills)
+- **Actions**: "Apply Sub-Coverages" button + Select All / Clear All links
+- **Success state**: Green confirmation with count of applied sub-coverages
+
+### 4. Apply JS Function
+
+`applySubCoverages()` in the review panel script:
+
+1. Collect checked sub-coverages and their selected fields from the parsed JSON
+2. For each new sub-coverage:
+   - `POST /policies/{uid}/sub-coverages` with `coverage_type` body
+   - Then `PATCH /policies/{uid}/sub-coverages/{new_id}` with financial fields
+3. For each existing sub-coverage update:
+   - `PATCH /policies/{uid}/sub-coverages/{existing_id}` with selected fields
+4. On success, replace the card with green confirmation
+5. Currency fields sent as raw numbers (the PATCH endpoint handles formatting)
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/policydb/llm_schemas.py` | Add `sub_coverages` to `POLICY_EXTRACTION_SCHEMA["nested_groups"]` |
+| `src/policydb/web/routes/policies.py` | Add sub-coverage diff logic to `_ai_import_parse_inner()`, pass `ai_sub_coverage_data` to template |
+| `src/policydb/web/templates/policies/_ai_review_panel.html` | Add Section C for sub-coverage review + JS apply function |
+
+## Not Changed
+
+- No new routes (reuses existing sub-coverage CRUD endpoints)
+- No migrations (table already has all needed columns)
+- No new JS libraries
+- No config changes
+- Prompt generation and JSON template code unchanged (generic nested_groups handling)

--- a/src/policydb/llm_schemas.py
+++ b/src/policydb/llm_schemas.py
@@ -503,6 +503,60 @@ POLICY_EXTRACTION_SCHEMA: dict = {
                 },
             },
         },
+        "sub_coverages": {
+            "type": "array",
+            "optional": True,
+            "description": (
+                "Sub-coverages, endorsements, or coverage parts within this policy. "
+                "Use for: package/BOP policies with multiple lines, Workers Comp "
+                "with Employers Liability, or any policy listing multiple coverage "
+                "sections with separate limits or deductibles."
+            ),
+            "fields": [
+                {
+                    "key": "coverage_type",
+                    "label": "Coverage Type",
+                    "type": "string",
+                    "required": True,
+                    "description": "The sub-line coverage type (e.g., General Liability, Property, Employers Liability)",
+                    "config_values": "policy_types",
+                    "config_mode": "prefer",
+                    "normalizer": "normalize_coverage_type",
+                },
+                {
+                    "key": "limit_amount",
+                    "label": "Limit",
+                    "type": "number",
+                    "required": False,
+                    "description": "Per-occurrence or aggregate limit for this sub-coverage",
+                    "normalizer": "parse_currency_with_magnitude",
+                },
+                {
+                    "key": "deductible",
+                    "label": "Deductible / Retention",
+                    "type": "number",
+                    "required": False,
+                    "description": "Deductible or self-insured retention for this sub-coverage",
+                    "normalizer": "parse_currency_with_magnitude",
+                },
+                {
+                    "key": "coverage_form",
+                    "label": "Coverage Form",
+                    "type": "string",
+                    "required": False,
+                    "description": "Coverage trigger form (e.g., Occurrence, Claims-Made)",
+                    "config_values": "coverage_forms",
+                    "config_mode": "strict",
+                },
+                {
+                    "key": "notes",
+                    "label": "Notes",
+                    "type": "string",
+                    "required": False,
+                    "description": "Any additional notes about this sub-coverage",
+                },
+            ],
+        },
     },
 }
 

--- a/src/policydb/web/routes/policies.py
+++ b/src/policydb/web/routes/policies.py
@@ -1298,7 +1298,7 @@ def _ai_import_parse_inner(request: Request, conn, uid: str, result: dict):
     import_changes: list[dict] = []
     _field_labels = {f["key"]: f["label"] for f in POLICY_EXTRACTION_SCHEMA.get("fields", [])}
     for k, v in result["parsed"].items():
-        if v is not None and k != "locations":
+        if v is not None and k not in ("locations", "sub_coverages"):
             old_val = policy_dict.get(k)
             if str(v).strip() != str(old_val or "").strip():
                 import_changes.append({
@@ -1352,7 +1352,7 @@ def _ai_import_parse_inner(request: Request, conn, uid: str, result: dict):
     _field_labels = {f["key"]: f["label"] for f in POLICY_EXTRACTION_SCHEMA["fields"]}
     ai_policy_diffs: list[dict] = []
     for k, v in result["parsed"].items():
-        if k == "locations" or v is None:
+        if k in ("locations", "sub_coverages") or v is None:
             continue
         current = policy_dict.get(k)
         current_str = str(current) if current is not None else ""
@@ -1495,9 +1495,84 @@ def _ai_import_parse_inner(request: Request, conn, uid: str, result: dict):
 
             ai_location_data.append(loc_entry)
 
+    # ── Build sub-coverage diffs ──
+    sub_coverages_parsed = result["parsed"].get("sub_coverages", [])
+    ai_sub_coverage_data: list[dict] = []
+    if sub_coverages_parsed:
+        existing_subs = _get_sub_coverages(conn, merged["id"])
+        _sc_field_labels = {
+            "coverage_type": "Coverage Type",
+            "limit_amount": "Limit",
+            "deductible": "Deductible / Retention",
+            "coverage_form": "Coverage Form",
+            "notes": "Notes",
+        }
+        _sc_diff_fields = ["limit_amount", "deductible", "coverage_form", "notes"]
+
+        for sc_idx, sc in enumerate(sub_coverages_parsed):
+            sc_type = sc.get("coverage_type", "")
+            sc_entry: dict = {
+                "index": sc_idx,
+                "coverage_type": sc_type,
+                "extracted": sc,
+                "existing": None,
+                "existing_id": None,
+                "diffs": [],
+                "match_type": "new",
+                "match_score": 0,
+            }
+
+            # Fuzzy-match against existing sub-coverages by coverage_type
+            if existing_subs and sc_type:
+                best_score = 0
+                best_match = None
+                for esub in existing_subs:
+                    score = fuzz.ratio(
+                        sc_type.lower(), (esub.get("coverage_type") or "").lower()
+                    )
+                    if score > best_score and score >= 75:
+                        best_score = score
+                        best_match = esub
+                if best_match:
+                    sc_entry["match_type"] = "matched"
+                    sc_entry["match_score"] = int(best_score)
+                    sc_entry["existing"] = best_match
+                    sc_entry["existing_id"] = best_match["id"]
+
+                    # Per-field diffs
+                    for fkey in _sc_diff_fields:
+                        ext_val = sc.get(fkey)
+                        cur_val = best_match.get(fkey)
+                        if ext_val is not None:
+                            cur_str = str(cur_val) if cur_val else ""
+                            ext_str = str(ext_val) if ext_val else ""
+                            if cur_str != ext_str:
+                                sc_entry["diffs"].append({
+                                    "field": fkey,
+                                    "label": _sc_field_labels.get(fkey, fkey),
+                                    "current": cur_val,
+                                    "extracted": ext_val,
+                                    "is_fill": not cur_str,
+                                })
+
+            if sc_entry["match_type"] == "new":
+                # All fields are fills for new sub-coverages
+                for fkey in _sc_diff_fields:
+                    ext_val = sc.get(fkey)
+                    if ext_val is not None:
+                        sc_entry["diffs"].append({
+                            "field": fkey,
+                            "label": _sc_field_labels.get(fkey, fkey),
+                            "current": None,
+                            "extracted": ext_val,
+                            "is_fill": True,
+                        })
+
+            ai_sub_coverage_data.append(sc_entry)
+
     logger.debug(
-        "AI import parse inner: diffs built — %d policy diffs, %d locations",
-        len(ai_policy_diffs), len(ai_location_data),
+        "AI import parse inner: diffs built — %d policy diffs, %d locations, %d sub-coverages",
+        len(ai_policy_diffs), len(ai_location_data), len(ai_sub_coverage_data),
     )
 
     # Build the same context as policy_tab_details
@@ -1574,6 +1649,7 @@ def _ai_import_parse_inner(request: Request, conn, uid: str, result: dict):
         "ai_warnings": ai_warnings,
         "ai_policy_diffs": ai_policy_diffs,
         "ai_location_data": ai_location_data,
+        "ai_sub_coverage_data": ai_sub_coverage_data,
         "ai_parsed_json": json.dumps(result["parsed"], default=str),
     })
 

--- a/src/policydb/web/templates/policies/_ai_review_panel.html
+++ b/src/policydb/web/templates/policies/_ai_review_panel.html
@@ -160,6 +160,74 @@
   {% endfor %}
   {% endif %}
 
+  {# ══════════════════════════════════════════════════════════════════════════
+     SECTION C — Sub-Coverage Review
+     ══════════════════════════════════════════════════════════════════════════ #}
+  {% if ai_sub_coverage_data is defined and ai_sub_coverage_data %}
+  <div class="card border-violet-200 bg-violet-50/20 mb-4" id="ai-sub-coverages-card">
+    <div class="px-5 py-3 border-b border-violet-100 flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-4 h-4 text-violet-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"/>
+        </svg>
+        <span class="text-xs font-semibold text-violet-600 uppercase tracking-wide">Sub-Coverages</span>
+      </div>
+      <span class="text-xs text-gray-400">{{ ai_sub_coverage_data | length }} found</span>
+    </div>
+
+    {% for sc in ai_sub_coverage_data %}
+    <div class="border-b border-violet-50 last:border-b-0" id="ai-sc-item-{{ sc.index }}"
+         {% if sc.existing_id %}data-existing-id="{{ sc.existing_id }}"{% endif %}>
+      {# Sub-coverage header #}
+      <div class="px-5 py-2.5 flex items-center gap-3 bg-violet-50/30">
+        <input type="checkbox" class="ai-sc-select rounded border-gray-300 text-violet-600 focus:ring-violet-500"
+               value="{{ sc.index }}" checked>
+        <span class="text-xs font-semibold text-violet-800">{{ sc.coverage_type }}</span>
+        {% if sc.match_type == 'matched' %}
+        <span class="px-2 py-0.5 rounded-full text-[10px] font-bold bg-violet-100 text-violet-700">
+          Update existing ({{ sc.match_score }}%)
+        </span>
+        {% else %}
+        <span class="px-2 py-0.5 rounded-full text-[10px] font-bold bg-blue-100 text-blue-700">New</span>
+        {% endif %}
+      </div>
+
+      {# Per-field diffs #}
+      {% if sc.diffs %}
+      <div class="divide-y divide-violet-50">
+        {% for d in sc.diffs %}
+        <label class="flex items-center gap-4 px-5 py-2 hover:bg-violet-50/40 cursor-pointer transition-colors">
+          <input type="checkbox" name="apply_sc_{{ sc.index }}" value="{{ d.field }}"
+                 class="ai-sc-field-cb-{{ sc.index }} rounded border-gray-300 text-violet-600 focus:ring-violet-500"
+                 {% if d.is_fill %}checked{% endif %}>
+          <span class="text-xs font-medium text-gray-500 w-36 shrink-0">{{ d.label }}</span>
+          <span class="text-xs text-gray-400 flex-1 truncate">
+            {% if d.current is not none and d.current != '' %}{{ d.current }}{% else %}<em class="text-gray-300">empty</em>{% endif %}
+          </span>
+          <svg class="w-4 h-4 text-violet-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+          </svg>
+          <span class="text-xs font-medium text-violet-700 flex-1 truncate">{{ d.extracted }}</span>
+        </label>
+        {% endfor %}
+      </div>
+      {% endif %}
+    </div>
+    {% endfor %}
+
+    <div class="px-5 py-3 border-t border-violet-100 flex items-center gap-3">
+      <button type="button" onclick="applySubCoverages()"
+              class="px-4 py-1.5 rounded-lg text-xs font-medium bg-violet-600 text-white hover:bg-violet-700 transition-colors">
+        Apply Selected Sub-Coverages
+      </button>
+      <button type="button" onclick="document.querySelectorAll('.ai-sc-select').forEach(function(cb){cb.checked=true})"
+              class="text-xs text-violet-500 hover:text-violet-700">Select All</button>
+      <button type="button" onclick="document.querySelectorAll('.ai-sc-select').forEach(function(cb){cb.checked=false})"
+              class="text-xs text-gray-400 hover:text-gray-600">Clear All</button>
+    </div>
+  </div>
+  {% endif %}
+
 </div>
 
 <script>
@@ -243,6 +311,92 @@ function applyLocation(locIndex, projectId, createNew) {
         '<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>' +
         label + ' — ' + count + ' field' + (count !== 1 ? 's' : '') + ' applied' +
         (data.created ? ' (new location created)' : '') + '</div>';
+      card.className = 'card border-emerald-200 bg-emerald-50/20 mb-4';
+    }
+  });
+}
+
+function applySubCoverages() {
+  var panel = document.getElementById('ai-review-panel');
+  var parsed = JSON.parse(panel.dataset.parsed);
+  var subCoverages = parsed.sub_coverages || [];
+  var uid = '{{ policy.policy_uid }}';
+  var applied = 0;
+
+  /* Collect selected sub-coverage indices */
+  var selectedIndices = [];
+  document.querySelectorAll('.ai-sc-select:checked').forEach(function(cb) {
+    selectedIndices.push(parseInt(cb.value));
+  });
+  if (!selectedIndices.length) return;
+
+  /* Build data per selected sub-coverage: index → {existing_id, fields_to_patch} */
+  var tasks = selectedIndices.map(function(idx) {
+    var scData = subCoverages[idx];
+    if (!scData) return null;
+
+    /* Collect selected fields for this sub-coverage */
+    var fields = {};
+    document.querySelectorAll('.ai-sc-field-cb-' + idx + ':checked').forEach(function(cb) {
+      var val = scData[cb.value];
+      if (val !== undefined && val !== null) fields[cb.value] = val;
+    });
+
+    /* Read existing_id from the template-rendered data attribute */
+    var itemEl = document.getElementById('ai-sc-item-' + idx);
+    var existingId = itemEl ? itemEl.dataset.existingId : null;
+
+    return {
+      index: idx,
+      coverage_type: scData.coverage_type || '',
+      existing_id: existingId ? parseInt(existingId) : null,
+      fields: fields
+    };
+  }).filter(Boolean);
+
+  /* Process sequentially: create new or patch existing */
+  var chain = Promise.resolve();
+  tasks.forEach(function(task) {
+    chain = chain.then(function() {
+      if (task.existing_id) {
+        /* Patch existing sub-coverage */
+        return fetch('/policies/' + uid + '/sub-coverages/' + task.existing_id, {
+          method: 'PATCH',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify(task.fields)
+        }).then(function(r) { applied++; return r; });
+      } else {
+        /* Create new, then patch with financial fields */
+        return fetch('/policies/' + uid + '/sub-coverages', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({coverage_type: task.coverage_type})
+        }).then(function(r) { return r.json(); })
+        .then(function(data) {
+          if (!data.ok) return;
+          /* Find the newly created sub-coverage id */
+          var subs = data.sub_coverages || [];
+          var newSub = subs.find(function(s) { return s.coverage_type === task.coverage_type; });
+          if (newSub && Object.keys(task.fields).length > 0) {
+            return fetch('/policies/' + uid + '/sub-coverages/' + newSub.id, {
+              method: 'PATCH',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify(task.fields)
+            }).then(function() { applied++; });
+          } else {
+            applied++;
+          }
+        });
+      }
+    });
+  });
+
+  chain.then(function() {
+    var card = document.getElementById('ai-sub-coverages-card');
+    if (card) {
+      card.innerHTML = '<div class="px-5 py-4 text-sm text-emerald-600 font-medium flex items-center gap-2">' +
+        '<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>' +
+        applied + ' sub-coverage' + (applied !== 1 ? 's' : '') + ' applied</div>';
       card.className = 'card border-emerald-200 bg-emerald-50/20 mb-4';
     }
   });

--- a/src/policydb/web/templates/policies/_tab_details.html
+++ b/src/policydb/web/templates/policies/_tab_details.html
@@ -19,7 +19,7 @@ textarea.field-inline { resize: none; }
 </style>
 <div id="tab-details-content">
 
-{% if ai_policy_diffs is defined and (ai_policy_diffs or ai_location_data) %}
+{% if ai_policy_diffs is defined and (ai_policy_diffs or ai_location_data or ai_sub_coverage_data) %}
 {% include 'policies/_ai_review_panel.html' %}
 {% endif %}
 


### PR DESCRIPTION
## Summary
- Adds `sub_coverages` nested group to `POLICY_EXTRACTION_SCHEMA` — the AI import prompt now asks for coverage types, limits, deductibles, coverage forms, and notes
- Parse route fuzzy-matches extracted sub-coverages against existing ones and builds per-field diffs
- Violet-themed review panel (Section C) in `_ai_review_panel.html` shows each sub-coverage with checkboxes for selective apply
- Apply action creates new or patches existing sub-coverages via existing CRUD endpoints

## Test plan
- [x] Schema loads with `sub_coverages` in nested_groups
- [x] Prompt generation includes sub-coverage instructions
- [x] Parse endpoint returns sub-coverage review UI with correct diffs
- [x] Sub-coverages excluded from policy-level field diffs
- [x] Apply creates sub-coverages with correct financial fields in DB
- [x] Fuzzy matching works for existing sub-coverages (update vs new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)