### PR TITLE
feat: renewal issues — standing issues per renewal

### DIFF
--- a/src/policydb/config.py
+++ b/src/policydb/config.py
@@ -170,6 +170,9 @@ _DEFAULTS: dict[str, Any] = {
     ],
     "renewal_issue_window_days": 120,
     "renewal_issue_health_threshold": "at_risk",
+    "renewal_issue_auto_create": True,
+    "renewal_issue_auto_link": True,
+    "renewal_issue_resolve_statuses": ["Bound"],
     # ── Knowledge Base ────────────────────────────────────────────────
     "kb_categories": [
         "Glossary",

--- a/src/policydb/db.py
+++ b/src/policydb/db.py
@@ -1556,6 +1556,15 @@ def init_db(path: Path | None = None) -> None:
         conn.commit()
         logger.info("Migration 112: created knowledge base tables")
 
+    if 113 not in applied:
+        conn.executescript((_MIGRATIONS_DIR / "113_renewal_issues.sql").read_text())
+        conn.execute(
+            "INSERT INTO schema_version (version, description) VALUES (?, ?)",
+            (113, "Add renewal issue columns and partial unique index"),
+        )
+        conn.commit()
+        logger.info("Migration 113: added renewal issue columns")
+
     if 114 not in applied:
         existing_cols = {r[1] for r in conn.execute("PRAGMA table_info(programs)").fetchall()}
         if "project_id" not in existing_cols:
@@ -1662,6 +1671,10 @@ def init_db(path: Path | None = None) -> None:
     # Generate policy timelines for all active policies with milestone profiles
     from policydb.timeline_engine import generate_policy_timelines
     generate_policy_timelines(conn)
+
+    # Create/update renewal issues for policies/programs in the renewal window
+    from policydb.renewal_issues import ensure_renewal_issues
+    ensure_renewal_issues(conn)
 
     # Seed default nudge email templates if none exist
     _seed_nudge_templates(conn)

--- a/src/policydb/migrations/113_renewal_issues.sql
+++ b/src/policydb/migrations/113_renewal_issues.sql
@@ -1,0 +1,11 @@
+-- Renewal issues: standing issues auto-created per renewal/program
+-- is_renewal_issue: flag distinguishing auto-created from manual issues
+-- renewal_term_key: uniqueness key (policy_uid or program:{program_uid})
+
+ALTER TABLE activity_log ADD COLUMN is_renewal_issue INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE activity_log ADD COLUMN renewal_term_key TEXT;
+
+CREATE UNIQUE INDEX idx_one_open_renewal_issue
+    ON activity_log (renewal_term_key)
+    WHERE is_renewal_issue = 1
+      AND issue_status NOT IN ('Resolved', 'Closed');

--- a/src/policydb/renewal_issues.py
+++ b/src/policydb/renewal_issues.py
@@ -1,0 +1,352 @@
+"""Renewal issues — standing issues auto-created per renewal or program.
+
+Auto-creates one issue per renewal (or per program) to serve as the hub for
+all renewal-related activities. Severity tracks timeline health. Auto-resolves
+when the renewal reaches a terminal status (e.g., Bound).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, timedelta
+
+import policydb.config as cfg
+from policydb.db import generate_issue_uid
+
+logger = logging.getLogger("policydb.renewal_issues")
+
+# ── Health → Severity mapping ────────────────────────────────────────────────
+
+_HEALTH_SEVERITY = {
+    "critical": "Critical",
+    "at_risk": "High",
+    "compressed": "Normal",
+    "drifting": "Normal",
+    "on_track": "Low",
+}
+
+
+def _severity_sla(severity: str) -> int:
+    """Look up SLA days for a severity label from config."""
+    for sev in cfg.get("issue_severities", []):
+        if sev["label"] == severity:
+            return sev.get("sla_days", 7)
+    return 7
+
+
+def _worst_health_severity(conn, policy_uid: str) -> str:
+    """Derive issue severity from the worst incomplete milestone health."""
+    row = conn.execute("""
+        SELECT health FROM policy_timeline
+        WHERE policy_uid = ? AND completed_date IS NULL
+        ORDER BY CASE health
+            WHEN 'critical' THEN 1
+            WHEN 'at_risk' THEN 2
+            WHEN 'compressed' THEN 3
+            WHEN 'drifting' THEN 4
+            ELSE 5
+        END
+        LIMIT 1
+    """, (policy_uid,)).fetchone()
+    if row:
+        return _HEALTH_SEVERITY.get(row["health"], "Low")
+    return "Low"
+
+
+def _worst_program_health_severity(conn, program_id: int) -> str:
+    """Derive severity from worst health across all child policy timelines."""
+    row = conn.execute("""
+        SELECT pt.health
+        FROM policy_timeline pt
+        JOIN policies p ON p.policy_uid = pt.policy_uid
+        WHERE p.program_id = ?
+          AND pt.completed_date IS NULL
+        ORDER BY CASE pt.health
+            WHEN 'critical' THEN 1
+            WHEN 'at_risk' THEN 2
+            WHEN 'compressed' THEN 3
+            WHEN 'drifting' THEN 4
+            ELSE 5
+        END
+        LIMIT 1
+    """, (program_id,)).fetchone()
+    if row:
+        return _HEALTH_SEVERITY.get(row["health"], "Low")
+    return "Low"
+
+
+# ── ensure_renewal_issues ────────────────────────────────────────────────────
+
+
+def ensure_renewal_issues(conn, policy_uid: str | None = None) -> None:
+    """Create renewal issues for eligible policies/programs within the window.
+
+    Called from init_db() after generate_policy_timelines().
+    Idempotent — skips policies/programs that already have an open renewal issue.
+    """
+    if not cfg.get("renewal_issue_auto_create", True):
+        return
+
+    window_days = cfg.get("renewal_issue_window_days", 120)
+    today = date.today()
+    horizon = today + timedelta(days=window_days)
+
+    # ── Standalone policies (no program) ─────────────────────────────
+    if policy_uid:
+        policy_rows = conn.execute("""
+            SELECT p.policy_uid, p.expiration_date, p.policy_type, p.id AS policy_id,
+                   c.name AS client_name, p.client_id, p.program_id
+            FROM policies p
+            JOIN clients c ON c.id = p.client_id
+            WHERE p.policy_uid = ?
+        """, (policy_uid,)).fetchall()
+    else:
+        policy_rows = conn.execute("""
+            SELECT p.policy_uid, p.expiration_date, p.policy_type, p.id AS policy_id,
+                   c.name AS client_name, p.client_id, p.program_id
+            FROM policies p
+            JOIN clients c ON c.id = p.client_id
+            WHERE (p.is_opportunity = 0 OR p.is_opportunity IS NULL)
+              AND (p.archived = 0 OR p.archived IS NULL)
+              AND p.expiration_date IS NOT NULL
+              AND p.expiration_date >= ?
+              AND p.expiration_date <= ?
+        """, (today.isoformat(), horizon.isoformat())).fetchall()
+
+    for pol in policy_rows:
+        # Skip child policies in active programs — they roll up to program issue
+        if pol["program_id"] is not None:
+            continue
+
+        term_key = pol["policy_uid"]
+        _create_renewal_issue_if_needed(
+            conn, term_key,
+            client_id=pol["client_id"],
+            policy_id=pol["policy_id"],
+            program_id=None,
+            subject=_build_subject(pol["expiration_date"], pol["policy_type"], pol["client_name"]),
+            severity_fn=lambda: _worst_health_severity(conn, pol["policy_uid"]),
+        )
+
+    # ── Programs ─────────────────────────────────────────────────────
+    if not policy_uid:
+        program_rows = conn.execute("""
+            SELECT pg.id, pg.program_uid, pg.expiration_date, pg.line_of_business,
+                   pg.name AS program_name, c.name AS client_name, pg.client_id
+            FROM programs pg
+            JOIN clients c ON c.id = pg.client_id
+            WHERE (pg.archived = 0 OR pg.archived IS NULL)
+              AND pg.expiration_date IS NOT NULL
+              AND pg.expiration_date >= ?
+              AND pg.expiration_date <= ?
+        """, (today.isoformat(), horizon.isoformat())).fetchall()
+
+        for pgm in program_rows:
+            term_key = f"program:{pgm['program_uid']}"
+            label = pgm["line_of_business"] or pgm["program_name"] or "Program"
+            _create_renewal_issue_if_needed(
+                conn, term_key,
+                client_id=pgm["client_id"],
+                policy_id=None,
+                program_id=pgm["id"],
+                subject=_build_subject(pgm["expiration_date"], f"{label} Program", pgm["client_name"]),
+                severity_fn=lambda pgm_id=pgm["id"]: _worst_program_health_severity(conn, pgm_id),
+            )
+
+    conn.commit()
+
+
+def _create_renewal_issue_if_needed(
+    conn, term_key: str, *, client_id: int, policy_id: int | None,
+    program_id: int | None, subject: str, severity_fn,
+) -> None:
+    """Create a renewal issue if one doesn't already exist for this term key."""
+    existing = conn.execute("""
+        SELECT id FROM activity_log
+        WHERE is_renewal_issue = 1
+          AND renewal_term_key = ?
+          AND issue_status NOT IN ('Resolved', 'Closed')
+    """, (term_key,)).fetchone()
+    if existing:
+        return
+
+    severity = severity_fn()
+    sla_days = _severity_sla(severity)
+    uid = generate_issue_uid()
+    today_str = date.today().isoformat()
+
+    cur = conn.execute("""
+        INSERT INTO activity_log (
+            activity_date, client_id, policy_id, activity_type, subject,
+            item_kind, issue_uid, issue_status, issue_severity, issue_sla_days,
+            program_id, is_renewal_issue, renewal_term_key, created_at
+        ) VALUES (?, ?, ?, 'Issue', ?, 'issue', ?, 'Open', ?, ?, ?, 1, ?, CURRENT_TIMESTAMP)
+    """, (
+        today_str, client_id, policy_id, subject,
+        uid, severity, sla_days, program_id, term_key,
+    ))
+    new_issue_id = cur.lastrowid
+
+    # Backfill-link recent unlinked activities on this policy/program
+    _backfill_link(conn, new_issue_id, client_id, policy_id, program_id)
+    logger.info("Created renewal issue %s for %s (severity=%s)", uid, term_key, severity)
+
+
+def _backfill_link(conn, issue_id: int, client_id: int, policy_id: int | None, program_id: int | None) -> None:
+    """Link recent unlinked activities to a newly created renewal issue."""
+    window_days = cfg.get("renewal_issue_window_days", 120)
+    cutoff = (date.today() - timedelta(days=window_days)).isoformat()
+
+    if program_id:
+        # Link activities on program or any child policy
+        conn.execute("""
+            UPDATE activity_log
+            SET issue_id = ?
+            WHERE issue_id IS NULL
+              AND item_kind = 'followup'
+              AND activity_date >= ?
+              AND (
+                  program_id = ?
+                  OR policy_id IN (SELECT id FROM policies WHERE program_id = ?)
+              )
+        """, (issue_id, cutoff, program_id, program_id))
+    elif policy_id:
+        conn.execute("""
+            UPDATE activity_log
+            SET issue_id = ?
+            WHERE issue_id IS NULL
+              AND item_kind = 'followup'
+              AND activity_date >= ?
+              AND policy_id = ?
+        """, (issue_id, cutoff, policy_id))
+
+
+def _build_subject(expiration_date: str | None, policy_type: str | None, client_name: str) -> str:
+    """Build renewal issue subject: '2026 GL Renewal — Acme Corp'."""
+    year = ""
+    if expiration_date:
+        try:
+            year = expiration_date[:4]
+        except (TypeError, IndexError):
+            pass
+    ptype = policy_type or "Renewal"
+    parts = []
+    if year:
+        parts.append(year)
+    parts.append(f"{ptype} Renewal")
+    return f"{' '.join(parts)} — {client_name}"
+
+
+# ── sync_renewal_issue_severity ──────────────────────────────────────────────
+
+
+def sync_renewal_issue_severity(conn, policy_uid: str) -> None:
+    """Update the renewal issue severity based on current timeline health.
+
+    Only touches auto-created renewal issues (is_renewal_issue=1).
+    """
+    # Check if this policy is part of a program
+    pol = conn.execute(
+        "SELECT program_id FROM policies WHERE policy_uid = ?", (policy_uid,)
+    ).fetchone()
+    if not pol:
+        return
+
+    if pol["program_id"]:
+        # Sync the program's renewal issue instead
+        pgm = conn.execute(
+            "SELECT program_uid FROM programs WHERE id = ?", (pol["program_id"],)
+        ).fetchone()
+        if not pgm:
+            return
+        term_key = f"program:{pgm['program_uid']}"
+        severity = _worst_program_health_severity(conn, pol["program_id"])
+    else:
+        term_key = policy_uid
+        severity = _worst_health_severity(conn, policy_uid)
+
+    sla_days = _severity_sla(severity)
+    conn.execute("""
+        UPDATE activity_log
+        SET issue_severity = ?, issue_sla_days = ?
+        WHERE is_renewal_issue = 1
+          AND renewal_term_key = ?
+          AND issue_status NOT IN ('Resolved', 'Closed')
+    """, (severity, sla_days, term_key))
+
+
+# ── auto_resolve_renewal_issue ───────────────────────────────────────────────
+
+
+def auto_resolve_renewal_issue(conn, policy_uid: str | None = None, program_uid: str | None = None) -> None:
+    """Resolve the renewal issue when renewal reaches a terminal status.
+
+    Call with policy_uid for standalone policies, program_uid for programs.
+    """
+    if policy_uid:
+        term_key = policy_uid
+    elif program_uid:
+        term_key = f"program:{program_uid}"
+    else:
+        return
+
+    today_str = date.today().isoformat()
+    conn.execute("""
+        UPDATE activity_log
+        SET issue_status = 'Resolved',
+            resolution_type = 'Completed',
+            resolution_notes = 'Auto-resolved: renewal bound',
+            resolved_date = ?
+        WHERE is_renewal_issue = 1
+          AND renewal_term_key = ?
+          AND issue_status NOT IN ('Resolved', 'Closed')
+    """, (today_str, term_key))
+
+
+# ── auto_link_to_renewal_issue ───────────────────────────────────────────────
+
+
+def auto_link_to_renewal_issue(conn, policy_id: int, activity_id: int) -> None:
+    """Link a newly created activity to the open renewal issue for its policy.
+
+    Checks the policy itself first, then falls back to the policy's program.
+    Only links if renewal_issue_auto_link config is True.
+    """
+    if not cfg.get("renewal_issue_auto_link", True):
+        return
+
+    # Look up the policy's uid and program
+    pol = conn.execute(
+        "SELECT policy_uid, program_id FROM policies WHERE id = ?", (policy_id,)
+    ).fetchone()
+    if not pol:
+        return
+
+    # Try standalone policy first
+    issue = conn.execute("""
+        SELECT id FROM activity_log
+        WHERE is_renewal_issue = 1
+          AND renewal_term_key = ?
+          AND issue_status NOT IN ('Resolved', 'Closed')
+        LIMIT 1
+    """, (pol["policy_uid"],)).fetchone()
+
+    # Fall back to program renewal issue
+    if not issue and pol["program_id"]:
+        pgm = conn.execute(
+            "SELECT program_uid FROM programs WHERE id = ?", (pol["program_id"],)
+        ).fetchone()
+        if pgm:
+            issue = conn.execute("""
+                SELECT id FROM activity_log
+                WHERE is_renewal_issue = 1
+                  AND renewal_term_key = ?
+                  AND issue_status NOT IN ('Resolved', 'Closed')
+                LIMIT 1
+            """, (f"program:{pgm['program_uid']}",)).fetchone()
+
+    if issue:
+        conn.execute(
+            "UPDATE activity_log SET issue_id = ? WHERE id = ?",
+            (issue["id"], activity_id),
+        )

--- a/src/policydb/timeline_engine.py
+++ b/src/policydb/timeline_engine.py
@@ -417,6 +417,11 @@ def _recompute_prep_and_health(conn, policy_uid: str, expiration_date: str) -> N
 
     conn.commit()
 
+    # Sync renewal issue severity from updated health
+    from policydb.renewal_issues import sync_renewal_issue_severity
+    sync_renewal_issue_severity(conn, policy_uid)
+    conn.commit()
+
 
 # ── Follow-up / Re-diary Integration ──────────────────────────────────
 
@@ -500,12 +505,21 @@ def complete_timeline_milestone(conn, policy_uid: str, milestone_name: str) -> N
                 WHERE id = ?
             """, (now, existing["id"]))
 
-    # Recompute health
+    # Recompute health (also triggers renewal issue severity sync)
     exp = conn.execute(
         "SELECT expiration_date FROM policies WHERE policy_uid = ?", (policy_uid,)
     ).fetchone()
     if exp and exp["expiration_date"]:
         _recompute_prep_and_health(conn, policy_uid, exp["expiration_date"])
+
+    # Auto-resolve renewal issue if ALL milestones are now complete
+    remaining = conn.execute("""
+        SELECT COUNT(*) AS cnt FROM policy_timeline
+        WHERE policy_uid = ? AND completed_date IS NULL
+    """, (policy_uid,)).fetchone()
+    if remaining and remaining["cnt"] == 0:
+        from policydb.renewal_issues import auto_resolve_renewal_issue
+        auto_resolve_renewal_issue(conn, policy_uid=policy_uid)
 
     conn.commit()
 

--- a/src/policydb/web/routes/action_center.py
+++ b/src/policydb/web/routes/action_center.py
@@ -627,7 +627,7 @@ def _issues_ctx(conn, q: str = "", client_id: int = 0, view_mode: str = "board")
         SELECT a.id, a.issue_uid, a.subject, a.details, a.client_id, a.policy_id,
                a.program_id, a.issue_status, a.issue_severity, a.issue_sla_days,
                a.resolution_type, a.resolution_notes, a.root_cause_category,
-               a.resolved_date, a.activity_date, a.created_at,
+               a.resolved_date, a.activity_date, a.created_at, a.is_renewal_issue,
                c.name AS client_name,
                p.policy_uid, p.policy_type, p.carrier,
                (SELECT COUNT(*) FROM activity_log sub

--- a/src/policydb/web/routes/activities.py
+++ b/src/policydb/web/routes/activities.py
@@ -133,6 +133,11 @@ def activity_log(
     )
     new_id = cursor.lastrowid
 
+    # Auto-link to renewal issue if no explicit issue_id
+    if not issue_id and policy_id:
+        from policydb.renewal_issues import auto_link_to_renewal_issue
+        auto_link_to_renewal_issue(conn, policy_id, new_id)
+
     conn.commit()
     logger.info("Activity created for client %d: %s", client_id, activity_type)
     # Return the new activity row as HTMX partial

--- a/src/policydb/web/routes/issues.py
+++ b/src/policydb/web/routes/issues.py
@@ -405,6 +405,29 @@ def issue_detail(
     issue["sla_days"] = sla
     issue["over_sla"] = (issue.get("days_open") or 0) > sla
 
+    # For renewal issues, include timeline milestone data
+    timeline_milestones = []
+    if issue.get("is_renewal_issue"):
+        policy_uid = issue.get("policy_uid")
+        if policy_uid:
+            timeline_milestones = [dict(r) for r in conn.execute("""
+                SELECT milestone_name, ideal_date, projected_date, completed_date,
+                       health, accountability, waiting_on
+                FROM policy_timeline
+                WHERE policy_uid = ?
+                ORDER BY ideal_date
+            """, (policy_uid,)).fetchall()]
+        elif issue.get("program_id"):
+            # Program-level: aggregate child policy milestones
+            timeline_milestones = [dict(r) for r in conn.execute("""
+                SELECT pt.milestone_name, pt.ideal_date, pt.projected_date,
+                       pt.completed_date, pt.health, pt.accountability, pt.waiting_on
+                FROM policy_timeline pt
+                JOIN policies p ON p.policy_uid = pt.policy_uid
+                WHERE p.program_id = ?
+                ORDER BY pt.ideal_date
+            """, (issue["program_id"],)).fetchall()]
+
     ctx = {
         "request": request,
         "active": "action-center",
@@ -417,6 +440,7 @@ def issue_detail(
         "issue_root_cause_categories": cfg.get("issue_root_cause_categories", []),
         "activity_types": cfg.get("activity_types", []),
         "follow_up_dispositions": cfg.get("follow_up_dispositions", []),
+        "timeline_milestones": timeline_milestones,
     }
     return templates.TemplateResponse("issues/detail.html", ctx)
 

--- a/src/policydb/web/routes/policies.py
+++ b/src/policydb/web/routes/policies.py
@@ -2605,6 +2605,19 @@ def policy_tab_pulse(
         except (ValueError, TypeError):
             pass
 
+    # Renewal issue for this policy (if any)
+    renewal_issue = conn.execute("""
+        SELECT id, issue_uid, issue_status, issue_severity, is_renewal_issue,
+               julianday(date('now')) - julianday(activity_date) AS days_open,
+               (SELECT COUNT(*) FROM activity_log sub WHERE sub.issue_id = a.id) AS activity_count
+        FROM activity_log a
+        WHERE a.is_renewal_issue = 1
+          AND a.renewal_term_key = ?
+          AND a.issue_status NOT IN ('Resolved', 'Closed')
+        LIMIT 1
+    """, (policy_uid,)).fetchone()
+    renewal_issue = dict(renewal_issue) if renewal_issue else None
+
     return templates.TemplateResponse("policies/_tab_pulse.html", {
         "request": request,
         "policy": dict(p),
@@ -2627,6 +2640,7 @@ def policy_tab_pulse(
         "days_since_review": days_since_review,
         "issue_severities": cfg.get("issue_severities", []),
         "all_clients": [{"id": client_info["id"], "name": client_info["name"]}],
+        "renewal_issue": renewal_issue,
     })
 
 
@@ -3289,6 +3303,10 @@ async def policy_cell_save(request: Request, policy_uid: str, conn=Depends(get_d
         val = value.strip()
         conn.execute("UPDATE policies SET renewal_status = ? WHERE policy_uid = ?", (val or None, uid))
         formatted = val
+        # Auto-resolve renewal issue on terminal status
+        if val in cfg.get("renewal_issue_resolve_statuses", ["Bound"]):
+            from policydb.renewal_issues import auto_resolve_renewal_issue
+            auto_resolve_renewal_issue(conn, policy_uid=uid)
     elif field == "opportunity_status":
         val = value.strip()
         conn.execute("UPDATE policies SET opportunity_status = ? WHERE policy_uid = ?", (val or None, uid))
@@ -3601,6 +3619,13 @@ def policy_update_status(
     )
     conn.commit()
     logger.info("Policy %s status -> %s", uid, status)
+
+    # Auto-resolve renewal issue on terminal status
+    if status in cfg.get("renewal_issue_resolve_statuses", ["Bound"]):
+        from policydb.renewal_issues import auto_resolve_renewal_issue
+        auto_resolve_renewal_issue(conn, policy_uid=uid)
+        conn.commit()
+
     policy = get_policy_by_uid(conn, uid)
     if not policy:
         return HTMLResponse("", status_code=404)

--- a/src/policydb/web/routes/programs.py
+++ b/src/policydb/web/routes/programs.py
@@ -206,6 +206,18 @@ def program_tab_overview(
         "SELECT id, name FROM clients WHERE archived=0 ORDER BY name"
     ).fetchall()]
 
+    # Renewal issue for this program
+    renewal_issue = conn.execute("""
+        SELECT id, issue_uid, issue_status, issue_severity, is_renewal_issue,
+               julianday(date('now')) - julianday(activity_date) AS days_open,
+               (SELECT COUNT(*) FROM activity_log sub WHERE sub.issue_id = a.id) AS activity_count
+        FROM activity_log a
+        WHERE a.is_renewal_issue = 1
+          AND a.renewal_term_key = ?
+          AND a.issue_status NOT IN ('Resolved', 'Closed')
+        LIMIT 1
+    """, (f"program:{program_uid}",)).fetchone()
+
     return templates.TemplateResponse("programs/_tab_overview.html", {
         "request": request,
         "program": program,
@@ -220,6 +232,7 @@ def program_tab_overview(
         "client_name": client_name,
         "all_clients": all_clients,
         "issue_severities": cfg.get("issue_severities", []),
+        "renewal_issue": dict(renewal_issue) if renewal_issue else None,
     })
 
 
@@ -490,6 +503,14 @@ async def patch_program_header(
     vals = list(updates.values()) + [program_uid]
     conn.execute(f"UPDATE programs SET {set_clause}, updated_at = CURRENT_TIMESTAMP WHERE program_uid = ?", vals)
     conn.commit()
+
+    # Auto-resolve renewal issue on terminal status
+    if "renewal_status" in updates:
+        import policydb.config as _cfg
+        if updates["renewal_status"] in _cfg.get("renewal_issue_resolve_statuses", ["Bound"]):
+            from policydb.renewal_issues import auto_resolve_renewal_issue
+            auto_resolve_renewal_issue(conn, program_uid=program_uid)
+            conn.commit()
 
     return JSONResponse({"ok": True, "formatted": new_name if "name" in updates else ""})
 

--- a/src/policydb/web/routes/settings.py
+++ b/src/policydb/web/routes/settings.py
@@ -56,6 +56,7 @@ EDITABLE_LISTS: dict[str, str] = {
     "service_model_options": "Service Model Options",
     "kb_categories": "KB Categories",
     "kb_article_sources": "KB Article Sources",
+    "renewal_issue_resolve_statuses": "Renewal Issue — Resolve Statuses",
 }
 
 TAB_LISTS: dict[str, dict[str, str]] = {
@@ -105,6 +106,7 @@ TAB_LISTS: dict[str, dict[str, str]] = {
         "issue_lifecycle_states": "Issue Lifecycle States",
         "issue_resolution_types": "Issue Resolution Types",
         "issue_root_cause_categories": "Issue Root Cause Categories",
+        "renewal_issue_resolve_statuses": "Renewal Issue — Resolve Statuses",
     },
     "database": {
         "project_stages": "Project Stages",
@@ -204,6 +206,8 @@ def _build_tab_context(tab: str, conn) -> dict:
         ctx["issue_severities"] = cfg.get("issue_severities", [])
         ctx["renewal_issue_window_days"] = cfg.get("renewal_issue_window_days", 120)
         ctx["renewal_issue_health_threshold"] = cfg.get("renewal_issue_health_threshold", "at_risk")
+        ctx["renewal_issue_auto_create"] = cfg.get("renewal_issue_auto_create", True)
+        ctx["renewal_issue_auto_link"] = cfg.get("renewal_issue_auto_link", True)
 
     elif tab == "email-contacts":
         ctx["email_subject_policy"] = cfg.get("email_subject_policy", "")
@@ -612,10 +616,14 @@ def update_renewal_issue_window(
     request: Request,
     window_days: int = Form(...),
     health_threshold: str = Form("at_risk"),
+    auto_create: str = Form("off"),
+    auto_link: str = Form("off"),
 ):
     full = dict(cfg.load_config())
     full["renewal_issue_window_days"] = max(30, min(window_days, 365))
     full["renewal_issue_health_threshold"] = health_threshold
+    full["renewal_issue_auto_create"] = auto_create == "on"
+    full["renewal_issue_auto_link"] = auto_link == "on"
     cfg.save_config(full)
     cfg.reload_config()
     return RedirectResponse("/settings?tab=issues", status_code=303)

--- a/src/policydb/web/templates/action_center/_issue_board_card.html
+++ b/src/policydb/web/templates/action_center/_issue_board_card.html
@@ -27,6 +27,13 @@
   </div>
   {% endif %}
 
+  {# Renewal badge #}
+  {% if issue.is_renewal_issue %}
+  <div class="mt-1">
+    <span class="inline-flex items-center text-[9px] font-medium bg-emerald-50 text-emerald-700 border border-emerald-200 rounded-full px-1.5 py-0.5">Renewal</span>
+  </div>
+  {% endif %}
+
   {# Row 2: client + policy type #}
   <div class="flex items-center gap-1 mt-1.5 text-[11px] text-gray-500">
     <span class="truncate">{{ issue.client_name }}</span>

--- a/src/policydb/web/templates/action_center/_issue_row.html
+++ b/src/policydb/web/templates/action_center/_issue_row.html
@@ -19,6 +19,9 @@
         class="inline-flex items-center text-[10px] font-mono text-gray-400 hover:text-marsh bg-gray-50 border border-gray-200 hover:border-marsh/40 rounded-full px-1.5 py-0.5 cursor-pointer transition-colors whitespace-nowrap no-print flex-shrink-0"
         title="Click to copy issue ref tag">{{ issue.issue_uid }}</button>
       {% endif %}
+      {% if issue.is_renewal_issue %}
+      <span class="inline-flex items-center text-[10px] font-medium bg-emerald-50 text-emerald-700 border border-emerald-200 rounded-full px-1.5 py-0.5 flex-shrink-0">Renewal</span>
+      {% endif %}
     </div>
     <div class="flex items-center gap-2 text-xs text-gray-500 mt-0.5">
       <a href="/clients/{{ issue.client_id }}" class="hover:text-marsh">{{ issue.client_name }}</a>

--- a/src/policydb/web/templates/issues/detail.html
+++ b/src/policydb/web/templates/issues/detail.html
@@ -234,6 +234,49 @@
         </div>
       </div>
 
+      {# Renewal issue: timeline milestones summary #}
+      {% if issue.is_renewal_issue and timeline_milestones %}
+      <div class="card p-4 border-l-4 border-emerald-400">
+        <div class="flex items-center gap-2 mb-2">
+          <span class="text-[10px] text-emerald-800 uppercase tracking-wide font-semibold">Timeline Milestones</span>
+          <span class="inline-flex items-center text-[9px] font-medium bg-emerald-50 text-emerald-700 border border-emerald-200 rounded-full px-1.5 py-0.5">Renewal Issue</span>
+        </div>
+        <div class="text-[10px] text-gray-400 mb-2">Severity auto-managed by timeline health</div>
+        <div class="space-y-1.5">
+          {% for ms in timeline_milestones %}
+          {% set h = ms.health or 'on_track' %}
+          <div class="flex items-center gap-2 text-xs">
+            {% if ms.completed_date %}
+              <span class="w-4 h-4 flex items-center justify-center text-green-600">&#10003;</span>
+            {% elif h == 'critical' %}
+              <span class="w-4 h-4 flex items-center justify-center rounded-full bg-red-100 text-red-600 text-[9px] font-bold">!</span>
+            {% elif h == 'at_risk' %}
+              <span class="w-4 h-4 flex items-center justify-center rounded-full bg-amber-100 text-amber-600 text-[9px] font-bold">!</span>
+            {% elif h in ('compressed', 'drifting') %}
+              <span class="w-4 h-4 flex items-center justify-center rounded-full bg-blue-100 text-blue-600 text-[9px]">&bull;</span>
+            {% else %}
+              <span class="w-4 h-4 flex items-center justify-center text-gray-300">&bull;</span>
+            {% endif %}
+            <span class="flex-1 truncate {% if ms.completed_date %}text-gray-400 line-through{% else %}text-gray-700{% endif %}">{{ ms.milestone_name }}</span>
+            <span class="text-[10px] {% if h == 'critical' %}text-red-600 font-semibold{% elif h == 'at_risk' %}text-amber-600{% else %}text-gray-400{% endif %}">
+              {{ (ms.projected_date or ms.ideal_date or '')[5:] | replace('-', '/') }}
+            </span>
+          </div>
+          {% endfor %}
+        </div>
+        {% if issue.policy_uid %}
+        <a href="/policies/{{ issue.policy_uid }}#pulse" class="block text-[10px] text-marsh hover:underline mt-2">View full timeline &rarr;</a>
+        {% endif %}
+      </div>
+      {% elif issue.is_renewal_issue %}
+      <div class="card p-4 border-l-4 border-emerald-400">
+        <div class="flex items-center gap-2 mb-1">
+          <span class="inline-flex items-center text-[9px] font-medium bg-emerald-50 text-emerald-700 border border-emerald-200 rounded-full px-1.5 py-0.5">Renewal Issue</span>
+        </div>
+        <div class="text-[10px] text-gray-400">Severity auto-managed by timeline health. Auto-resolves when renewal is bound.</div>
+      </div>
+      {% endif %}
+
       {# Description card (contenteditable) #}
       <div class="card p-4">
         <div class="text-[10px] text-gray-400 uppercase tracking-wide mb-2">Description</div>

--- a/src/policydb/web/templates/policies/_tab_pulse.html
+++ b/src/policydb/web/templates/policies/_tab_pulse.html
@@ -50,6 +50,33 @@
 </div>
 
 {# ══════════════════════════════════════════════════════════
+   Renewal Issue Banner (if active)
+   ══════════════════════════════════════════════════════════ #}
+{% if renewal_issue %}
+{% set ri_sev = renewal_issue.issue_severity or 'Normal' %}
+<a href="/issues/{{ renewal_issue.issue_uid }}" class="card px-3 py-2 flex items-center gap-2 border-l-4
+  {% if ri_sev == 'Critical' %}border-red-400 bg-red-50/40
+  {% elif ri_sev == 'High' %}border-amber-400 bg-amber-50/40
+  {% elif ri_sev == 'Normal' %}border-blue-400 bg-blue-50/40
+  {% else %}border-gray-300 bg-gray-50/40{% endif %}
+  hover:shadow-sm transition-shadow group">
+  <span class="inline-flex items-center text-[10px] font-medium bg-emerald-50 text-emerald-700 border border-emerald-200 rounded-full px-1.5 py-0.5">Renewal Issue</span>
+  <span class="w-2 h-2 rounded-full flex-shrink-0
+    {% if ri_sev == 'Critical' %}bg-red-500
+    {% elif ri_sev == 'High' %}bg-amber-500
+    {% elif ri_sev == 'Normal' %}bg-blue-500
+    {% else %}bg-gray-400{% endif %}"></span>
+  <span class="text-xs font-medium text-gray-700">{{ ri_sev }}</span>
+  <span class="text-xs text-gray-400">&middot; {{ renewal_issue.issue_status }}</span>
+  <span class="text-xs text-gray-400">&middot; {{ (renewal_issue.days_open or 0)|int }}d open</span>
+  {% if renewal_issue.activity_count %}
+  <span class="text-xs text-gray-400">&middot; {{ renewal_issue.activity_count }} act</span>
+  {% endif %}
+  <span class="ml-auto text-[10px] text-gray-400 group-hover:text-marsh">View &rarr;</span>
+</a>
+{% endif %}
+
+{# ══════════════════════════════════════════════════════════
    Section 2: Metrics Bar
    ══════════════════════════════════════════════════════════ #}
 <div id="pulse-metrics" class="grid grid-cols-4 gap-2">

--- a/src/policydb/web/templates/programs/_tab_overview.html
+++ b/src/policydb/web/templates/programs/_tab_overview.html
@@ -7,6 +7,31 @@
   <span><strong class="text-gray-700">{{ aggregates.total_premium | currency }}</strong> total premium</span>
 </div>
 
+{# -- Renewal Issue Banner (if active) -- #}
+{% if renewal_issue %}
+{% set ri_sev = renewal_issue.issue_severity or 'Normal' %}
+<a href="/issues/{{ renewal_issue.issue_uid }}" class="card px-3 py-2 mb-4 flex items-center gap-2 border-l-4
+  {% if ri_sev == 'Critical' %}border-red-400 bg-red-50/40
+  {% elif ri_sev == 'High' %}border-amber-400 bg-amber-50/40
+  {% elif ri_sev == 'Normal' %}border-blue-400 bg-blue-50/40
+  {% else %}border-gray-300 bg-gray-50/40{% endif %}
+  hover:shadow-sm transition-shadow group">
+  <span class="inline-flex items-center text-[10px] font-medium bg-emerald-50 text-emerald-700 border border-emerald-200 rounded-full px-1.5 py-0.5">Renewal Issue</span>
+  <span class="w-2 h-2 rounded-full flex-shrink-0
+    {% if ri_sev == 'Critical' %}bg-red-500
+    {% elif ri_sev == 'High' %}bg-amber-500
+    {% elif ri_sev == 'Normal' %}bg-blue-500
+    {% else %}bg-gray-400{% endif %}"></span>
+  <span class="text-xs font-medium text-gray-700">{{ ri_sev }}</span>
+  <span class="text-xs text-gray-400">&middot; {{ renewal_issue.issue_status }}</span>
+  <span class="text-xs text-gray-400">&middot; {{ (renewal_issue.days_open or 0)|int }}d open</span>
+  {% if renewal_issue.activity_count %}
+  <span class="text-xs text-gray-400">&middot; {{ renewal_issue.activity_count }} act</span>
+  {% endif %}
+  <span class="ml-auto text-[10px] text-gray-400 group-hover:text-marsh">View &rarr;</span>
+</a>
+{% endif %}
+
 {# -- Child Policies Editable Grid -- #}
 <div class="card mb-4">
   <div class="px-4 py-2.5 bg-gray-50 border-b border-gray-100 flex items-center justify-between">

--- a/src/policydb/web/templates/settings/_tab_issues.html
+++ b/src/policydb/web/templates/settings/_tab_issues.html
@@ -52,6 +52,18 @@
           {% endfor %}
         </select>
       </div>
+      <div class="flex items-center gap-6 pt-1">
+        <label class="flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
+          <input type="checkbox" name="auto_create" {% if renewal_issue_auto_create %}checked{% endif %}
+                 class="rounded border-gray-300 text-marsh focus:ring-marsh">
+          Auto-create renewal issues
+        </label>
+        <label class="flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
+          <input type="checkbox" name="auto_link" {% if renewal_issue_auto_link %}checked{% endif %}
+                 class="rounded border-gray-300 text-marsh focus:ring-marsh">
+          Auto-link activities to renewal issues
+        </label>
+      </div>
       <button type="submit" class="text-sm text-blue-600 hover:underline">Save</button>
     </form>
   </div>


### PR DESCRIPTION
## Summary
- Auto-creates a standing issue per policy/program when it enters the renewal window (120d default)
- Auto-links new activities to the renewal issue (no manual assignment needed)
- Syncs severity from timeline milestone health (critical→Critical, at_risk→High, etc.)
- Auto-resolves when renewal status reaches terminal state (e.g., Bound)
- Child policies roll up to the program's renewal issue — one hub per program
- Emerald "Renewal" badges on issue board, list, and detail views
- Renewal issue banner on policy Pulse tab and program Overview tab
- New settings: auto-create toggle, auto-link toggle, resolve statuses list

## Files Changed
- **New:** `migrations/113_renewal_issues.sql`, `renewal_issues.py` (core module)
- **Modified:** `db.py`, `config.py`, `timeline_engine.py`, 5 route files, 5 templates

## Test plan
- [x] 21 renewal issues created at startup (20 policy + 1 program)
- [x] Board and list views show emerald Renewal badges
- [x] Issue detail shows auto-managed severity indicator
- [x] Program overview shows renewal issue banner
- [x] Auto-link: new activity auto-linked to renewal issue
- [x] Idempotency: server restart creates no duplicates
- [x] Child policies excluded (roll up to program issue)
- [x] Settings toggles and resolve statuses list render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)