### PR TITLE
Consolidate-by-location, merge tombstone purge, contact title, issue location link

### DIFF
--- a/src/policydb/config.py
+++ b/src/policydb/config.py
@@ -639,6 +639,7 @@ _DEFAULTS: dict[str, Any] = {
     "migration_backup_retention_count": 10,
     "log_level": "INFO",
     "log_retention_days": 730,
+    "merged_issue_retention_days": 90,
     "default_review_activity_type": "Other",
     "review_session_gap_minutes": 30,
     "review_dismiss_days": 7,

--- a/src/policydb/db.py
+++ b/src/policydb/db.py
@@ -364,7 +364,7 @@ def _init_db_inner(conn: sqlite3.Connection, db_path: Path) -> None:
     # Back up the database once before running any pending migrations.
     # This gives a clean restore point regardless of which migration fails.
 
-    _KNOWN_MIGRATIONS = set(range(1, 140))  # update upper bound when adding new migrations
+    _KNOWN_MIGRATIONS = set(range(1, 142))  # update upper bound when adding new migrations
 
     if _KNOWN_MIGRATIONS - applied:
         _backup_db(conn, db_path)
@@ -1857,6 +1857,17 @@ def _init_db_inner(conn: sqlite3.Connection, db_path: Path) -> None:
         conn.commit()
         logger.info("Migration 140: added policy_number_unknown column")
 
+    if 141 not in applied:
+        conn.executescript(
+            (_MIGRATIONS_DIR / "141_record_attachments_merge_tracking.sql").read_text()
+        )
+        conn.execute(
+            "INSERT INTO schema_version (version, description) VALUES (?, ?)",
+            (141, "Track merged-from issue on record_attachments for dissolve restore"),
+        )
+        conn.commit()
+        logger.info("Migration 141: added merged_from_issue_id to record_attachments")
+
     # Data hygiene: fix 'None' string corruption in text fields (runs every startup, fast no-op if clean)
     conn.execute("UPDATE clients SET cn_number = NULL WHERE cn_number = 'None'")
 
@@ -2116,6 +2127,7 @@ def _init_db_inner(conn: sqlite3.Connection, db_path: Path) -> None:
 
     # Purge old log entries
     _purge_old_logs(conn)
+    _purge_merged_tombstones(conn)
 
     # DB size
     _HEALTH_STATUS["db_size"] = os.path.getsize(db_path) if os.path.exists(db_path) else 0
@@ -2197,6 +2209,92 @@ def _purge_old_logs(conn: sqlite3.Connection) -> None:
                 logger.info("VACUUM completed after large purge (%d rows)", total)
             except Exception as e:
                 logger.warning("VACUUM failed after purge: %s", e)
+
+
+def purge_merged_tombstones(conn: sqlite3.Connection) -> int:
+    """Delete closed-and-merged renewal issues older than retention, when the
+    merge target is itself Resolved/Closed or missing.
+
+    Safety interlock: a tombstone is only swept once its "parent" renewal is
+    also terminal. This preserves the duplicate-prevention behavior in
+    renewal_issues._create_renewal_issue_if_needed for still-active merges.
+
+    Returns the number of rows deleted.
+    """
+    from datetime import date, timedelta
+    from policydb import config as _purge_cfg
+
+    retention_days = _purge_cfg.get("merged_issue_retention_days", 90)
+    cutoff = (date.today() - timedelta(days=retention_days)).isoformat()
+
+    try:
+        ids = [r[0] for r in conn.execute("""
+            SELECT src.id FROM activity_log src
+            WHERE src.item_kind = 'issue'
+              AND src.is_renewal_issue = 1
+              AND src.issue_status = 'Closed'
+              AND src.merged_into_id IS NOT NULL
+              AND src.created_at < ?
+              AND NOT EXISTS (
+                  SELECT 1 FROM activity_log tgt
+                  WHERE tgt.id = src.merged_into_id
+                    AND tgt.item_kind = 'issue'
+                    AND tgt.issue_status NOT IN ('Resolved', 'Closed')
+              )
+        """, (cutoff,)).fetchall()]
+        if not ids:
+            return 0
+
+        # Null out FK references before DELETE. Purging is a one-way operation
+        # (dissolve is already foreclosed because the merge target is terminal),
+        # so losing these "merged_from" breadcrumbs is intentional.
+        placeholders = ",".join("?" * len(ids))
+        conn.execute(
+            f"UPDATE activity_log SET merged_from_issue_id = NULL "
+            f"WHERE merged_from_issue_id IN ({placeholders})",
+            ids,
+        )
+        conn.execute(
+            f"UPDATE activity_log SET issue_id = NULL "
+            f"WHERE issue_id IN ({placeholders})",
+            ids,
+        )
+        conn.execute(
+            f"UPDATE record_attachments SET merged_from_issue_id = NULL "
+            f"WHERE merged_from_issue_id IN ({placeholders})",
+            ids,
+        )
+        conn.execute(
+            f"UPDATE inbox SET activity_id = NULL "
+            f"WHERE activity_id IN ({placeholders})",
+            ids,
+        )
+        conn.execute(
+            f"UPDATE mandated_activity_log SET activity_id = NULL "
+            f"WHERE activity_id IN ({placeholders})",
+            ids,
+        )
+
+        cur = conn.execute(
+            f"DELETE FROM activity_log WHERE id IN ({placeholders})",
+            ids,
+        )
+        deleted = cur.rowcount or 0
+        if deleted:
+            conn.commit()
+        return deleted
+    except Exception as e:
+        logger.warning("Merged tombstone purge failed (non-fatal): %s", e)
+        conn.rollback()
+        return 0
+
+
+def _purge_merged_tombstones(conn: sqlite3.Connection) -> None:
+    """Startup wrapper for purge_merged_tombstones — logs but never blocks."""
+    deleted = purge_merged_tombstones(conn)
+    if deleted:
+        logger.info("Merged tombstone purge: %d rows removed", deleted)
+        _HEALTH_STATUS["last_purge_merged_tombstones"] = deleted
 
 
 def _migrate_unified_contacts(conn: sqlite3.Connection) -> None:

--- a/src/policydb/migrations/141_record_attachments_merge_tracking.sql
+++ b/src/policydb/migrations/141_record_attachments_merge_tracking.sql
@@ -1,0 +1,7 @@
+-- Track attachment ownership when an issue is merged so dissolve can restore
+-- header-level attachments back to the source issue.
+ALTER TABLE record_attachments ADD COLUMN merged_from_issue_id INTEGER;
+
+CREATE INDEX IF NOT EXISTS idx_record_attachments_merged_from
+    ON record_attachments(merged_from_issue_id)
+    WHERE merged_from_issue_id IS NOT NULL;

--- a/src/policydb/renewal_issues.py
+++ b/src/policydb/renewal_issues.py
@@ -185,11 +185,22 @@ def _create_renewal_issue_if_needed(
     due_date: str | None = None,
 ) -> None:
     """Create a renewal issue if one doesn't already exist for this term key."""
+    # Skip if an open issue already owns this term_key, OR if a closed-and-merged
+    # issue with this term_key still points at an open merge target — otherwise
+    # the generator would recreate an issue the user deliberately merged away.
     existing = conn.execute("""
-        SELECT id FROM activity_log
-        WHERE is_renewal_issue = 1
-          AND renewal_term_key = ?
-          AND issue_status NOT IN ('Resolved', 'Closed')
+        SELECT src.id FROM activity_log src
+        WHERE src.is_renewal_issue = 1
+          AND src.renewal_term_key = ?
+          AND (
+              src.issue_status NOT IN ('Resolved', 'Closed')
+              OR EXISTS (
+                  SELECT 1 FROM activity_log tgt
+                  WHERE tgt.id = src.merged_into_id
+                    AND tgt.item_kind = 'issue'
+                    AND tgt.issue_status NOT IN ('Resolved', 'Closed')
+              )
+          )
     """, (term_key,)).fetchone()
     if existing:
         return

--- a/src/policydb/web/routes/action_center.py
+++ b/src/policydb/web/routes/action_center.py
@@ -858,6 +858,45 @@ def _issues_ctx(conn, q: str = "", client_id: int = 0, issue_type: str = "") -> 
         if _cl:
             client_name = _cl["name"]
 
+    # ── Consolidation suggestions: open standalone renewal issues sharing (client, project) ──
+    cluster_rows = conn.execute("""
+        SELECT a.client_id, c.name AS client_name,
+               pr.id AS project_id, pr.name AS location_name,
+               a.id AS issue_id, a.issue_uid, a.subject,
+               p.policy_uid, p.policy_type, p.expiration_date
+        FROM activity_log a
+        JOIN clients c ON c.id = a.client_id
+        JOIN policies p ON p.id = a.policy_id
+        JOIN projects pr ON pr.id = p.project_id
+        WHERE a.item_kind = 'issue'
+          AND a.is_renewal_issue = 1
+          AND a.issue_status NOT IN ('Resolved', 'Closed')
+          AND a.merged_into_id IS NULL
+          AND a.program_id IS NULL
+        ORDER BY c.name, pr.name, p.expiration_date ASC, a.id ASC
+    """).fetchall()
+
+    clusters: dict[tuple[int, int], dict] = {}
+    for r in cluster_rows:
+        key = (r["client_id"], r["project_id"])
+        if key not in clusters:
+            clusters[key] = {
+                "client_id": r["client_id"],
+                "client_name": r["client_name"],
+                "project_id": r["project_id"],
+                "location_name": r["location_name"],
+                "issues": [],
+            }
+        clusters[key]["issues"].append({
+            "id": r["issue_id"],
+            "issue_uid": r["issue_uid"],
+            "subject": r["subject"],
+            "policy_uid": r["policy_uid"],
+            "policy_type": r["policy_type"],
+            "expiration_date": r["expiration_date"],
+        })
+    consolidation_suggestions = [c for c in clusters.values() if len(c["issues"]) >= 2]
+
     return {
         "critical_overdue": critical_overdue,
         "active_issues": active,
@@ -873,6 +912,7 @@ def _issues_ctx(conn, q: str = "", client_id: int = 0, issue_type: str = "") -> 
         "issue_lifecycle_states": cfg.get("issue_lifecycle_states", []),
         "sla_breach_count": sla_breach_count,
         "oldest_breach_days": oldest_breach_days,
+        "consolidation_suggestions": consolidation_suggestions,
     }
 
 

--- a/src/policydb/web/routes/contacts.py
+++ b/src/policydb/web/routes/contacts.py
@@ -931,6 +931,18 @@ def contact_detail(request: Request, contact_id: int, conn=Depends(get_db)):
     contact = dict(contact)
     _attach_expertise(conn, [contact])
 
+    # Representative title from junction tables (title lives per-assignment)
+    title_row = conn.execute(
+        """SELECT title FROM contact_client_assignments
+                WHERE contact_id = ? AND title IS NOT NULL AND TRIM(title) != ''
+           UNION ALL
+           SELECT title FROM contact_policy_assignments
+                WHERE contact_id = ? AND title IS NOT NULL AND TRIM(title) != ''
+           LIMIT 1""",
+        (contact_id, contact_id),
+    ).fetchone()
+    contact["title"] = title_row["title"] if title_row else ""
+
     # ── Policy assignments ────────────────────────────────────────────────
     policy_assignments = [dict(r) for r in conn.execute("""
         SELECT cpa.*, p.policy_uid, p.policy_type, p.carrier, p.renewal_status,

--- a/src/policydb/web/routes/issues.py
+++ b/src/policydb/web/routes/issues.py
@@ -795,12 +795,15 @@ def issue_detail(
     conn=Depends(get_db),
 ):
     """Full issue detail page with activity timeline."""
+    # Pull location from the issue's policy OR its program (program-level
+    # renewal issues have no policy_id but the program carries project_id).
     issue = conn.execute("""
         SELECT a.*, c.name AS client_name,
                p.policy_uid, p.policy_type, p.carrier, p.expiration_date,
                p.is_opportunity, p.opportunity_status, p.target_effective_date,
                p.premium AS policy_premium,
-               pr.name AS location_name,
+               COALESCE(pr.name, pr2.name) AS location_name,
+               COALESCE(pr.id, pr2.id) AS location_project_id,
                CASE WHEN a.resolved_date IS NOT NULL
                     THEN julianday(a.resolved_date) - julianday(a.activity_date)
                     ELSE julianday(date('now')) - julianday(a.activity_date)
@@ -813,6 +816,8 @@ def issue_detail(
         LEFT JOIN clients c ON c.id = a.client_id
         LEFT JOIN policies p ON p.id = a.policy_id
         LEFT JOIN projects pr ON pr.id = p.project_id
+        LEFT JOIN programs pg ON pg.id = a.program_id
+        LEFT JOIN projects pr2 ON pr2.id = pg.project_id
         WHERE a.issue_uid = ? AND a.item_kind = 'issue'
     """, (issue_uid,)).fetchone()
 
@@ -1148,6 +1153,42 @@ def delete_issue(
 # ── Merge issues ────────────────────────────────────────────────────────────
 
 
+def _merge_source_into_target(conn, src_id: int, target_id: int, today: str) -> int:
+    """Relink a single source issue into a target issue, returning auto-closed count."""
+    closed = auto_close_followups(
+        conn, issue_id=src_id, reason="issue_merged",
+        closed_by="issue_merge", before_date=today,
+    )
+    # Relink child activities to target (tag with source for dissolve)
+    conn.execute(
+        "UPDATE activity_log SET issue_id = ?, merged_from_issue_id = ? WHERE issue_id = ?",
+        (target_id, src_id, src_id),
+    )
+    # Move header-level attachments from source to target, tagging each with
+    # source for dissolve restore. UPDATE OR IGNORE skips collisions; the
+    # follow-up DELETE clears leftover source rows.
+    conn.execute("""
+        UPDATE OR IGNORE record_attachments
+        SET record_id = ?, merged_from_issue_id = ?
+        WHERE record_type = 'issue' AND record_id = ?
+    """, (target_id, src_id, src_id))
+    conn.execute(
+        "DELETE FROM record_attachments WHERE record_type = 'issue' AND record_id = ?",
+        (src_id,),
+    )
+    # Close source issue as merged
+    conn.execute("""
+        UPDATE activity_log
+        SET issue_status = 'Closed',
+            resolution_type = 'Duplicate',
+            resolution_notes = 'Merged into ' || (SELECT issue_uid FROM activity_log WHERE id = ?),
+            resolved_date = ?,
+            merged_into_id = ?
+        WHERE id = ? AND item_kind = 'issue'
+    """, (target_id, today, target_id, src_id))
+    return closed
+
+
 @router.post("/issues/{target_id}/merge", response_class=HTMLResponse)
 def merge_issues(
     target_id: int,
@@ -1170,33 +1211,60 @@ def merge_issues(
             parsed_ids.append(int(v))
 
     today = date.today().isoformat()
-    total_closed = 0
     for src_id in parsed_ids:
         if src_id == target_id:
             continue
-        # Auto-close stale follow-ups on source before relink
-        total_closed += auto_close_followups(
-            conn, issue_id=src_id, reason="issue_merged",
-            closed_by="issue_merge", before_date=today,
-        )
-        # Relink child activities to target (tag with source for dissolve)
-        conn.execute(
-            "UPDATE activity_log SET issue_id = ?, merged_from_issue_id = ? WHERE issue_id = ?",
-            (target_id, src_id, src_id),
-        )
-        # Close source issue as merged
-        conn.execute("""
-            UPDATE activity_log
-            SET issue_status = 'Closed',
-                resolution_type = 'Duplicate',
-                resolution_notes = 'Merged into ' || (SELECT issue_uid FROM activity_log WHERE id = ?),
-                resolved_date = ?,
-                merged_into_id = ?
-            WHERE id = ? AND item_kind = 'issue'
-        """, (target_id, today, target_id, src_id))
+        _merge_source_into_target(conn, src_id, target_id, today)
 
     conn.commit()
     return RedirectResponse(f"/issues/{target['issue_uid']}", status_code=303)
+
+
+# ── Consolidate by location ─────────────────────────────────────────────────
+
+
+@router.post("/issues/consolidate")
+def consolidate_location(
+    request: Request,
+    client_id: int = Form(...),
+    project_id: int = Form(...),
+    conn=Depends(get_db),
+):
+    """Merge all open standalone renewal issues at one location into a single issue.
+
+    Target is the issue with the earliest expiration date (tiebreak: lowest id).
+    Responds with HX-Redirect when called from HTMX, 303 otherwise.
+    """
+    rows = conn.execute("""
+        SELECT a.id, p.expiration_date
+        FROM activity_log a
+        JOIN policies p ON p.id = a.policy_id
+        WHERE a.item_kind = 'issue'
+          AND a.is_renewal_issue = 1
+          AND a.issue_status NOT IN ('Resolved', 'Closed')
+          AND a.merged_into_id IS NULL
+          AND a.program_id IS NULL
+          AND a.client_id = ?
+          AND p.project_id = ?
+        ORDER BY p.expiration_date ASC, a.id ASC
+    """, (client_id, project_id)).fetchall()
+
+    target_uid = None
+    if len(rows) >= 2:
+        target_id = rows[0]["id"]
+        today = date.today().isoformat()
+        for r in rows[1:]:
+            _merge_source_into_target(conn, r["id"], target_id, today)
+        conn.commit()
+        target_row = conn.execute(
+            "SELECT issue_uid FROM activity_log WHERE id = ?", (target_id,)
+        ).fetchone()
+        target_uid = target_row["issue_uid"] if target_row else None
+
+    redirect_url = f"/issues/{target_uid}" if target_uid else "/action-center?tab=issues"
+    if request.headers.get("HX-Request"):
+        return HTMLResponse("", headers={"HX-Redirect": redirect_url})
+    return RedirectResponse(redirect_url, status_code=303)
 
 
 # ── Dissolve merge ─────────────────────────────────────────────────────────
@@ -1228,6 +1296,19 @@ def dissolve_merge(
     conn.execute(
         "UPDATE activity_log SET issue_id = ?, merged_from_issue_id = NULL WHERE issue_id = ? AND merged_from_issue_id = ?",
         (source_id, target_id, source_id),
+    )
+
+    # Move header-level attachments back to source, undoing the merge.
+    # UPDATE OR IGNORE + DELETE handles the case where the source issue
+    # separately re-acquired the same attachment after the merge.
+    conn.execute("""
+        UPDATE OR IGNORE record_attachments
+        SET record_id = ?, merged_from_issue_id = NULL
+        WHERE record_type = 'issue' AND record_id = ? AND merged_from_issue_id = ?
+    """, (source_id, target_id, source_id))
+    conn.execute(
+        "DELETE FROM record_attachments WHERE record_type = 'issue' AND record_id = ? AND merged_from_issue_id = ?",
+        (target_id, source_id),
     )
 
     # Reopen source issue

--- a/src/policydb/web/routes/settings.py
+++ b/src/policydb/web/routes/settings.py
@@ -1155,6 +1155,24 @@ def db_vacuum(conn=Depends(get_db)):
         return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
 
 
+@router.post("/db/purge-merged-tombstones")
+def db_purge_merged_tombstones(conn=Depends(get_db)):
+    """Delete closed-and-merged renewal issues whose merge target is also terminal."""
+    from policydb.db import purge_merged_tombstones
+    try:
+        deleted = purge_merged_tombstones(conn)
+        retention = cfg.get("merged_issue_retention_days", 90)
+        msg = (
+            f"Removed {deleted} merged tombstone{'s' if deleted != 1 else ''} "
+            f"older than {retention} days."
+            if deleted
+            else "No eligible tombstones to purge."
+        )
+        return JSONResponse({"ok": True, "deleted": deleted, "message": msg})
+    except Exception as e:
+        return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+
+
 @router.get("/db/download")
 def db_download(conn=Depends(get_db)):
     """Checkpoint WAL and serve the database file as a download."""

--- a/src/policydb/web/templates/action_center/_issues.html
+++ b/src/policydb/web/templates/action_center/_issues.html
@@ -9,6 +9,50 @@
   </div>
   {% endif %}
 
+  {# ── Consolidation suggestions ── #}
+  {% if consolidation_suggestions %}
+  <div class="bg-amber-50 border border-amber-200 rounded-lg px-4 py-3 mb-4">
+    <div class="flex items-center gap-2 mb-2">
+      <span class="text-xs font-semibold text-amber-800 uppercase tracking-wide">
+        Consolidate by Location
+      </span>
+      <span class="text-[11px] text-amber-600">
+        {{ consolidation_suggestions|length }}
+        {{ 'location has' if consolidation_suggestions|length == 1 else 'locations have' }}
+        multiple open renewal issues
+      </span>
+    </div>
+    <div class="space-y-1.5">
+      {% for cluster in consolidation_suggestions %}
+      <div class="flex items-center gap-3 bg-white border border-amber-100 rounded px-3 py-2">
+        <div class="flex-1 min-w-0">
+          <div class="text-sm font-medium text-gray-800 truncate">
+            <a href="/clients/{{ cluster.client_id }}" class="hover:underline">{{ cluster.client_name }}</a>
+            <span class="text-gray-300 mx-1">&middot;</span>
+            <a href="/clients/{{ cluster.client_id }}/projects/{{ cluster.project_id }}"
+               class="text-marsh hover:underline">{{ cluster.location_name }}</a>
+          </div>
+          <div class="text-[11px] text-gray-500 mt-0.5 truncate">
+            {% for iss in cluster.issues %}
+              <span class="font-mono">{{ iss.policy_uid }}</span>{% if iss.policy_type %} {{ iss.policy_type }}{% endif %}{% if not loop.last %} &middot; {% endif %}
+            {% endfor %}
+          </div>
+        </div>
+        <button type="button"
+                hx-post="/issues/consolidate"
+                hx-vals='{"client_id": {{ cluster.client_id }}, "project_id": {{ cluster.project_id }}}'
+                hx-target="body"
+                hx-swap="outerHTML"
+                hx-confirm="Merge {{ cluster.issues|length }} renewal issues at {{ cluster.location_name }} into one?"
+                class="shrink-0 text-xs bg-amber-600 text-white rounded px-3 py-1.5 hover:bg-amber-700 transition-colors">
+          Consolidate {{ cluster.issues|length }} &rarr; 1
+        </button>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+  {% endif %}
+
   {# ── Filter bar ── #}
   <div class="flex items-center gap-3 mb-4 flex-wrap">
     <input type="search" placeholder="Search issues…"

--- a/src/policydb/web/templates/contacts/detail.html
+++ b/src/policydb/web/templates/contacts/detail.html
@@ -27,7 +27,12 @@
           data-field="name"
           data-placeholder="Contact name"
           onblur="saveContactField(this, 'name')">{{ contact.name }}</h1>
-      <p class="text-sm text-gray-500 mt-1 cd-editable"
+      <p class="text-sm text-gray-700 mt-1 cd-editable"
+         contenteditable="true"
+         data-field="title"
+         data-placeholder="Job title"
+         onblur="saveContactField(this, 'title')">{{ contact.title or '' }}</p>
+      <p class="text-sm text-gray-500 mt-0.5 cd-editable"
          contenteditable="true"
          data-field="organization"
          data-placeholder="Organization"
@@ -327,8 +332,10 @@
       });
       return;
     }
-    // For organization, use the unified cell endpoint
-    if (field === 'organization') {
+    // Organization and title both save via the unified cell endpoint.
+    // Title is stored per-assignment in the junction tables; the unified
+    // store updates all assignments at once.
+    if (field === 'organization' || field === 'title') {
       fetch('/contacts/unified/' + encodeURIComponent(contactName) + '/cell', {
         method: 'PATCH',
         headers: {'Content-Type': 'application/json'},

--- a/src/policydb/web/templates/issues/detail.html
+++ b/src/policydb/web/templates/issues/detail.html
@@ -71,7 +71,12 @@
     {% endif %}
     {% if issue.location_name %}
       <span class="text-gray-300">&middot;</span>
+      {% if issue.location_project_id %}
+      <a href="/clients/{{ issue.client_id }}/projects/{{ issue.location_project_id }}"
+         class="text-marsh hover:underline">{{ issue.location_name }}</a>
+      {% else %}
       <span class="text-gray-500">{{ issue.location_name }}</span>
+      {% endif %}
     {% endif %}
     <span class="text-gray-300">&middot;</span>
     {% if issue.is_renewal_issue %}
@@ -373,7 +378,14 @@
         <a href="/policies/{{ issue.policy_uid }}/edit" class="block text-[10px] text-marsh hover:underline mt-1">Review Policy &rarr;</a>
         {% endif %}
         {% if issue.location_name %}
-        <div class="text-xs text-gray-500 mt-1">{{ issue.location_name }}</div>
+        <div class="text-xs mt-1">
+          {% if issue.location_project_id %}
+          <a href="/clients/{{ issue.client_id }}/projects/{{ issue.location_project_id }}"
+             class="text-marsh hover:underline">{{ issue.location_name }} &rarr;</a>
+          {% else %}
+          <span class="text-gray-500">{{ issue.location_name }}</span>
+          {% endif %}
+        </div>
         {% endif %}
         {% if issue.is_renewal_issue %}
         <div class="text-xs text-gray-500 mt-2">{{ days }}d open</div>

--- a/src/policydb/web/templates/settings/_db_health.html
+++ b/src/policydb/web/templates/settings/_db_health.html
@@ -111,6 +111,11 @@
       class="text-xs bg-white text-gray-700 hover:bg-gray-50 border border-gray-300 px-3 py-1.5 rounded-lg font-medium transition-colors">
       VACUUM
     </button>
+    <button type="button" onclick="dbPurgeMergedTombstones()"
+      class="text-xs bg-white text-gray-700 hover:bg-gray-50 border border-gray-300 px-3 py-1.5 rounded-lg font-medium transition-colors"
+      title="Delete closed-and-merged renewal issues whose parent is also terminal">
+      Purge Merged Tombstones
+    </button>
     <a href="/settings/db/download"
       class="text-xs bg-white text-gray-700 hover:bg-gray-50 border border-gray-300 px-3 py-1.5 rounded-lg font-medium transition-colors inline-block">
       Download DB
@@ -182,6 +187,20 @@ function dbBackupNow() {
 function dbVacuum() {
   _dbSetStatus('Running VACUUM…', 'text-gray-500');
   fetch('/settings/db/vacuum', { method: 'POST' })
+    .then(function(r) { return r.json(); })
+    .then(function(d) {
+      if (d.ok) {
+        _dbSetStatus(d.message, 'text-green-600');
+      } else {
+        _dbSetStatus('Error: ' + d.error, 'text-red-600');
+      }
+    })
+    .catch(function(e) { _dbSetStatus('Request failed.', 'text-red-600'); });
+}
+
+function dbPurgeMergedTombstones() {
+  _dbSetStatus('Purging merged tombstones…', 'text-gray-500');
+  fetch('/settings/db/purge-merged-tombstones', { method: 'POST' })
     .then(function(r) { return r.json(); })
     .then(function(d) {
       if (d.ok) {


### PR DESCRIPTION
## Summary
- **Consolidate-by-location** — Action Center Issues tab shows an amber banner listing locations with 2+ open standalone renewal issues; one-click button merges them into the earliest-expiring target. New `POST /issues/consolidate` endpoint reuses a shared `_merge_source_into_target` helper.
- **Merge tombstone purge** — new `purge_merged_tombstones()` runs at startup and is also exposed via a "Purge Merged Tombstones" button on Settings → DB Health. Deletes closed-and-merged renewal issues older than `merged_issue_retention_days` (90d default), but only once the merge target is itself terminal. Nulls inbound FK references (activity_log self-refs, `record_attachments`, `inbox`, `mandated_activity_log`) before DELETE to avoid FK errors.
- **Renewal generator guard** — `_create_renewal_issue_if_needed` now skips term keys whose tombstone still points at an open merge target, so merges cannot be silently unmade.
- **Migration 141** — adds `record_attachments.merged_from_issue_id` so dissolve can restore header-level attachments back to the source issue. Merge and dissolve now move attachments with `UPDATE OR IGNORE` + `DELETE` to handle collisions.
- **Issue detail location link** — location name is now a link to the project page, pulled via policy OR program so program-level renewal issues also resolve a location.
- **Contact detail title field** — title (stored per-assignment in the junction tables) is editable on the contact detail page via the unified cell endpoint.

## Test plan
- [x] Migration 141 applies cleanly on startup
- [x] Startup purge handles existing tombstones without FK error (2 deleted, 1 retained because its merge target is still active)
- [x] Action Center consolidation banner renders for locations with 2+ open renewal issues
- [x] Consolidate button merges source issues into earliest-expiring target, banner clears on reload
- [x] Settings "Purge Merged Tombstones" button returns "No eligible tombstones to purge" when none remain
- [x] Contact detail page renders title field; PATCH updates all junction rows
- [x] Issue detail page location links to `/clients/{id}/projects/{project_id}` in both header and sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)