### PR TITLE
fix: policy activity log double-click bug and scope issue widget

### DIFF
--- a/src/policydb/web/routes/issues.py
+++ b/src/policydb/web/routes/issues.py
@@ -264,6 +264,36 @@ def issues_for_client(
     )
 
 
+@router.get("/issues/for-policy/{policy_id}", response_class=HTMLResponse)
+def issues_for_policy(
+    policy_id: int,
+    request: Request,
+    conn=Depends(get_db),
+):
+    """Return open issues for a specific policy — used by policy page issue widgets."""
+    rows = conn.execute("""
+        SELECT id, issue_uid, subject, issue_severity, issue_sla_days,
+               CAST(julianday('now') - julianday(activity_date) AS INTEGER) AS days_open
+        FROM activity_log
+        WHERE item_kind = 'issue'
+          AND issue_id IS NULL
+          AND policy_id = ?
+          AND (issue_status IS NULL OR issue_status NOT IN ('Resolved', 'Closed'))
+    """, (policy_id,)).fetchall()
+
+    issues = sorted(
+        [dict(r) for r in rows],
+        key=lambda r: (
+            _SEVERITY_ORDER.get(r.get("issue_severity") or "Normal", 2),
+            r.get("days_open") or 0,
+        ),
+    )
+    return templates.TemplateResponse(
+        "issues/_issue_widget.html",
+        {"request": request, "issues": issues},
+    )
+
+
 # ── Linkable activities for an issue ─────────────────────────────────────────
 
 

--- a/src/policydb/web/templates/policies/_tab_activity.html
+++ b/src/policydb/web/templates/policies/_tab_activity.html
@@ -48,7 +48,7 @@
     <div class="flex items-center gap-3 no-print">
       <button type="button" onclick="openIssueCreateSlideover({client_id:'{{ policy.client_id }}', client_name:'{{ client.name|e }}', policy_id:'{{ policy.id }}', policy_label:'{{ policy.policy_uid }} {{ policy.policy_type|default("",true)|e }}'})"
         class="text-xs text-amber-600 hover:underline">+ Issue</button>
-      <button type="button" onclick="document.getElementById('log-form-edit').classList.toggle('hidden'); this.textContent = this.textContent.trim() === '+ Log' ? '− Close' : '+ Log'"
+      <button type="button" id="log-toggle-btn" onclick="document.getElementById('log-form-edit').classList.toggle('hidden'); this.textContent = this.textContent.trim() === '+ Log' ? '− Close' : '+ Log'"
         class="text-xs text-marsh hover:underline">+ Log</button>
     </div>
   </div>
@@ -56,7 +56,7 @@
     <form hx-post="/activities/log"
           hx-target="#edit-activity-list"
           hx-swap="afterbegin"
-          hx-on::after-request="this.reset(); document.getElementById('log-form-edit').classList.add('hidden'); document.querySelector('#log-toggle-bar button').textContent = '+ Log'"
+          hx-on::after-request="this.reset(); document.getElementById('log-form-edit').classList.add('hidden'); document.getElementById('log-toggle-btn').textContent = '+ Log'"
           class="border-l-4 border-marsh bg-green-50/30 pl-3 pr-2 py-2 rounded-r">
       <input type="hidden" name="client_id" value="{{ policy.client_id }}">
       <input type="hidden" name="policy_id" value="{{ policy.id }}">
@@ -117,8 +117,8 @@
       {% endif %}
       {# Issue widget — link activity to an open issue #}
       <div id="policy-log-issue-widget" class="mt-2"
-           hx-get="/issues/for-client/{{ policy.client_id }}"
-           hx-trigger="intersect once"
+           hx-get="/issues/for-policy/{{ policy.id }}"
+           hx-trigger="load"
            hx-swap="innerHTML"></div>
     </form>
   </div>

--- a/src/policydb/web/templates/policies/_tab_pulse.html
+++ b/src/policydb/web/templates/policies/_tab_pulse.html
@@ -483,7 +483,7 @@
       </div>
       {# Issue widget — link activity to an open issue #}
       <div class="mt-2"
-           hx-get="/issues/for-client/{{ policy.client_id }}"
+           hx-get="/issues/for-policy/{{ policy.id }}"
            hx-trigger="intersect once"
            hx-swap="innerHTML"></div>
     </form>


### PR DESCRIPTION
## Summary
- **Fix double-click bug**: The "+ Log" button on the policy Activity tab required two clicks because the issue widget's `intersect once` HTMX trigger fired when the hidden form toggled visible, and the after-submit handler targeted the wrong button ("+ Issue" instead of "+ Log")
- **Scope issue widget to policy**: Both policy page issue widgets (Activity and Pulse tabs) were showing all client-level open issues instead of only issues for the current policy — added `/issues/for-policy/{policy_id}` endpoint and updated both templates
- **Codebase audit**: Verified Action Center's client-scoped issue widget is correct (user picks client from dropdown) — no changes needed there

## Test plan
- [ ] Navigate to a policy edit page → Activity tab → click "+ Log" once — form should open immediately
- [ ] Verify issue widget only shows issues for that specific policy, not all client issues
- [ ] Submit a log entry → verify form closes and button resets to "+ Log"
- [ ] Check Policy Pulse tab Quick Log → issue widget should also be policy-scoped
- [ ] Check Action Center → Quick Log Activity → issue widget should still show client-scoped issues (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)