### PR TITLE
feat: location-scoped programs

### DIFF
--- a/docs/superpowers/specs/2026-03-30-location-scoped-programs-design.md
+++ b/docs/superpowers/specs/2026-03-30-location-scoped-programs-design.md
@@ -1,0 +1,177 @@
+# Location-Scoped Programs
+
+**Date:** 2026-03-30
+**Status:** Draft
+
+## Problem
+
+Programs and projects/locations are currently independent entities in PolicyDB. Both hang off a client, but they have no direct relationship. In practice, insurance programs are often tied to specific locations (a plant's coverage tower) or construction projects (OCIP/CCIP wrap-ups). Without this link, the user must mentally track which programs belong to which locations.
+
+## Solution
+
+Add a nullable `project_id` FK on the `programs` table, creating a direct Client → Location → Program → Policies hierarchy. Location-scoped programs auto-sync their location to child policies on assignment.
+
+---
+
+## Schema
+
+### Migration (next sequential number)
+
+```sql
+ALTER TABLE programs ADD COLUMN project_id INTEGER REFERENCES projects(id) ON DELETE CASCADE;
+CREATE INDEX idx_programs_project ON programs(project_id);
+```
+
+- `ON DELETE CASCADE` — deleting a location deletes its programs
+- Before cascading, application code must null out `policies.program_id` for affected child policies (since `policies.program_id` FK lacks CASCADE)
+- Existing programs get `project_id = NULL` — client-level programs, unchanged behavior
+
+---
+
+## Auto-Sync Behavior
+
+### Policy → Location-Scoped Program Assignment
+
+When a policy is assigned to a program that has `project_id` set:
+
+1. Set `policies.program_id` = program.id *(existing)*
+2. Set `policies.project_id` = program.project_id *(new)*
+3. Set `policies.project_name` = project.name *(new)*
+4. Sync exposure address fields from project *(existing location-assign behavior)*
+
+### Policy Unassignment
+
+When a policy is removed from a location-scoped program:
+- Clear `policies.program_id` *(existing)*
+- **Do not** clear `policies.project_id` — the policy may legitimately remain at that location
+
+### Program Location Change
+
+When a program's `project_id` is updated to a different location:
+- Show inline prompt: "Move X child policies to new location too?"
+- If yes: update all child policies' `project_id` + exposure fields
+- If no: only the program's link changes; policies keep their current location
+
+---
+
+## UI Changes
+
+### Program Detail Page (Header)
+
+- Show location name + link next to program name if `project_id` is set
+- Location picker (combobox of client's locations/projects) in header, editable
+- Changing location triggers the move-children prompt above
+
+### Program Creation Flow
+
+- Existing "Create Program" on client Programs tab stays the same
+- New: optional location picker (combobox) in creation form
+- New: "Create Program" button on project/location detail page — pre-fills `project_id`
+
+### Project/Location Detail Page
+
+New **Programs** section below existing content:
+- Cards for each program at this location: name, LOB, total premium, policy count, status badge
+- "Create Program" button (scoped to this location)
+- Click card → navigate to program detail page
+
+### Client Programs Tab
+
+Group programs by location:
+- **Location A** — Program 1, Program 2
+- **Location B** — Program 3
+- **Client-Level** — Programs with no location (`project_id IS NULL`)
+
+Each group is collapsible. Location name links to project detail page.
+
+### Location Assignment Board
+
+- Show small program count badge on location cards that have programs
+- e.g., "2 programs" next to policy count
+
+### Construction Project Completion
+
+When a construction project's status changes to "Complete":
+- Check for active (non-archived) programs linked to this project
+- If found, show inline confirmation: "This project has X active program(s). Archive them too?"
+- "Yes" → set `programs.archived = 1` for all linked programs
+- "No" → programs remain active (tail coverage scenario)
+
+---
+
+## Query Changes
+
+### New Queries
+
+- `get_programs_for_project(conn, project_id)` — all programs for a location with aggregates (policy_count, carrier_count, total_premium)
+
+### Modified Queries
+
+- `get_programs_for_client(conn, client_id)` — add JOIN to projects for `project_id`, `project_name`; support grouping by location
+- `get_program_pipeline(conn, client_id, window_days)` — include project info for display/grouping
+- `get_programs_for_client()` result set gets `project_name` field
+
+### Auto-Sync Helper
+
+New function in `programs.py`:
+```
+_sync_policy_to_program_location(conn, policy_uid, program)
+```
+Sets `project_id`, `project_name`, and exposure address fields on the policy from the program's linked project.
+
+Called from:
+- `/programs/{uid}/assign/{policy_uid}` endpoint
+- Bulk renewal flow (new child policies)
+
+---
+
+## Renewal Behavior
+
+When a program renews via `/programs/{uid}/renew`:
+- New child policies inherit `program_id` *(existing)*
+- New child policies inherit the program's `project_id` via auto-sync *(new)*
+- The program itself keeps its `project_id` — location doesn't change on renewal
+
+---
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| Existing program, no location | Works as today. `project_id = NULL`. |
+| Policy at location A, assigned to program at location B | Auto-sync overwrites to location B |
+| Program moved to different location | Prompt: "Move X children too?" |
+| Location deleted (CASCADE) | Null child policies' `program_id` first, then programs cascade-delete |
+| Program unlinked from location (`project_id` → NULL) | Becomes client-level. Children keep their current location. |
+| Multiple programs at same location | Each operates independently. No conflict. |
+
+---
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `src/policydb/migrations/NNN_program_project_link.sql` | New migration: add `project_id` FK + index |
+| `src/policydb/db.py` | Wire migration into `init_db()` |
+| `src/policydb/queries.py` | `get_programs_for_project()`, modify `get_programs_for_client()`, `get_program_pipeline()` |
+| `src/policydb/web/routes/programs.py` | Auto-sync on assign, location picker in header, location change prompt |
+| `src/policydb/web/routes/clients.py` | Programs section on project detail, completion prompt, location board badge |
+| `src/policydb/web/templates/programs/detail.html` | Location display + picker in header |
+| `src/policydb/web/templates/clients/project.html` | New Programs section |
+| `src/policydb/web/templates/clients/_programs.html` | Group by location |
+| `src/policydb/web/templates/clients/_location_board.html` | Program count badge |
+
+---
+
+## Verification
+
+1. **Create location-scoped program:** Create a program from a location detail page. Verify `project_id` is set.
+2. **Assign policy:** Assign a policy to the location-scoped program. Verify policy's `project_id` and exposure address auto-sync.
+3. **Unassign policy:** Remove policy from program. Verify `project_id` stays on the policy.
+4. **Move program location:** Change program's location. Verify prompt appears. Test both Yes/No paths.
+5. **Client Programs tab:** Verify programs grouped by location with client-level section.
+6. **Location board:** Verify program count badges on locations.
+7. **Construction completion:** Set project status to Complete. Verify archive prompt for programs.
+8. **Renewal:** Renew a location-scoped program. Verify new policies get the same location.
+9. **Delete location:** Delete a location with programs. Verify programs cascade-delete and child policies' `program_id` is nulled.
+10. **Existing programs:** Verify client-level programs (no location) work unchanged.

--- a/src/policydb/db.py
+++ b/src/policydb/db.py
@@ -362,7 +362,7 @@ def init_db(path: Path | None = None) -> None:
     # Back up the database once before running any pending migrations.
     # This gives a clean restore point regardless of which migration fails.
 
-    _KNOWN_MIGRATIONS = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112}
+    _KNOWN_MIGRATIONS = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114}
 
     if _KNOWN_MIGRATIONS - applied:
         _backup_db(conn, db_path)
@@ -1555,6 +1555,21 @@ def init_db(path: Path | None = None) -> None:
         )
         conn.commit()
         logger.info("Migration 112: created knowledge base tables")
+
+    if 114 not in applied:
+        existing_cols = {r[1] for r in conn.execute("PRAGMA table_info(programs)").fetchall()}
+        if "project_id" not in existing_cols:
+            conn.execute("ALTER TABLE programs ADD COLUMN project_id INTEGER REFERENCES projects(id) ON DELETE CASCADE")
+        try:
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_programs_project ON programs(project_id)")
+        except Exception:
+            pass
+        conn.execute(
+            "INSERT INTO schema_version (version, description) VALUES (?, ?)",
+            (114, "Link programs to projects/locations via project_id FK"),
+        )
+        conn.commit()
+        logger.info("Migration 114: added project_id FK to programs table")
 
     # Data hygiene: fix 'None' string corruption in text fields (runs every startup, fast no-op if clean)
     conn.execute("UPDATE clients SET cn_number = NULL WHERE cn_number = 'None'")

--- a/src/policydb/migrations/114_program_project_link.sql
+++ b/src/policydb/migrations/114_program_project_link.sql
@@ -1,0 +1,6 @@
+-- Migration 113: Link programs to projects/locations
+-- Adds project_id FK on programs table so programs can be scoped to a location or construction project.
+-- ON DELETE CASCADE: deleting a location cascades to its programs.
+
+ALTER TABLE programs ADD COLUMN project_id INTEGER REFERENCES projects(id) ON DELETE CASCADE;
+CREATE INDEX IF NOT EXISTS idx_programs_project ON programs(project_id);

--- a/src/policydb/queries.py
+++ b/src/policydb/queries.py
@@ -196,8 +196,9 @@ def get_program_pipeline(
     """Return one row per active program with renewal-relevant aggregated data."""
     sql = """
     SELECT pg.id AS program_id, pg.program_uid, pg.name AS program_name,
-           pg.client_id, pg.renewal_status,
+           pg.client_id, pg.renewal_status, pg.project_id,
            c.name AS client_name, c.cn_number,
+           pr.name AS project_name,
            COUNT(p.id) AS policy_count,
            COUNT(DISTINCT p.carrier) AS carrier_count,
            COALESCE(SUM(p.premium), 0) AS total_premium,
@@ -206,6 +207,7 @@ def get_program_pipeline(
            GROUP_CONCAT(DISTINCT p.carrier) AS carriers_list
     FROM programs pg
     JOIN clients c ON pg.client_id = c.id
+    LEFT JOIN projects pr ON pg.project_id = pr.id
     LEFT JOIN policies p ON p.program_id = pg.id
         AND p.archived = 0
         AND (p.is_opportunity = 0 OR p.is_opportunity IS NULL)
@@ -2690,7 +2692,13 @@ def auto_generate_sub_coverages(conn, policy_id: int, policy_type: str):
 def get_program_by_uid(conn: sqlite3.Connection, program_uid: str) -> dict | None:
     """Return a program dict by its UID, or None if not found."""
     row = conn.execute(
-        "SELECT * FROM programs WHERE program_uid = ?", (program_uid,)
+        """SELECT pg.*, pr.name AS project_name,
+                  pr.address AS project_address, pr.city AS project_city,
+                  pr.state AS project_state, pr.zip AS project_zip
+           FROM programs pg
+           LEFT JOIN projects pr ON pg.project_id = pr.id
+           WHERE pg.program_uid = ?""",
+        (program_uid,),
     ).fetchone()
     return dict(row) if row else None
 
@@ -2731,10 +2739,29 @@ def get_program_aggregates(conn: sqlite3.Connection, program_id: int) -> dict:
 
 
 def get_programs_for_client(conn: sqlite3.Connection, client_id: int) -> list[dict]:
-    """Return all programs for a client with aggregated stats."""
+    """Return all programs for a client with aggregated stats, including project/location info."""
     rows = conn.execute(
-        "SELECT * FROM programs WHERE client_id = ? AND archived = 0 ORDER BY name",
+        """SELECT pg.*, pr.name AS project_name
+           FROM programs pg
+           LEFT JOIN projects pr ON pg.project_id = pr.id
+           WHERE pg.client_id = ? AND pg.archived = 0
+           ORDER BY pr.name NULLS LAST, pg.name""",
         (client_id,),
+    ).fetchall()
+    programs = []
+    for r in rows:
+        pgm = dict(r)
+        agg = get_program_aggregates(conn, pgm["id"])
+        pgm.update(agg)
+        programs.append(pgm)
+    return programs
+
+
+def get_programs_for_project(conn: sqlite3.Connection, project_id: int) -> list[dict]:
+    """Return all programs linked to a specific project/location with aggregated stats."""
+    rows = conn.execute(
+        "SELECT * FROM programs WHERE project_id = ? AND archived = 0 ORDER BY name",
+        (project_id,),
     ).fetchall()
     programs = []
     for r in rows:

--- a/src/policydb/web/routes/clients.py
+++ b/src/policydb/web/routes/clients.py
@@ -3568,6 +3568,10 @@ def project_detail(
     ).fetchone()
     cope = dict(cope_row) if cope_row else None
 
+    # Programs linked to this location
+    from policydb.queries import get_programs_for_project
+    location_programs = get_programs_for_project(conn, project_id)
+
     return templates.TemplateResponse(
         "clients/project.html",
         {
@@ -3576,6 +3580,7 @@ def project_detail(
             "client": dict(client),
             "policies": [dict(p) for p in policies],
             "cope": cope,
+            "location_programs": location_programs,
         },
     )
 
@@ -4904,13 +4909,38 @@ def project_pipeline_status(
     project = conn.execute("SELECT * FROM projects WHERE id = ?", (project_id,)).fetchone()
     if not project:
         return HTMLResponse("", status_code=404)
+
+    # Check for active programs when marking Complete
+    active_program_count = 0
+    if status == "Complete":
+        active_program_count = conn.execute(
+            "SELECT COUNT(*) FROM programs WHERE project_id = ? AND archived = 0",
+            (project_id,),
+        ).fetchone()[0]
+
     client = get_client_by_id(conn, client_id)
     return templates.TemplateResponse("clients/_project_status_badge.html", {
         "request": request,
         "p": dict(project),
         "client": dict(client),
         "project_stages": stages,
+        "active_program_count": active_program_count,
     })
+
+
+@router.post("/{client_id}/projects/{project_id}/archive-programs")
+def archive_project_programs(
+    client_id: int,
+    project_id: int,
+    conn=Depends(get_db),
+):
+    """Archive all active programs linked to a project (used when project completes)."""
+    conn.execute(
+        "UPDATE programs SET archived = 1, updated_at = CURRENT_TIMESTAMP WHERE project_id = ? AND archived = 0",
+        (project_id,),
+    )
+    conn.commit()
+    return JSONResponse({"ok": True})
 
 
 @router.post("/{client_id}/projects/{project_id}/type", response_class=HTMLResponse)
@@ -5031,7 +5061,24 @@ def project_pipeline_delete(
     project_id: int,
     conn=Depends(get_db),
 ):
-    """Delete a pipeline project, unlinking its policies."""
+    """Delete a pipeline project, unlinking its policies and cleaning up programs."""
+    # Cascade safety: null out program_id on child policies of programs linked to this project,
+    # and clean up tower data, before the CASCADE delete removes the programs.
+    linked_programs = conn.execute(
+        "SELECT id FROM programs WHERE project_id = ?", (project_id,)
+    ).fetchall()
+    for pgm in linked_programs:
+        # Clean tower coverage/line refs for child policies
+        child_ids = [r[0] for r in conn.execute(
+            "SELECT id FROM policies WHERE program_id = ?", (pgm["id"],)
+        ).fetchall()]
+        if child_ids:
+            id_list = ",".join(str(cid) for cid in child_ids)
+            conn.execute(f"DELETE FROM program_tower_coverage WHERE excess_policy_id IN ({id_list}) OR underlying_policy_id IN ({id_list})")
+            conn.execute(f"DELETE FROM program_tower_lines WHERE source_policy_id IN ({id_list})")
+        # Null out program_id so policies survive the program deletion
+        conn.execute("UPDATE policies SET program_id = NULL, tower_group = NULL WHERE program_id = ?", (pgm["id"],))
+
     conn.execute("UPDATE policies SET project_id = NULL, project_name = NULL WHERE project_id = ?", (project_id,))
     conn.execute("DELETE FROM projects WHERE id = ? AND client_id = ?", (project_id, client_id))
     conn.commit()
@@ -5372,6 +5419,10 @@ def client_locations(request: Request, client_id: int, conn=Depends(get_db)):
             "SELECT 1 FROM client_exposures WHERE project_id=? LIMIT 1",
             (proj["id"],),
         ).fetchone() is not None
+        program_count = conn.execute(
+            "SELECT COUNT(*) FROM programs WHERE project_id = ? AND archived = 0",
+            (proj["id"],),
+        ).fetchone()[0]
         locations.append({
             "id": proj["id"], "name": proj["name"],
             "address": " ".join(filter(None, [
@@ -5382,6 +5433,7 @@ def client_locations(request: Request, client_id: int, conn=Depends(get_db)):
             "total_premium": sum(p.get("premium") or 0 for p in proj_policies),
             "color_bg": bg, "color_text": text, "color_light": light,
             "has_exposures": has_exposures,
+            "program_count": program_count,
         })
 
     # Smart suggestions: group unassigned by shared exposure_address

--- a/src/policydb/web/routes/programs.py
+++ b/src/policydb/web/routes/programs.py
@@ -17,7 +17,7 @@ from policydb.utils import parse_currency_with_magnitude
 from policydb.queries import (
     get_sub_coverages_by_policy_id, get_sub_coverages_full_by_policy_id,
     get_program_by_uid, get_program_child_policies, get_program_aggregates,
-    get_unassigned_policies,
+    get_unassigned_policies, get_programs_for_project,
     get_program_timeline_milestones, get_program_activities,
     renew_policy,
 )
@@ -29,6 +29,44 @@ router = APIRouter(tags=["programs"])
 # ===========================================================================
 # PROGRAMS v2 — Standalone entity routes (programs table)
 # ===========================================================================
+
+
+def _sync_policy_to_program_location(
+    conn: sqlite3.Connection, policy_uid: str, program: dict
+) -> None:
+    """Sync a policy's location to match its program's project/location.
+
+    Sets project_id, project_name, and exposure address fields on the policy
+    from the program's linked project. Uses COALESCE for address fields so
+    blank project addresses don't overwrite existing policy data.
+    """
+    if not program.get("project_id"):
+        return
+    project = conn.execute(
+        "SELECT id, name, address, city, state, zip FROM projects WHERE id = ?",
+        (program["project_id"],),
+    ).fetchone()
+    if not project:
+        return
+    conn.execute(
+        """UPDATE policies SET
+           project_id = ?,
+           project_name = ?,
+           exposure_address = COALESCE(NULLIF(?, ''), exposure_address),
+           exposure_city = COALESCE(NULLIF(?, ''), exposure_city),
+           exposure_state = COALESCE(NULLIF(?, ''), exposure_state),
+           exposure_zip = COALESCE(NULLIF(?, ''), exposure_zip)
+           WHERE policy_uid = ?""",
+        (
+            project["id"],
+            project["name"],
+            project["address"] or "",
+            project["city"] or "",
+            project["state"] or "",
+            project["zip"] or "",
+            policy_uid,
+        ),
+    )
 
 
 @router.post("/clients/{client_id}/programs/create")
@@ -53,11 +91,15 @@ async def create_program_v2(
     if existing:
         return JSONResponse({"ok": False, "error": f"Program '{name}' already exists"}, status_code=409)
 
+    project_id = body.get("project_id")
+    if project_id is not None:
+        project_id = int(project_id) if project_id else None
+
     uid = next_program_uid(conn)
     conn.execute(
-        """INSERT INTO programs (program_uid, client_id, name, line_of_business)
-           VALUES (?, ?, ?, ?)""",
-        (uid, client_id, name, lob),
+        """INSERT INTO programs (program_uid, client_id, name, line_of_business, project_id)
+           VALUES (?, ?, ?, ?, ?)""",
+        (uid, client_id, name, lob, project_id),
     )
     conn.commit()
     logger.info("Created program v2 '%s' (%s) for client %d", name, uid, client_id)
@@ -90,6 +132,20 @@ def program_detail(
         "SELECT id, name FROM clients WHERE archived=0 ORDER BY name"
     ).fetchall()]
 
+    # Client locations for the location picker
+    client_locations = [
+        dict(r) for r in conn.execute(
+            "SELECT id, name FROM projects WHERE client_id = ? ORDER BY name",
+            (program["client_id"],),
+        ).fetchall()
+    ]
+
+    # Count child policies (for move-children prompt)
+    child_count = conn.execute(
+        "SELECT COUNT(*) FROM policies WHERE program_id = ? AND archived = 0",
+        (program["id"],),
+    ).fetchone()[0]
+
     return templates.TemplateResponse("programs/detail.html", {
         "request": request,
         "active": "clients",
@@ -99,6 +155,8 @@ def program_detail(
         "renewal_statuses": renewal_statuses,
         "issue_severities": cfg.get("issue_severities", []),
         "all_clients": all_clients,
+        "client_locations": client_locations,
+        "child_count": child_count,
     })
 
 
@@ -408,10 +466,16 @@ async def patch_program_header(
     body = await request.json()
     allowed = {"name", "effective_date", "expiration_date", "renewal_status",
                "line_of_business", "notes", "working_notes", "lead_broker",
-               "placement_colleague", "account_exec", "milestone_profile"}
+               "placement_colleague", "account_exec", "milestone_profile",
+               "project_id"}
     updates = {k: v for k, v in body.items() if k in allowed}
     if not updates:
         return JSONResponse({"ok": False, "error": "No valid fields"})
+
+    # Normalize project_id to int or None
+    if "project_id" in updates:
+        pid = updates["project_id"]
+        updates["project_id"] = int(pid) if pid else None
 
     # If name changes, also update tower_group on child policies
     old_name = program["name"]
@@ -454,6 +518,8 @@ def assign_to_program_v2(
            WHERE policy_uid = ?""",
         (program["id"], program["name"], policy_uid),
     )
+    # Auto-sync location if program is scoped to a project/location
+    _sync_policy_to_program_location(conn, policy_uid, program)
     conn.commit()
     logger.info("Assigned %s to program %s", policy_uid, program_uid)
 
@@ -489,6 +555,27 @@ def unassign_from_program_v2(
     logger.info("Unassigned %s from program %s", policy_uid, program_uid)
 
     return JSONResponse({"ok": True})
+
+
+@router.post("/programs/{program_uid}/move-children")
+async def move_children_to_location(
+    request: Request,
+    program_uid: str,
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    """Bulk-update child policies' location to match program's new project_id."""
+    program = get_program_by_uid(conn, program_uid)
+    if not program:
+        return JSONResponse({"ok": False, "error": "Program not found"}, status_code=404)
+
+    children = get_program_child_policies(conn, program["id"])
+    moved = 0
+    for child in children:
+        _sync_policy_to_program_location(conn, child["policy_uid"], program)
+        moved += 1
+    conn.commit()
+    logger.info("Moved %d child policies of %s to project %s", moved, program_uid, program.get("project_id"))
+    return JSONResponse({"ok": True, "moved": moved})
 
 
 # ---------------------------------------------------------------------------
@@ -876,6 +963,8 @@ async def renew_program(request: Request, program_uid: str,
                        WHERE id = ?""",
                     (pgm["id"], pgm["name"], child.get("schematic_column"), new_id),
                 )
+                # Auto-sync location if program is scoped to a project/location
+                _sync_policy_to_program_location(conn, new_uid, pgm)
                 conn.commit()
                 renewed += 1
         except Exception as exc:

--- a/src/policydb/web/templates/clients/_location_group.html
+++ b/src/policydb/web/templates/clients/_location_group.html
@@ -19,6 +19,9 @@
     {% endif %}
 
     <span class="text-xs text-gray-400">&middot; {{ location.policies | length }} polic{{ 'y' if location.policies | length == 1 else 'ies' }}</span>
+    {% if location.program_count %}
+    <span class="text-xs bg-indigo-100 text-indigo-700 px-1.5 py-0.5 rounded-full font-medium">{{ location.program_count }} program{{ 's' if location.program_count != 1 }}</span>
+    {% endif %}
     <span class="text-xs text-gray-500 tabular-nums font-medium">{{ location.total_premium | currency }}</span>
 
     <div class="ml-auto flex items-center gap-2 no-print">

--- a/src/policydb/web/templates/clients/_programs.html
+++ b/src/policydb/web/templates/clients/_programs.html
@@ -1,27 +1,41 @@
-{# ── v2 Programs (from standalone programs table) ── #}
+{# ── v2 Programs (from standalone programs table) — grouped by location ── #}
 {% if programs_v2 %}
-<details class="card mb-4 overflow-hidden" open>
-  <summary class="px-4 py-2.5 bg-blue-50 border-b border-blue-100 cursor-pointer select-none list-none flex items-center gap-2 hover:bg-blue-100 transition-colors">
-    <span class="text-xs text-blue-400 details-arrow">&#9654;</span>
-    <span class="text-xs font-bold text-marsh uppercase tracking-wide">Programs</span>
-    <span class="text-xs text-gray-400">&middot; {{ programs_v2 | length }} program{{ 's' if programs_v2 | length != 1 }}</span>
-  </summary>
-  <div class="overflow-x-auto">
-    <table class="w-full text-sm">
-      <thead>
-        <tr class="border-b border-gray-100 text-left text-xs text-gray-400">
-          <th class="px-4 py-2 font-medium"></th>
-          <th class="px-4 py-2 font-medium">Program</th>
-          <th class="px-4 py-2 font-medium">LOB</th>
-          <th class="px-4 py-2 font-medium text-right">Premium</th>
-          <th class="px-4 py-2 font-medium text-center">Policies</th>
-          <th class="px-4 py-2 font-medium text-center">Carriers</th>
-          <th class="px-4 py-2 font-medium">Term</th>
-          <th class="px-4 py-2 font-medium">Status</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for pgm in programs_v2 %}
+{% set ns = namespace(current_group='__INIT__') %}
+<div class="space-y-4">
+{% for pgm in programs_v2 %}
+  {% set group_key = pgm.project_name or '' %}
+  {% if group_key != ns.current_group %}
+    {% if ns.current_group != '__INIT__' %}
+      {# Close previous table/details #}
+      </tbody></table></div></details>
+    {% endif %}
+    {% set ns.current_group = group_key %}
+
+    <details class="card overflow-hidden" open>
+      <summary class="px-4 py-2.5 bg-blue-50 border-b border-blue-100 cursor-pointer select-none list-none flex items-center gap-2 hover:bg-blue-100 transition-colors">
+        <span class="text-xs text-blue-400 details-arrow">&#9654;</span>
+        {% if pgm.project_id %}
+          <span class="text-xs font-bold text-marsh uppercase tracking-wide">{{ pgm.project_name }}</span>
+        {% else %}
+          <span class="text-xs font-bold text-gray-500 uppercase tracking-wide">Client-Level Programs</span>
+        {% endif %}
+      </summary>
+      <div class="overflow-x-auto">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b border-gray-100 text-left text-xs text-gray-400">
+              <th class="px-4 py-2 font-medium"></th>
+              <th class="px-4 py-2 font-medium">Program</th>
+              <th class="px-4 py-2 font-medium">LOB</th>
+              <th class="px-4 py-2 font-medium text-right">Premium</th>
+              <th class="px-4 py-2 font-medium text-center">Policies</th>
+              <th class="px-4 py-2 font-medium text-center">Carriers</th>
+              <th class="px-4 py-2 font-medium">Term</th>
+              <th class="px-4 py-2 font-medium">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+  {% endif %}
         <tr class="border-b border-gray-50 hover:bg-gray-50 transition-colors">
           <td class="px-4 py-2.5">
             <span class="bg-blue-100 text-blue-700 text-[10px] font-bold px-1.5 py-0.5 rounded">PGM</span>
@@ -54,10 +68,8 @@
                class="text-[10px] text-marsh hover:underline whitespace-nowrap no-print">Open &rarr;</a>
           </td>
         </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
-</details>
+{% endfor %}
+{# Close final group #}
+      </tbody></table></div></details>
+</div>
 {% endif %}
-

--- a/src/policydb/web/templates/clients/_project_status_badge.html
+++ b/src/policydb/web/templates/clients/_project_status_badge.html
@@ -17,4 +17,17 @@
     <option value="{{ s }}" {% if s == p.status %}selected{% endif %}>{{ s }}</option>
     {% endfor %}
   </select>
+  {% if active_program_count %}
+  <div class="ml-2 flex items-center gap-2 text-xs">
+    <span class="text-amber-700">{{ active_program_count }} active program{{ 's' if active_program_count != 1 }}</span>
+    <button type="button"
+      class="bg-amber-100 hover:bg-amber-200 text-amber-700 px-2 py-0.5 rounded transition-colors"
+      onclick="if(confirm('Archive {{ active_program_count }} program{{ 's' if active_program_count != 1 }} linked to this project?')){fetch('/clients/{{ client.id }}/projects/{{ p.id }}/archive-programs',{method:'POST'}).then(function(){window.location.reload()})}">
+      Archive
+    </button>
+    <button type="button"
+      class="text-gray-400 hover:text-gray-600 px-1"
+      onclick="this.parentElement.remove()" title="Keep active">&times;</button>
+  </div>
+  {% endif %}
 </div>

--- a/src/policydb/web/templates/clients/project.html
+++ b/src/policydb/web/templates/clients/project.html
@@ -72,6 +72,40 @@
       {% endif %}
     </div>
 
+    {# Programs at this location #}
+    <div class="card p-4">
+      <p class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">
+        Programs
+      </p>
+      {% if location_programs %}
+      <ul class="space-y-2">
+        {% for pgm in location_programs %}
+        <li>
+          <a href="/programs/{{ pgm.program_uid }}"
+             class="block rounded border border-gray-100 hover:border-marsh/30 p-2 transition-colors group">
+            <div class="flex items-center justify-between">
+              <span class="text-sm font-medium text-gray-900 group-hover:text-marsh">{{ pgm.name }}</span>
+              <span class="text-xs text-gray-400">{{ pgm.program_uid }}</span>
+            </div>
+            <div class="flex items-center gap-3 mt-1 text-xs text-gray-500">
+              {% if pgm.line_of_business %}<span>{{ pgm.line_of_business }}</span>{% endif %}
+              <span>{{ pgm.policy_count }} polic{{ 'y' if pgm.policy_count == 1 else 'ies' }}</span>
+              {% if pgm.total_premium %}<span>{{ pgm.total_premium | currency_short }}</span>{% endif %}
+            </div>
+            {% if pgm.renewal_status %}
+            <span class="inline-block mt-1 text-xs px-1.5 py-0.5 rounded bg-gray-100 text-gray-600">{{ pgm.renewal_status }}</span>
+            {% endif %}
+          </a>
+        </li>
+        {% endfor %}
+      </ul>
+      {% else %}
+      <p class="text-xs text-gray-400 italic">No programs at this location.</p>
+      {% endif %}
+      <button onclick="createProgramAtLocation()"
+              class="mt-3 text-xs text-marsh hover:underline no-print">+ Create Program</button>
+    </div>
+
     {# Address + Map #}
     {% set addr = project.address or project.get('exposure_address', '') %}
     {% set city = project.city or project.get('exposure_city', '') %}
@@ -267,6 +301,22 @@
 
   updateWordCount();
 })();
+
+function createProgramAtLocation() {
+  var name = prompt('Program name:');
+  if (!name) return;
+  fetch('/clients/{{ client.id }}/programs/create', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({name: name, project_id: {{ project.id }}})
+  }).then(function(r) { return r.json(); }).then(function(data) {
+    if (data.ok && data.redirect) {
+      window.location.href = data.redirect;
+    } else if (data.error) {
+      alert(data.error);
+    }
+  });
+}
 </script>
 
 {% endblock %}

--- a/src/policydb/web/templates/programs/detail.html
+++ b/src/policydb/web/templates/programs/detail.html
@@ -33,6 +33,24 @@
          class="text-xs text-marsh hover:underline no-print">&larr; Back to Client</a>
     </div>
     <div class="flex flex-wrap items-center gap-6 text-sm">
+      {# ── Location picker ── #}
+      <div class="flex items-center gap-1.5">
+        <span class="text-gray-400 text-xs">Location:</span>
+        {% if program.project_id and program.project_name %}
+          <a href="/clients/{{ client.id }}/projects/{{ program.project_id }}"
+             class="text-sm text-marsh hover:underline">{{ program.project_name }}</a>
+          <button onclick="changeLocation('')" class="text-gray-400 hover:text-red-500 text-xs ml-1" title="Unlink location">&times;</button>
+        {% else %}
+          <select id="location-picker"
+                  class="border-0 border-b border-gray-200 text-sm text-gray-700 bg-transparent px-1 py-0.5 focus:border-marsh focus:ring-0"
+                  onchange="changeLocation(this.value)">
+            <option value="">— None —</option>
+            {% for loc in client_locations %}
+              <option value="{{ loc.id }}">{{ loc.name }}</option>
+            {% endfor %}
+          </select>
+        {% endif %}
+      </div>
       <div class="flex items-center gap-1.5">
         <span class="text-gray-400 text-xs">Term:</span>
         <input type="date" value="{{ program.effective_date or '' }}"
@@ -113,6 +131,23 @@ function patchProgramHeader(field, value) {
       }
     }
   });
+}
+
+function changeLocation(projectId) {
+  var childCount = {{ child_count }};
+  // First, update the program's project_id
+  patchProgramHeader('project_id', projectId || null);
+  // If there are child policies, ask whether to move them too
+  if (childCount > 0 && projectId) {
+    if (confirm('Move ' + childCount + ' child polic' + (childCount === 1 ? 'y' : 'ies') + ' to this location too?')) {
+      fetch('/programs/{{ program.program_uid }}/move-children', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'}
+      }).then(function() { window.location.reload(); });
+      return;
+    }
+  }
+  window.location.reload();
 }
 </script>
 


### PR DESCRIPTION
## Summary
- Programs can now be linked to a project/location via `project_id` FK on the `programs` table
- Auto-syncs policy location (project_id + exposure address) when assigning to a location-scoped program
- Bidirectional UI: create/manage from program detail or project detail page
- Programs tab groups programs by location; location board shows program count badges
- Construction project completion prompts to archive linked programs
- Cascade safety: cleans up tower data and nulls policy references before location deletion

## Test plan
- [ ] Create program from location detail page — verify project_id set
- [ ] Assign policy to location-scoped program — verify location auto-sync
- [ ] Unassign policy — verify project_id stays
- [ ] Change program location — verify move-children prompt
- [ ] Client Programs tab — verify grouped by location
- [ ] Location board — verify program badges
- [ ] Construction project Complete → verify archive prompt
- [ ] Renew location-scoped program — verify new policies get location
- [ ] Delete location with programs — verify cascade + cleanup
- [ ] Existing client-level programs — verify unchanged behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)