### PR TITLE
Auto-remove Weekly Review rows and update counts on dispatch

### DIFF
--- a/src/policydb/web/routes/inbox.py
+++ b/src/policydb/web/routes/inbox.py
@@ -351,7 +351,10 @@ def inbox_process(
     siblings = _find_thread_siblings(conn, inbox_id)
     sibling_ids = [s["id"] for s in siblings]
     import json as _json
-    trigger_data = {"activityLogged": "processed"}
+    trigger_data = {
+        "activityLogged": "processed",
+        "reviewRowCleared": f"#ac-inbox-item-{inbox_id}",
+    }
     if sibling_ids:
         trigger_data["threadSiblings"] = {
             "count": len(sibling_ids),

--- a/src/policydb/web/routes/review.py
+++ b/src/policydb/web/routes/review.py
@@ -871,12 +871,17 @@ def policy_slideover_mark_reviewed(
 
     suggestions = suggest_profile(conn)
 
-    # Render the updated table row (OOB swap)
+    # Render the updated table row as an OOB swap so it updates wherever it
+    # exists (review queue page) without breaking on pages that lack the row
+    # (weekly-review walkthrough). Wrap in <template> so the HTML fragment
+    # parser accepts the <tr> without a surrounding <table> context.
     row_html = templates.TemplateResponse(
         "review/_policy_row.html",
         _policy_row_context(request, r, reviewed=True, needs_followup=needs_followup,
                             suggestions=suggestions),
     ).body.decode()
+    row_html = row_html.replace('<tr id="review-row-', '<tr hx-swap-oob="true" id="review-row-', 1)
+    row_html = f"<template>{row_html}</template>"
 
     # Render the slideover footer in reviewed state
     footer_html = f"""
@@ -890,8 +895,12 @@ def policy_slideover_mark_reviewed(
     </div>
     """
 
+    import json as _json
     resp = HTMLResponse(row_html + footer_html)
-    resp.headers["HX-Trigger"] = "refreshReviewStats"
+    resp.headers["HX-Trigger"] = _json.dumps({
+        "refreshReviewStats": True,
+        "reviewRowCleared": f"#review-walkthrough-policy-{uid}",
+    })
     return resp
 
 
@@ -993,13 +1002,17 @@ def client_slideover_mark_reviewed(
     if not row:
         return HTMLResponse("")
 
-    # OOB row update
+    # Render row as OOB so it updates wherever present (queue) without
+    # requiring the target on the walkthrough page. Wrap in <template> so the
+    # HTML parser accepts <tr> without a <table> context.
     row_html = templates.TemplateResponse("review/_client_row.html", {
         "request": request,
         "c": dict(row),
         "cycle_labels": REVIEW_CYCLE_LABELS,
         "reviewed": True,
     }).body.decode()
+    row_html = row_html.replace('<tr id="review-client-', '<tr hx-swap-oob="true" id="review-client-', 1)
+    row_html = f"<template>{row_html}</template>"
 
     footer_html = """
     <div id="client-review-slideover-footer" hx-swap-oob="innerHTML:#client-review-slideover-footer">
@@ -1012,8 +1025,12 @@ def client_slideover_mark_reviewed(
     </div>
     """
 
+    import json as _json
     resp = HTMLResponse(row_html + footer_html)
-    resp.headers["HX-Trigger"] = "refreshReviewStats"
+    resp.headers["HX-Trigger"] = _json.dumps({
+        "refreshReviewStats": True,
+        "reviewRowCleared": f"#review-walkthrough-client-{client_id}",
+    })
     return resp
 
 

--- a/src/policydb/web/templates/review/_client_review_slideover.html
+++ b/src/policydb/web/templates/review/_client_review_slideover.html
@@ -266,7 +266,7 @@
     <div class="flex items-center justify-between">
       <a href="/clients/{{ c.id }}" class="text-xs text-gray-400 hover:underline">Open Client Page</a>
       <button hx-post="/review/clients/{{ c.id }}/slideover/reviewed"
-              hx-target="#review-client-{{ c.id }}" hx-swap="outerHTML"
+              hx-target="body" hx-swap="none"
               class="text-sm bg-marsh text-white px-4 py-2 rounded-lg hover:bg-marsh-light transition-colors font-medium">
         Mark Reviewed
       </button>

--- a/src/policydb/web/templates/review/_policy_review_slideover.html
+++ b/src/policydb/web/templates/review/_policy_review_slideover.html
@@ -329,7 +329,7 @@
         <a href="/policies/{{ p.policy_uid }}/edit" class="text-xs text-gray-400 hover:underline">Full Page</a>
         {% if gate.all_pass %}
         <button hx-post="/review/policies/{{ p.policy_uid }}/slideover/reviewed"
-                hx-target="#review-row-{{ p.policy_uid }}" hx-swap="outerHTML"
+                hx-target="body" hx-swap="none"
                 class="text-sm bg-marsh text-white px-4 py-2 rounded-lg hover:bg-marsh-light transition-colors font-medium">
           Mark Reviewed
         </button>
@@ -345,7 +345,7 @@
     {% if not gate.all_pass %}
     <div id="review-override-form-{{ p.policy_uid }}" class="hidden mt-3 pt-3 border-t border-gray-100">
       <form hx-post="/review/policies/{{ p.policy_uid }}/slideover/reviewed"
-            hx-target="#review-row-{{ p.policy_uid }}" hx-swap="outerHTML"
+            hx-target="body" hx-swap="none"
             class="flex items-center gap-2">
         <input type="text" name="override_reason" required placeholder="Why is this OK to review now?"
                class="flex-1 text-sm border border-gray-300 rounded-lg px-3 py-1.5 focus:ring-marsh focus:outline-none">

--- a/src/policydb/web/templates/review/_walkthrough_section.html
+++ b/src/policydb/web/templates/review/_walkthrough_section.html
@@ -39,7 +39,7 @@
   {% if items %}
   <div class="space-y-2">
     {% for item in items %}
-    <div class="flex items-center justify-between py-2 px-3 rounded-lg hover:bg-gray-50 border border-gray-100">
+    <div id="review-walkthrough-policy-{{ item.policy_uid }}" class="flex items-center justify-between py-2 px-3 rounded-lg hover:bg-gray-50 border border-gray-100">
       <div class="flex-1 min-w-0">
         <div class="flex items-center gap-2">
           <a href="/policies/{{ item.policy_uid }}" class="text-sm font-medium text-marsh hover:underline">{{ item.policy_uid }}</a>
@@ -113,7 +113,7 @@
   {% if items %}
   <div class="space-y-2">
     {% for item in items %}
-    <div class="flex items-center justify-between py-2 px-3 rounded-lg hover:bg-gray-50 border border-gray-100">
+    <div id="review-walkthrough-client-{{ item.id }}" class="flex items-center justify-between py-2 px-3 rounded-lg hover:bg-gray-50 border border-gray-100">
       <div class="flex-1 min-w-0">
         <div class="flex items-center gap-2">
           <button type="button"
@@ -153,7 +153,7 @@
   {% if items %}
   <div class="space-y-2">
     {% for item in items %}
-    <div class="flex items-center justify-between py-2 px-3 rounded-lg hover:bg-gray-50 border border-gray-100">
+    <div id="review-walkthrough-policy-{{ item.policy_uid }}" class="flex items-center justify-between py-2 px-3 rounded-lg hover:bg-gray-50 border border-gray-100">
       <div class="flex-1 min-w-0">
         <div class="flex items-center gap-2">
           <button type="button"

--- a/src/policydb/web/templates/review/index.html
+++ b/src/policydb/web/templates/review/index.html
@@ -32,7 +32,7 @@
           {% endif %}
           <span class="flex-1">{{ s.label }}</span>
           {% if count > 0 and sec.get('status') != 'complete' and sec.get('status') != 'skipped' %}
-            <span class="text-xs bg-gray-200 text-gray-600 rounded-full px-1.5 py-0.5 tabular-nums">{{ count }}</span>
+            <span data-review-count-nav="{{ s.key }}" class="text-xs bg-gray-200 text-gray-600 rounded-full px-1.5 py-0.5 tabular-nums">{{ count }}</span>
           {% endif %}
         </a>
       {% endif %}
@@ -134,9 +134,9 @@
               {% endif %}
               <span class="section-title">{{ s.label }}</span>
               {% if count > 0 %}
-                <span class="text-xs text-gray-400">{{ count }} item{{ 's' if count != 1 else '' }}</span>
+                <span data-review-count-header="{{ s.key }}" class="text-xs text-gray-400">{{ count }} item{{ 's' if count != 1 else '' }}</span>
               {% elif sec.get('status') not in ('complete', 'skipped') %}
-                <span class="text-xs text-green-600">No items</span>
+                <span data-review-count-header="{{ s.key }}" class="text-xs text-green-600">No items</span>
               {% endif %}
               {% if s.get('estimated_minutes') and sec.get('status') not in ('complete', 'skipped') %}
                 <span class="text-xs text-gray-400">&middot; ~{{ s.estimated_minutes }} min</span>
@@ -348,6 +348,48 @@ function scheduleFollowUp(recordId, note) {
   var target = document.getElementById('review-gate-' + recordId);
   if (target) {
     htmx.ajax('GET', '/review/policies/' + recordId + '/row/log', {target: target, swap: 'afterend'});
+  }
+}
+
+// Remove walkthrough rows + update counts when slideovers dispatch items.
+// Fired via HX-Trigger header from mark-reviewed / process endpoints.
+document.body.addEventListener('reviewRowCleared', function(e) {
+  var detail = e.detail || {};
+  var selector = detail.value || detail.selector || detail;
+  if (typeof selector !== 'string' || !selector) return;
+  var rows = document.querySelectorAll(selector);
+  var sections = new Set();
+  rows.forEach(function(row) {
+    var section = row.closest('[id^="section-"]');
+    if (section) sections.add(section);
+    row.remove();
+  });
+  if (window.closeReviewSlideover) closeReviewSlideover();
+  if (window.closeFollowupEdit) closeFollowupEdit();
+  sections.forEach(updateReviewSectionCount);
+});
+
+function updateReviewSectionCount(section) {
+  var sectionKey = section.id.replace('section-', '');
+  var remaining = section.querySelectorAll('[id^="review-walkthrough-"], [id^="ac-inbox-item-"]').length;
+  var navBadge = document.querySelector('[data-review-count-nav="' + sectionKey + '"]');
+  var headerCount = document.querySelector('[data-review-count-header="' + sectionKey + '"]');
+  if (navBadge) {
+    if (remaining > 0) navBadge.textContent = remaining;
+    else navBadge.style.display = 'none';
+  }
+  if (headerCount) {
+    if (remaining > 0) {
+      headerCount.textContent = remaining + ' item' + (remaining === 1 ? '' : 's');
+    } else {
+      headerCount.textContent = 'No items';
+      headerCount.classList.remove('text-gray-400');
+      headerCount.classList.add('text-green-600');
+    }
+  }
+  if (remaining === 0) {
+    var completeBtn = section.querySelector('button[hx-post*="/complete"]');
+    if (completeBtn) setTimeout(function() { completeBtn.click(); }, 400);
   }
 }
 


### PR DESCRIPTION
## Summary
- Mark Reviewed (policy + client) and Process Inbox now emit an \`HX-Trigger: reviewRowCleared\` event; a body-level listener in \`review/index.html\` removes the dispatched row, decrements the nav badge + section header count, and auto-fires section complete when count reaches zero.
- Fixes two latent bugs that surfaced when the walkthrough page reused these slideovers: Mark Reviewed buttons no longer hit HTMX \`targetError\` on pages without \`#review-row-{uid}\` / \`#review-client-{id}\` (retargeted to \`body\` / \`hx-swap=\"none\"\`), and the OOB \`<tr>\` row response is wrapped in \`<template>\` so the fragment parser accepts it without a surrounding table.
- Part 2 of the Weekly Review GTD overhaul — follows PR #202 (slideover wiring). Items #5, #6, #8, #9, #10 from the 10-item plan remain.

## Test plan
- [x] Open \`/review\`, scroll to Client Health, click Review on a row, click Mark Reviewed — row disappears, nav badge decrements 2→1, section header updates \"2 items\"→\"1 item\"
- [x] Clear the last client in the section — section auto-fires complete, page reloads, \"2 completed / 7 remaining\" banner updated, Client Health shows \"Done\"
- [x] No \`htmx:targetError\` or \`htmx:swapError\` in console during the full sequence
- [x] Review queue page (\`/review\` separate tab) still updates the reviewed row in place via the OOB \`hx-swap-oob=\"true\"\` \`<tr>\` — no regression
- [ ] Policy Audit → Review → Mark Reviewed flow (same code path as client, not retested in QA but same event chain)
- [ ] Inbox → Process → Submit (same event chain; existing test in PR #202 still applies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)