### PR TITLE
Add Bind Order: unified renew-and-bind workflow

### DIFF
--- a/src/policydb/bind_order.py
+++ b/src/policydb/bind_order.py
@@ -1,0 +1,845 @@
+"""Bind Order — unified renew-and-bind workflow for policies and programs.
+
+This module provides the pure-logic core for the Bind Order action:
+
+    Subject (program OR standalone policy)
+            │
+            ├── For each CHECKED child:
+            │     - if needs_renew: renew_policy() → new term row
+            │     - then mark Bound (set bound_date, log activity, complete
+            │       milestones, close follow-ups, cascade to program)
+            │
+            ├── For each UNCHECKED child with a disposition:
+            │     - apply disposition (Declined / Lost / Non-Renewed / Defer)
+            │
+            ├── If subject is a program AND every child terminal:
+            │     - update programs.bound_date + renewal_status='Bound'
+            │
+            ├── Generate post-bind follow-ups ONCE per subject
+            │     (program-scoped if program; policy-scoped if standalone)
+            │
+            └── auto_resolve_renewal_issue() for the subject
+
+The module is FastAPI-free. Routes live in web/routes/bind_order.py.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta
+from typing import Literal, Optional
+
+from policydb import config as cfg
+from policydb.queries import (
+    get_policy_by_uid,
+    get_program_by_uid,
+    get_program_child_policies,
+    renew_policy,
+)
+from policydb.renewal_issues import (
+    auto_resolve_renewal_issue,
+    cascade_program_renewal_close,
+)
+
+logger = logging.getLogger("policydb.bind_order")
+
+ChildState = Literal["needs_renew", "ready_to_bind", "already_bound"]
+SubjectType = Literal["program", "policy"]
+Disposition = Literal["Bound", "Declined", "Lost", "Non-Renewed", "Defer"]
+
+
+# ─── Data classes ────────────────────────────────────────────────────────────
+
+
+@dataclass
+class BindSubject:
+    """A subject (program or standalone policy) being bound in this action."""
+    subject_type: SubjectType
+    subject_uid: str  # program_uid or policy_uid
+
+    @classmethod
+    def parse(cls, token: str) -> "BindSubject":
+        """Parse a 'program:PGM-042' or 'policy:POL-017' token."""
+        if ":" not in token:
+            raise ValueError(f"Invalid subject token (missing ':'): {token}")
+        kind, uid = token.split(":", 1)
+        kind = kind.strip().lower()
+        uid = uid.strip().upper()
+        if kind not in ("program", "policy"):
+            raise ValueError(f"Unknown subject type: {kind}")
+        if not uid:
+            raise ValueError(f"Empty uid in subject token: {token}")
+        return cls(subject_type=kind, subject_uid=uid)  # type: ignore[arg-type]
+
+    def to_token(self) -> str:
+        return f"{self.subject_type}:{self.subject_uid}"
+
+
+@dataclass
+class ChildPanelRow:
+    """One child policy row as displayed in the bind panel."""
+    policy_uid: str
+    policy_id: int
+    policy_type: str | None
+    carrier: str | None
+    premium: float | None
+    renewal_status: str | None
+    state: ChildState  # needs_renew | ready_to_bind | already_bound
+    effective_date: str | None
+    expiration_date: str | None
+    bound_date: str | None
+
+
+@dataclass
+class SubjectPanelSection:
+    """A section of the bind panel — one program or one standalone policy."""
+    subject_type: SubjectType
+    subject_uid: str
+    subject_id: int
+    client_id: int
+    display_name: str
+    new_effective: str  # ISO date — pre-filled default
+    new_expiration: str  # ISO date — pre-filled default
+    children: list[ChildPanelRow] = field(default_factory=list)
+
+
+@dataclass
+class BindPanelData:
+    """Full payload for rendering the bind panel."""
+    bind_date: str  # ISO today
+    sections: list[SubjectPanelSection]
+    errors: list[str] = field(default_factory=list)
+
+
+@dataclass
+class BindChildPayload:
+    """Per-child instruction submitted from the panel."""
+    policy_uid: str
+    checked: bool
+    disposition: str | None  # Bound (default if checked) or one of the exceptions
+    new_premium: float | None = None  # only used when checked + override
+
+
+@dataclass
+class BindSubjectPayload:
+    """Per-subject submission."""
+    subject_type: SubjectType
+    subject_uid: str
+    new_effective: str  # ISO date
+    new_expiration: str  # ISO date
+    children: list[BindChildPayload]
+
+
+@dataclass
+class BindOrderPayload:
+    """Whole panel submission."""
+    bind_date: str  # ISO date
+    bind_note: str
+    subjects: list[BindSubjectPayload]
+
+
+@dataclass
+class BindOrderResult:
+    bound_count: int = 0
+    excepted_count: int = 0
+    renewed_inline_count: int = 0
+    bind_event_ids: list[int] = field(default_factory=list)
+    toast_message: str = ""
+
+
+# ─── State resolution ────────────────────────────────────────────────────────
+
+
+def resolve_child_state(conn: sqlite3.Connection, policy_uid: str) -> ChildState:
+    """Decide whether a policy needs to be renewed before binding, is ready to
+    bind directly, or has already been bound for its current term.
+
+    Logic:
+      - already_bound: bound_date IS NOT NULL on the current row (this term has
+        already had its bind event recorded)
+      - ready_to_bind: bound_date IS NULL AND there's no successor row (no
+        prior_policy_uid pointing to this row) — i.e., this row IS the new term
+        we want to bind. Either the user pre-renewed proactively, or this is the
+        natural in-place state if the row's expiration hasn't been rolled.
+      - needs_renew: bound_date IS NULL AND the row's expiration_date is in the
+        past or the user has explicitly asked us to renew it. In practice we
+        treat any non-bound row with no successor as ready_to_bind UNLESS the
+        expiration_date has already passed (meaning the row is the *expired*
+        term and we need to roll forward).
+
+    The needs_renew vs ready_to_bind distinction at panel-load time is
+    informational — the panel shows the user which rows will be touched by
+    renew_policy() before bind. Final routing happens in execute_bind_order()
+    so the user can change their mind by editing dates in the panel.
+    """
+    row = conn.execute(
+        """SELECT policy_uid, bound_date, expiration_date, archived
+           FROM policies WHERE policy_uid = ?""",
+        (policy_uid,),
+    ).fetchone()
+    if not row:
+        raise ValueError(f"Policy {policy_uid} not found")
+    if row["archived"]:
+        return "already_bound"
+    if row["bound_date"]:
+        return "already_bound"
+
+    # Has any newer row pointing back at this one (i.e., already renewed)?
+    successor = conn.execute(
+        "SELECT 1 FROM policies WHERE prior_policy_uid = ? AND archived = 0 LIMIT 1",
+        (policy_uid,),
+    ).fetchone()
+    if successor:
+        # This row is the OLD term — caller should bind the successor instead.
+        # Mark already_bound so the panel skips it (we don't want double-binding).
+        return "already_bound"
+
+    # Has the term already lapsed? If so, the row needs to be rolled forward
+    # before binding makes sense.
+    if row["expiration_date"]:
+        try:
+            exp = date.fromisoformat(row["expiration_date"])
+            if exp < date.today():
+                return "needs_renew"
+        except ValueError:
+            pass
+
+    # Default: this row is current, unbound, and ready to receive the bind event.
+    return "ready_to_bind"
+
+
+# ─── Panel preview ───────────────────────────────────────────────────────────
+
+
+def _median(values: list[int]) -> int:
+    if not values:
+        return 365
+    s = sorted(values)
+    n = len(s)
+    mid = n // 2
+    return s[mid] if n % 2 else (s[mid - 1] + s[mid]) // 2
+
+
+def _compute_default_dates(children: list[dict]) -> tuple[str, str]:
+    """Pick the default new_effective + new_expiration for a subject section.
+
+    new_effective = max(child.expiration_date) — the latest term we need to roll past
+    new_expiration = new_effective + median(child term length in days)
+    """
+    today = date.today()
+    expirations: list[date] = []
+    term_lengths: list[int] = []
+    for c in children:
+        if c.get("expiration_date"):
+            try:
+                exp = date.fromisoformat(c["expiration_date"])
+                expirations.append(exp)
+                if c.get("effective_date"):
+                    eff = date.fromisoformat(c["effective_date"])
+                    term_lengths.append((exp - eff).days)
+            except ValueError:
+                continue
+
+    new_eff = max(expirations) if expirations else today
+    term_days = _median(term_lengths) if term_lengths else 365
+    new_exp = new_eff + timedelta(days=term_days)
+    return new_eff.isoformat(), new_exp.isoformat()
+
+
+def _row_to_child(row: dict, state: ChildState) -> ChildPanelRow:
+    return ChildPanelRow(
+        policy_uid=row["policy_uid"],
+        policy_id=row["id"],
+        policy_type=row.get("policy_type"),
+        carrier=row.get("carrier"),
+        premium=row.get("premium"),
+        renewal_status=row.get("renewal_status"),
+        state=state,
+        effective_date=row.get("effective_date"),
+        expiration_date=row.get("expiration_date"),
+        bound_date=row.get("bound_date"),
+    )
+
+
+def preview_bind_panel(
+    conn: sqlite3.Connection, subjects: list[BindSubject]
+) -> BindPanelData:
+    """Build the panel preview for the given subjects."""
+    sections: list[SubjectPanelSection] = []
+    errors: list[str] = []
+
+    for subject in subjects:
+        if subject.subject_type == "program":
+            program = get_program_by_uid(conn, subject.subject_uid)
+            if not program:
+                errors.append(f"Program {subject.subject_uid} not found")
+                continue
+            children_rows = get_program_child_policies(conn, program["id"])
+            if not children_rows:
+                errors.append(f"Program {subject.subject_uid} has no active children")
+                continue
+            new_eff, new_exp = _compute_default_dates(children_rows)
+            children = [
+                _row_to_child(c, resolve_child_state(conn, c["policy_uid"]))
+                for c in children_rows
+            ]
+            sections.append(SubjectPanelSection(
+                subject_type="program",
+                subject_uid=subject.subject_uid,
+                subject_id=program["id"],
+                client_id=program["client_id"],
+                display_name=program.get("name") or subject.subject_uid,
+                new_effective=new_eff,
+                new_expiration=new_exp,
+                children=children,
+            ))
+        else:  # policy
+            row = get_policy_by_uid(conn, subject.subject_uid)
+            if not row:
+                errors.append(f"Policy {subject.subject_uid} not found")
+                continue
+            row_dict = dict(row)
+            new_eff, new_exp = _compute_default_dates([row_dict])
+            child = _row_to_child(
+                row_dict, resolve_child_state(conn, subject.subject_uid)
+            )
+            sections.append(SubjectPanelSection(
+                subject_type="policy",
+                subject_uid=subject.subject_uid,
+                subject_id=row_dict["id"],
+                client_id=row_dict["client_id"],
+                display_name=row_dict.get("policy_type") or subject.subject_uid,
+                new_effective=new_eff,
+                new_expiration=new_exp,
+                children=[child],
+            ))
+
+    return BindPanelData(
+        bind_date=date.today().isoformat(),
+        sections=sections,
+        errors=errors,
+    )
+
+
+# ─── Bind execution ──────────────────────────────────────────────────────────
+
+
+def _next_bind_event_uid(conn: sqlite3.Connection) -> str:
+    """Generate the next BIND-NNN uid. Low-frequency event — simple SELECT MAX
+    is sufficient (no need for the uid_sequence table)."""
+    row = conn.execute(
+        """SELECT bind_event_uid FROM bind_events
+           WHERE bind_event_uid LIKE 'BIND-%'
+           ORDER BY id DESC LIMIT 1"""
+    ).fetchone()
+    if row and row["bind_event_uid"]:
+        try:
+            n = int(row["bind_event_uid"].split("-", 1)[1])
+            return f"BIND-{n + 1:03d}"
+        except (ValueError, IndexError):
+            pass
+    return "BIND-001"
+
+
+def _sync_policy_to_program_location(
+    conn: sqlite3.Connection, policy_uid: str, program: dict
+) -> None:
+    """Mirror of programs.py:_sync_policy_to_program_location to avoid circular
+    import. Sets project_id + project_name + exposure address from the program's
+    linked project, using COALESCE so blank project values don't overwrite."""
+    if not program.get("project_id"):
+        return
+    project = conn.execute(
+        "SELECT id, name, address, city, state, zip FROM projects WHERE id = ?",
+        (program["project_id"],),
+    ).fetchone()
+    if not project:
+        return
+    conn.execute(
+        """UPDATE policies SET
+              project_id = ?,
+              project_name = ?,
+              exposure_address = COALESCE(NULLIF(?, ''), exposure_address),
+              exposure_city = COALESCE(NULLIF(?, ''), exposure_city),
+              exposure_state = COALESCE(NULLIF(?, ''), exposure_state),
+              exposure_zip = COALESCE(NULLIF(?, ''), exposure_zip)
+           WHERE policy_uid = ?""",
+        (
+            project["id"],
+            project["name"],
+            project["address"] or "",
+            project["city"] or "",
+            project["state"] or "",
+            project["zip"] or "",
+            policy_uid,
+        ),
+    )
+
+
+def _copy_tower_mappings(
+    conn: sqlite3.Connection, old_to_new_id: dict[int, int]
+) -> None:
+    """Mirror of programs.py:renew_program tower copy logic — remap excess +
+    underlying policy ids to the new term rows."""
+    if not old_to_new_id:
+        return
+
+    placeholders = ",".join(str(k) for k in old_to_new_id.keys())
+
+    coverages = conn.execute(
+        f"""SELECT * FROM program_tower_coverage
+            WHERE excess_policy_id IN ({placeholders})"""  # noqa: S608
+    ).fetchall()
+    for cov in coverages:
+        new_excess = old_to_new_id.get(cov["excess_policy_id"])
+        new_underlying = old_to_new_id.get(cov["underlying_policy_id"]) if cov["underlying_policy_id"] else None
+        if new_excess:
+            try:
+                conn.execute(
+                    """INSERT OR IGNORE INTO program_tower_coverage
+                       (excess_policy_id, underlying_policy_id, underlying_sub_coverage_id)
+                       VALUES (?, ?, ?)""",
+                    (
+                        new_excess,
+                        new_underlying or cov["underlying_policy_id"],
+                        cov["underlying_sub_coverage_id"],
+                    ),
+                )
+            except Exception:
+                pass
+
+    lines = conn.execute(
+        f"""SELECT * FROM program_tower_lines
+            WHERE source_policy_id IN ({placeholders})"""  # noqa: S608
+    ).fetchall()
+    for line in lines:
+        new_source = old_to_new_id.get(line["source_policy_id"])
+        if new_source:
+            try:
+                conn.execute(
+                    """INSERT OR IGNORE INTO program_tower_lines
+                       (program_policy_id, source_policy_id, sub_coverage_id,
+                        label, include_in_tower, sort_order)
+                       VALUES (?, ?, ?, ?, ?, ?)""",
+                    (
+                        line["program_policy_id"],
+                        new_source,
+                        line["sub_coverage_id"],
+                        line["label"],
+                        line["include_in_tower"],
+                        line["sort_order"],
+                    ),
+                )
+            except Exception:
+                pass
+
+
+def _handle_bound_transition(
+    conn: sqlite3.Connection,
+    policy_uid: str,
+    bind_date: str,
+    bind_note: str | None = None,
+    bind_event_id: int | None = None,
+) -> None:
+    """Single choke point for marking a single policy bound. Executes the
+    per-policy cascade — does NOT generate post-bind follow-ups (those are
+    generated once per subject by the caller)."""
+    uid = policy_uid.upper()
+    pol = conn.execute(
+        """SELECT id, client_id, policy_uid, is_opportunity, program_id
+           FROM policies WHERE policy_uid = ?""",
+        (uid,),
+    ).fetchone()
+    if not pol:
+        raise ValueError(f"Policy {uid} not found")
+    if pol["is_opportunity"]:
+        # Mirror policy_bound_confirm() current behavior — opportunities are skipped.
+        return
+
+    # 1. Status + bound_date + updated_at
+    conn.execute(
+        """UPDATE policies
+           SET renewal_status = 'Bound',
+               bound_date = ?,
+               updated_at = CURRENT_TIMESTAMP
+           WHERE policy_uid = ?""",
+        (bind_date, uid),
+    )
+
+    # 2. Log "Renewal bound" activity on the policy
+    details = bind_note if bind_note else None
+    bind_event_note = f" [bind_event_id={bind_event_id}]" if bind_event_id else ""
+    full_details = (details or "") + bind_event_note
+    conn.execute(
+        """INSERT INTO activity_log
+           (client_id, policy_id, activity_type, subject, details, activity_date, created_at)
+           VALUES (?, ?, 'Milestone', 'Renewal bound', ?, ?, datetime('now'))""",
+        (pol["client_id"], pol["id"], full_details.strip() or None, bind_date),
+    )
+
+    # 3. Complete remaining timeline milestones (mirror current policy_bound_confirm:
+    #    skip if program child — those milestones live at program level)
+    if not pol["program_id"]:
+        from policydb.timeline_engine import complete_timeline_milestone
+        incomplete = conn.execute(
+            "SELECT milestone_name FROM policy_timeline WHERE policy_uid = ? AND completed_date IS NULL",
+            (uid,),
+        ).fetchall()
+        for m in incomplete:
+            try:
+                complete_timeline_milestone(conn, uid, m["milestone_name"])
+            except Exception as exc:
+                logger.warning("Timeline milestone completion failed for %s/%s: %s",
+                               uid, m["milestone_name"], exc)
+
+    # 4. Close all open follow-ups on this policy
+    conn.execute(
+        """UPDATE activity_log
+           SET follow_up_done = 1,
+               auto_close_reason = 'renewal_bound',
+               auto_closed_at = datetime('now'),
+               auto_closed_by = 'bind_order'
+           WHERE policy_id = ? AND follow_up_done = 0 AND follow_up_date IS NOT NULL""",
+        (pol["id"],),
+    )
+    conn.execute(
+        "UPDATE policies SET follow_up_date = NULL WHERE policy_uid = ?", (uid,)
+    )
+
+    # 5. Cascade to program (if any) + auto-resolve renewal issue at policy scope
+    if pol["program_id"]:
+        cascade_program_renewal_close(conn, uid)
+    auto_resolve_renewal_issue(conn, policy_uid=uid)
+
+
+def _generate_post_bind_followups(
+    conn: sqlite3.Connection,
+    *,
+    client_id: int,
+    bind_date: str,
+    program_id: int | None = None,
+    policy_id: int | None = None,
+) -> int:
+    """Insert one follow-up activity_log row per item in
+    config.post_bind_activities. Returns count inserted."""
+    if program_id is None and policy_id is None:
+        raise ValueError("Must provide program_id or policy_id")
+
+    items = cfg.get("post_bind_activities", []) or []
+    if not items:
+        return 0
+
+    try:
+        bind_dt = date.fromisoformat(bind_date)
+    except ValueError:
+        bind_dt = date.today()
+
+    inserted = 0
+    for item in items:
+        try:
+            offset_days = int(item.get("days_after_bind", 0))
+        except (TypeError, ValueError):
+            offset_days = 0
+        fu_date = (bind_dt + timedelta(days=offset_days)).isoformat()
+        subject = item.get("subject") or item.get("name") or "Post-bind follow-up"
+        activity_type = item.get("activity_type") or "Follow-up"
+
+        conn.execute(
+            """INSERT INTO activity_log
+               (client_id, policy_id, program_id, activity_type, subject,
+                activity_date, follow_up_date, follow_up_done, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, 0, datetime('now'))""",
+            (
+                client_id,
+                policy_id,
+                program_id,
+                activity_type,
+                subject,
+                bind_date,
+                fu_date,
+            ),
+        )
+        inserted += 1
+    return inserted
+
+
+def execute_bind_order(
+    conn: sqlite3.Connection, payload: BindOrderPayload
+) -> BindOrderResult:
+    """Apply a bind order across one or more subjects in a single transaction."""
+    result = BindOrderResult()
+    bind_date = payload.bind_date or date.today().isoformat()
+    bind_note = (payload.bind_note or "").strip() or None
+    terminal_for_program = set(cfg.get("renewal_terminal_statuses", ["Bound", "Lost", "Non-Renewed", "Declined"]))
+
+    for sp in payload.subjects:
+        # Resolve the subject row
+        if sp.subject_type == "program":
+            program = get_program_by_uid(conn, sp.subject_uid)
+            if not program:
+                raise ValueError(f"Program {sp.subject_uid} not found")
+            subject_id = program["id"]
+            client_id = program["client_id"]
+        else:
+            pol = conn.execute(
+                "SELECT id, client_id FROM policies WHERE policy_uid = ?",
+                (sp.subject_uid,),
+            ).fetchone()
+            if not pol:
+                raise ValueError(f"Policy {sp.subject_uid} not found")
+            subject_id = pol["id"]
+            client_id = pol["client_id"]
+            program = None
+
+        # 1. Insert the bind_events row
+        bind_event_uid = _next_bind_event_uid(conn)
+        cur = conn.execute(
+            """INSERT INTO bind_events
+               (bind_event_uid, bind_date, subject_type, subject_id, subject_uid,
+                client_id, bind_note)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (
+                bind_event_uid,
+                bind_date,
+                sp.subject_type,
+                subject_id,
+                sp.subject_uid,
+                client_id,
+                bind_note,
+            ),
+        )
+        bind_event_id = cur.lastrowid
+        result.bind_event_ids.append(bind_event_id)
+
+        old_to_new_id: dict[int, int] = {}
+        bound_in_subject = 0
+        excepted_in_subject = 0
+        total_premium_bound = 0.0
+        all_terminal = True
+
+        # 2. Process each child
+        for ch in sp.children:
+            old_uid = ch.policy_uid.upper()
+            if not ch.checked:
+                # Disposition path — apply to the existing (expiring) row
+                disposition = (ch.disposition or "Defer").strip()
+                if disposition == "Defer":
+                    # Leave row untouched, but record the bind_event_children entry
+                    conn.execute(
+                        """INSERT INTO bind_event_children
+                           (bind_event_id, old_policy_uid, new_policy_uid,
+                            renewed_inline, disposition)
+                           VALUES (?, ?, ?, 0, ?)""",
+                        (bind_event_id, old_uid, old_uid, "Defer"),
+                    )
+                    excepted_in_subject += 1
+                    all_terminal = False
+                    continue
+                # Apply terminal status
+                conn.execute(
+                    """UPDATE policies
+                       SET renewal_status = ?,
+                           updated_at = CURRENT_TIMESTAMP
+                       WHERE policy_uid = ?""",
+                    (disposition, old_uid),
+                )
+                # Log activity capturing the disposition
+                pol_row = conn.execute(
+                    "SELECT id, client_id FROM policies WHERE policy_uid = ?", (old_uid,)
+                ).fetchone()
+                if pol_row:
+                    conn.execute(
+                        """INSERT INTO activity_log
+                           (client_id, policy_id, activity_type, subject, details,
+                            activity_date, created_at)
+                           VALUES (?, ?, 'Milestone', ?, ?, ?, datetime('now'))""",
+                        (
+                            pol_row["client_id"],
+                            pol_row["id"],
+                            f"Renewal {disposition.lower()}",
+                            f"Disposition recorded via Bind Order [bind_event_id={bind_event_id}]",
+                            bind_date,
+                        ),
+                    )
+                conn.execute(
+                    """INSERT INTO bind_event_children
+                       (bind_event_id, old_policy_uid, new_policy_uid,
+                        renewed_inline, disposition)
+                       VALUES (?, ?, ?, 0, ?)""",
+                    (bind_event_id, old_uid, old_uid, disposition),
+                )
+                excepted_in_subject += 1
+                if disposition not in terminal_for_program:
+                    all_terminal = False
+                continue
+
+            # CHECKED path — bind it (renewing first if needed)
+            state = resolve_child_state(conn, old_uid)
+            renewed_inline = 0
+            new_uid = old_uid
+
+            if state == "needs_renew":
+                old_row = conn.execute(
+                    "SELECT id FROM policies WHERE policy_uid = ?", (old_uid,)
+                ).fetchone()
+                old_id = old_row["id"] if old_row else None
+                new_uid = renew_policy(
+                    conn,
+                    old_uid,
+                    new_effective=sp.new_effective,
+                    new_expiration=sp.new_expiration,
+                    new_premium=ch.new_premium,
+                )
+                renewed_inline = 1
+                result.renewed_inline_count += 1
+
+                # Re-link the new row to its program (renew_policy doesn't copy program_id)
+                if program:
+                    new_row = conn.execute(
+                        "SELECT id, schematic_column FROM policies WHERE policy_uid = ?",
+                        (new_uid,),
+                    ).fetchone()
+                    if new_row:
+                        # Look up the OLD row's program metadata to preserve schematic_column
+                        old_meta = conn.execute(
+                            """SELECT tower_group, schematic_column
+                               FROM policies WHERE id = ?""",
+                            (old_id,),
+                        ).fetchone() if old_id else None
+                        conn.execute(
+                            """UPDATE policies
+                               SET program_id = ?,
+                                   tower_group = ?,
+                                   schematic_column = ?
+                               WHERE id = ?""",
+                            (
+                                program["id"],
+                                program.get("name"),
+                                old_meta["schematic_column"] if old_meta else None,
+                                new_row["id"],
+                            ),
+                        )
+                        if old_id:
+                            old_to_new_id[old_id] = new_row["id"]
+                        _sync_policy_to_program_location(conn, new_uid, program)
+            elif ch.new_premium is not None:
+                # ready_to_bind but user edited premium in the panel — apply the override
+                conn.execute(
+                    "UPDATE policies SET premium = ? WHERE policy_uid = ?",
+                    (ch.new_premium, old_uid),
+                )
+
+            # Mark bound (single choke point)
+            _handle_bound_transition(conn, new_uid, bind_date, bind_note, bind_event_id)
+
+            # Capture details for the bind_event_children row + premium total
+            new_row_full = conn.execute(
+                """SELECT id, premium, effective_date, expiration_date
+                   FROM policies WHERE policy_uid = ?""",
+                (new_uid,),
+            ).fetchone()
+            if new_row_full and new_row_full["premium"]:
+                try:
+                    total_premium_bound += float(new_row_full["premium"])
+                except (TypeError, ValueError):
+                    pass
+            conn.execute(
+                """INSERT INTO bind_event_children
+                   (bind_event_id, old_policy_uid, new_policy_uid, renewed_inline,
+                    disposition, bound_effective_date, bound_expiration_date, bound_premium)
+                   VALUES (?, ?, ?, ?, 'Bound', ?, ?, ?)""",
+                (
+                    bind_event_id,
+                    old_uid,
+                    new_uid,
+                    renewed_inline,
+                    new_row_full["effective_date"] if new_row_full else None,
+                    new_row_full["expiration_date"] if new_row_full else None,
+                    new_row_full["premium"] if new_row_full else None,
+                ),
+            )
+            bound_in_subject += 1
+
+        # 3. Copy tower mappings if any children were renewed inline (program path only)
+        if program and old_to_new_id:
+            _copy_tower_mappings(conn, old_to_new_id)
+
+        # 4. Update the program-level row if every child terminal
+        if sp.subject_type == "program" and all_terminal and bound_in_subject > 0:
+            conn.execute(
+                """UPDATE programs
+                   SET bound_date = ?,
+                       renewal_status = 'Bound',
+                       updated_at = CURRENT_TIMESTAMP
+                   WHERE program_uid = ?""",
+                (bind_date, sp.subject_uid),
+            )
+
+        # 5. Generate post-bind follow-ups ONCE per subject
+        if bound_in_subject > 0:
+            if sp.subject_type == "program":
+                _generate_post_bind_followups(
+                    conn,
+                    client_id=client_id,
+                    bind_date=bind_date,
+                    program_id=subject_id,
+                )
+            else:
+                # Standalone — anchor on the (possibly new) policy row
+                # If we renewed inline, prefer the new row's id
+                if old_to_new_id:
+                    new_id = next(iter(old_to_new_id.values()))
+                    target_policy_id = new_id
+                else:
+                    # Re-fetch in case the bound child id differs from subject_id
+                    target_policy_id = subject_id
+                _generate_post_bind_followups(
+                    conn,
+                    client_id=client_id,
+                    bind_date=bind_date,
+                    policy_id=target_policy_id,
+                )
+
+        # 6. Auto-resolve the subject's renewal issue
+        if sp.subject_type == "program":
+            auto_resolve_renewal_issue(conn, program_uid=sp.subject_uid)
+        else:
+            auto_resolve_renewal_issue(conn, policy_uid=sp.subject_uid)
+
+        # 7. Update the counts on bind_events row
+        conn.execute(
+            """UPDATE bind_events
+               SET policy_count_bound = ?,
+                   policy_count_excepted = ?,
+                   total_premium = ?
+               WHERE id = ?""",
+            (bound_in_subject, excepted_in_subject, total_premium_bound, bind_event_id),
+        )
+
+        result.bound_count += bound_in_subject
+        result.excepted_count += excepted_in_subject
+
+    conn.commit()
+
+    # Compose toast message
+    parts = []
+    if result.bound_count:
+        parts.append(f"Bound {result.bound_count}")
+    if result.excepted_count:
+        parts.append(f"{result.excepted_count} excepted")
+    if result.renewed_inline_count:
+        parts.append(f"{result.renewed_inline_count} renewed inline")
+    result.toast_message = (
+        " — ".join(parts) + " — see Action Center for post-bind follow-ups."
+        if parts
+        else "Bind order complete."
+    )
+
+    logger.info(
+        "Bind order complete: %d bound, %d excepted, %d renewed inline (events=%s)",
+        result.bound_count, result.excepted_count, result.renewed_inline_count,
+        result.bind_event_ids,
+    )
+    return result

--- a/src/policydb/config.py
+++ b/src/policydb/config.py
@@ -610,6 +610,35 @@ _DEFAULTS: dict[str, Any] = {
             "subject": "Confirm policy issued — {{policy_type}}",
         },
     ],
+    # Post-bind stewardship follow-ups generated when a Bind Order is submitted.
+    # Anchored on bind_date. Generated once per subject (program OR standalone policy).
+    # Editable in Settings (mirror of mandated_activities).
+    "post_bind_activities": [
+        {
+            "name": "Binder received from carrier",
+            "days_after_bind": 5,
+            "activity_type": "Follow-up",
+            "subject": "Confirm binder received from carrier",
+        },
+        {
+            "name": "Binder sent to client",
+            "days_after_bind": 7,
+            "activity_type": "Follow-up",
+            "subject": "Send binder to client",
+        },
+        {
+            "name": "Invoice issued to client",
+            "days_after_bind": 7,
+            "activity_type": "Follow-up",
+            "subject": "Issue invoice to client",
+        },
+        {
+            "name": "Final policy document received",
+            "days_after_bind": 30,
+            "activity_type": "Follow-up",
+            "subject": "Confirm final policy document received",
+        },
+    ],
     "email_subject_request": "{{client_name}} \u2014 {{rfi_uid}} {{request_title}}",
     "email_subject_request_all": "{{client_name}} \u2014 Outstanding Information Requests",
     "email_subject_rfi_notify": "FYI: {{client_name}} \u2014 {{rfi_uid}} Items Received",

--- a/src/policydb/db.py
+++ b/src/policydb/db.py
@@ -1868,6 +1868,15 @@ def _init_db_inner(conn: sqlite3.Connection, db_path: Path) -> None:
         conn.commit()
         logger.info("Migration 141: added merged_from_issue_id to record_attachments")
 
+    if 142 not in applied:
+        conn.executescript((_MIGRATIONS_DIR / "142_bind_events.sql").read_text())
+        conn.execute(
+            "INSERT INTO schema_version (version, description) VALUES (?, ?)",
+            (142, "Bind Events audit tables for renew-and-bind workflow"),
+        )
+        conn.commit()
+        logger.info("Migration 142: added bind_events and bind_event_children tables")
+
     # Data hygiene: fix 'None' string corruption in text fields (runs every startup, fast no-op if clean)
     conn.execute("UPDATE clients SET cn_number = NULL WHERE cn_number = 'None'")
 

--- a/src/policydb/migrations/142_bind_events.sql
+++ b/src/policydb/migrations/142_bind_events.sql
@@ -1,0 +1,39 @@
+-- 142: Bind Events audit tables — first-class artifact for "client issued bind order" moments
+-- Captures which subject (program or standalone policy) was bound, when, with what note,
+-- and which children were touched (with their disposition).
+
+CREATE TABLE IF NOT EXISTS bind_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    bind_event_uid TEXT UNIQUE,                -- e.g., "BIND-001"
+    bind_date DATE NOT NULL,
+    subject_type TEXT NOT NULL CHECK (subject_type IN ('program', 'policy')),
+    subject_id INTEGER NOT NULL,               -- programs.id or policies.id
+    subject_uid TEXT NOT NULL,                 -- program_uid or policy_uid (denormalized)
+    client_id INTEGER REFERENCES clients(id),
+    bind_note TEXT,                            -- free-text capture of bind instruction
+    policy_count_bound INTEGER NOT NULL DEFAULT 0,
+    policy_count_excepted INTEGER NOT NULL DEFAULT 0,
+    total_premium REAL,                        -- sum across bound children at time of bind
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_by TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_bind_events_subject ON bind_events(subject_type, subject_id);
+CREATE INDEX IF NOT EXISTS idx_bind_events_client ON bind_events(client_id);
+CREATE INDEX IF NOT EXISTS idx_bind_events_date ON bind_events(bind_date);
+
+CREATE TABLE IF NOT EXISTS bind_event_children (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    bind_event_id INTEGER NOT NULL REFERENCES bind_events(id) ON DELETE CASCADE,
+    old_policy_uid TEXT,                       -- archived row if renew-and-bind path
+    new_policy_uid TEXT NOT NULL,              -- the row that ended up bound (== old if no renew)
+    renewed_inline INTEGER NOT NULL DEFAULT 0, -- 1 if renew_policy() was called as part of bind
+    disposition TEXT NOT NULL,                 -- 'Bound' | 'Declined' | 'Lost' | 'Non-Renewed' | 'Defer'
+    bound_effective_date DATE,
+    bound_expiration_date DATE,
+    bound_premium REAL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_bind_event_children_event ON bind_event_children(bind_event_id);
+CREATE INDEX IF NOT EXISTS idx_bind_event_children_new_uid ON bind_event_children(new_policy_uid);

--- a/src/policydb/queries.py
+++ b/src/policydb/queries.py
@@ -583,12 +583,26 @@ def get_renewal_calendar(
 
 # ─── RENEWAL TERM CREATION ────────────────────────────────────────────────────
 
-def renew_policy(conn: sqlite3.Connection, uid: str) -> str:
+def renew_policy(
+    conn: sqlite3.Connection,
+    uid: str,
+    *,
+    new_effective: str | date | None = None,
+    new_expiration: str | date | None = None,
+    new_premium: float | None = None,
+) -> str:
     """Create a new annual term from an existing policy.
 
     Copies all fields from the prior term, advances dates by one year,
     archives the old record, snapshots premium to premium_history, and
     returns the new policy_uid.
+
+    Optional overrides (used by Bind Order panel):
+      new_effective / new_expiration: ISO date string or date object — override
+        the auto-computed term dates. If only one is provided, the other is
+        still auto-computed (effective = old.expiration; expiration = new_eff + term).
+      new_premium: override the premium on the new term row. If None, the new
+        row inherits the old row's premium (default behavior).
     """
     from policydb.db import next_policy_uid
 
@@ -596,16 +610,28 @@ def renew_policy(conn: sqlite3.Connection, uid: str) -> str:
     if old is None:
         raise ValueError(f"Policy {uid} not found")
 
-    # Advance dates by one year with Feb-29 fallback
+    def _coerce_date(value):
+        if value is None:
+            return None
+        if isinstance(value, date):
+            return value
+        return date.fromisoformat(value)
+
+    # Advance dates by one year with Feb-29 fallback (used as defaults if no override)
     exp = date.fromisoformat(old["expiration_date"])
-    new_eff = exp
+    auto_new_eff = exp
     try:
-        new_exp = exp.replace(year=exp.year + 1)
+        auto_new_exp = exp.replace(year=exp.year + 1)
     except ValueError:
         # Feb 29 → Feb 28 in non-leap year (industry standard: stay in month)
-        new_exp = exp.replace(year=exp.year + 1, day=exp.day - 1)
+        auto_new_exp = exp.replace(year=exp.year + 1, day=exp.day - 1)
+
+    new_eff = _coerce_date(new_effective) or auto_new_eff
+    new_exp = _coerce_date(new_expiration) or auto_new_exp
 
     new_uid = next_policy_uid(conn)
+
+    premium_value = new_premium if new_premium is not None else old["premium"]
 
     conn.execute(
         """INSERT INTO policies
@@ -621,7 +647,7 @@ def renew_policy(conn: sqlite3.Connection, uid: str) -> str:
         (
             new_uid, old["client_id"], old["policy_type"], old["carrier"], None,
             new_eff.isoformat(), new_exp.isoformat(),
-            old["premium"], old["premium"],  # premium carries over; prior_premium = old premium
+            premium_value, old["premium"],  # prior_premium snapshot stays = old premium
             old["limit_amount"], old["deductible"], old["description"], old["coverage_form"],
             old["layer_position"] or "Primary", old["tower_group"], old["is_standalone"],
             "Not Started", old["commission_rate"], old["account_exec"], None,

--- a/src/policydb/web/app.py
+++ b/src/policydb/web/app.py
@@ -327,7 +327,7 @@ def get_db() -> Generator[sqlite3.Connection, None, None]:
 
 
 # ── Register routers ──────────────────────────────────────────────────────────
-from policydb.web.routes import dashboard, clients, policies, activities, settings, reconcile, templates as tpl_routes, contacts, review, briefing, inbox, ref_lookup, compliance, action_center, logs, compose, import_history, geocoder as geocoder_routes, charts as charts_routes, programs as programs_routes, exports as exports_routes, issues as issues_routes, data_health as data_health_routes, anomalies as anomalies_routes, kb as kb_routes, attachments as attachments_routes, pinned_notes as pinned_notes_routes, outlook_routes, prompt_builder as prompt_builder_routes  # noqa: E402
+from policydb.web.routes import dashboard, clients, policies, activities, settings, reconcile, templates as tpl_routes, contacts, review, briefing, inbox, ref_lookup, compliance, action_center, logs, compose, import_history, geocoder as geocoder_routes, charts as charts_routes, programs as programs_routes, exports as exports_routes, issues as issues_routes, data_health as data_health_routes, anomalies as anomalies_routes, kb as kb_routes, attachments as attachments_routes, pinned_notes as pinned_notes_routes, outlook_routes, prompt_builder as prompt_builder_routes, bind_order as bind_order_routes  # noqa: E402
 
 app.include_router(dashboard.router)
 app.include_router(clients.router)
@@ -358,6 +358,7 @@ app.include_router(attachments_routes.router)
 app.include_router(pinned_notes_routes.router)
 app.include_router(outlook_routes.router)
 app.include_router(prompt_builder_routes.router)
+app.include_router(bind_order_routes.router)
 
 # Static files (charts JS/CSS assets)
 STATIC_DIR = Path(__file__).parent / "static"

--- a/src/policydb/web/routes/bind_order.py
+++ b/src/policydb/web/routes/bind_order.py
@@ -1,0 +1,123 @@
+"""Bind Order routes — slideover panel preview + submit."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse, JSONResponse
+
+from policydb.bind_order import (
+    BindChildPayload,
+    BindOrderPayload,
+    BindSubject,
+    BindSubjectPayload,
+    execute_bind_order,
+    preview_bind_panel,
+)
+from policydb.web.app import get_db, templates
+
+logger = logging.getLogger("policydb.bind_order")
+router = APIRouter(tags=["bind_order"])
+
+
+def _parse_subjects_param(raw: str) -> list[BindSubject]:
+    if not raw:
+        return []
+    tokens = [t.strip() for t in raw.split(",") if t.strip()]
+    parsed: list[BindSubject] = []
+    for t in tokens:
+        try:
+            parsed.append(BindSubject.parse(t))
+        except ValueError as e:
+            logger.warning("Skipping invalid subject token: %s (%s)", t, e)
+    return parsed
+
+
+@router.get("/bind-order/panel", response_class=HTMLResponse)
+def bind_order_panel(
+    request: Request,
+    subjects: str = Query(..., description="comma-separated tokens like 'program:PGM-042,policy:POL-017'"),
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    """Render the Bind Order slideover panel for the given subjects."""
+    parsed = _parse_subjects_param(subjects)
+    if not parsed:
+        raise HTTPException(status_code=400, detail="No valid subjects provided")
+
+    panel = preview_bind_panel(conn, parsed)
+    return templates.TemplateResponse("bind_order/_panel.html", {
+        "request": request,
+        "panel": panel,
+    })
+
+
+@router.post("/bind-order/submit")
+async def bind_order_submit(
+    request: Request,
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    """Apply a bind order. Accepts JSON payload describing the panel state."""
+    try:
+        body = await request.json()
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=400, detail="Invalid JSON body")
+
+    bind_date = (body.get("bind_date") or "").strip()
+    bind_note = body.get("bind_note") or ""
+    raw_subjects = body.get("subjects") or []
+    if not isinstance(raw_subjects, list) or not raw_subjects:
+        raise HTTPException(status_code=400, detail="Missing 'subjects' list")
+
+    payload_subjects: list[BindSubjectPayload] = []
+    for sub in raw_subjects:
+        try:
+            children_raw = sub.get("children") or []
+            children = [
+                BindChildPayload(
+                    policy_uid=str(c.get("policy_uid") or "").strip().upper(),
+                    checked=bool(c.get("checked")),
+                    disposition=(c.get("disposition") or None),
+                    new_premium=(float(c["new_premium"]) if c.get("new_premium") not in (None, "") else None),
+                )
+                for c in children_raw
+                if c.get("policy_uid")
+            ]
+            payload_subjects.append(BindSubjectPayload(
+                subject_type=sub["subject_type"],
+                subject_uid=str(sub["subject_uid"]).strip().upper(),
+                new_effective=str(sub.get("new_effective") or "").strip(),
+                new_expiration=str(sub.get("new_expiration") or "").strip(),
+                children=children,
+            ))
+        except (KeyError, TypeError, ValueError) as e:
+            raise HTTPException(status_code=400, detail=f"Invalid subject payload: {e}")
+
+    payload = BindOrderPayload(
+        bind_date=bind_date,
+        bind_note=bind_note,
+        subjects=payload_subjects,
+    )
+
+    try:
+        result = execute_bind_order(conn, payload)
+    except ValueError as e:
+        conn.rollback()
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        conn.rollback()
+        logger.exception("Bind order execution failed")
+        raise HTTPException(status_code=500, detail=f"Bind order failed: {e}")
+
+    response = JSONResponse({
+        "ok": True,
+        "bound_count": result.bound_count,
+        "excepted_count": result.excepted_count,
+        "renewed_inline_count": result.renewed_inline_count,
+        "bind_event_ids": result.bind_event_ids,
+        "toast_message": result.toast_message,
+    })
+    response.headers["HX-Trigger"] = json.dumps({"bindOrderComplete": result.toast_message})
+    return response

--- a/src/policydb/web/routes/policies.py
+++ b/src/policydb/web/routes/policies.py
@@ -3765,23 +3765,44 @@ async def policy_cell_save(request: Request, policy_uid: str, conn=Depends(get_d
         ).fetchone()
         prior_status = prior_row["renewal_status"] if prior_row else "Not Started"
         is_opp = prior_row["is_opportunity"] if prior_row else 0
+        resolve_statuses = cfg.get("renewal_issue_resolve_statuses", ["Bound"])
 
+        # Bound transition fires the full cascade through bind_order helper.
+        # Guard: if the row needs to be renewed before binding (expired term, etc.),
+        # block the silent-bound write and force the user through the Bind Order panel.
+        if val in resolve_statuses and not is_opp:
+            from policydb.bind_order import (
+                resolve_child_state,
+                _handle_bound_transition,
+                _generate_post_bind_followups,
+            )
+            from datetime import date as _date
+            try:
+                state = resolve_child_state(conn, uid)
+            except ValueError:
+                state = "ready_to_bind"
+            if state == "needs_renew":
+                return JSONResponse(
+                    {"ok": False, "error": "This policy still needs to be renewed first. Use the Bind Order action to roll the term forward and bind in one step."},
+                    status_code=400,
+                )
+            today_iso = _date.today().isoformat()
+            _handle_bound_transition(conn, uid, today_iso, bind_note=None)
+            _generate_post_bind_followups(
+                conn,
+                client_id=policy["client_id"],
+                bind_date=today_iso,
+                policy_id=policy["id"],
+            )
+            conn.commit()
+            return JSONResponse({"ok": True, "formatted": val})
+
+        # Non-bound status writes — straight UPDATE
         conn.execute("UPDATE policies SET renewal_status = ? WHERE policy_uid = ?", (val or None, uid))
         formatted = val
-
-        resolve_statuses = cfg.get("renewal_issue_resolve_statuses", ["Bound"])
         # Clear bound_date when moving away from terminal status
         if val not in resolve_statuses and prior_status in resolve_statuses:
             conn.execute("UPDATE policies SET bound_date=NULL WHERE policy_uid=?", (uid,))
-        # Signal confirmation banner for terminal status (skip opportunities)
-        if val in resolve_statuses and not is_opp:
-            conn.commit()
-            return JSONResponse({
-                "ok": True, "formatted": formatted,
-                "bound_confirm": True,
-                "policy_uid": uid,
-                "prior_status": prior_status,
-            })
     elif field == "opportunity_status":
         val = value.strip()
         conn.execute("UPDATE policies SET opportunity_status = ? WHERE policy_uid = ?", (val or None, uid))
@@ -4172,7 +4193,14 @@ def policy_bound_confirm(
     policy_uid: str,
     conn=Depends(get_db),
 ):
-    """Execute all bound automations after user confirms."""
+    """Execute all bound automations after user confirms (status badge banner path).
+
+    Refactored to delegate to bind_order._handle_bound_transition() — the single
+    choke point shared with the Bind Order panel and the cell-edit fast path.
+    """
+    from datetime import date as _date
+    from policydb.bind_order import _handle_bound_transition, _generate_post_bind_followups
+
     uid = policy_uid.upper()
     policy = conn.execute(
         "SELECT id, client_id, policy_uid, is_opportunity, program_id, expiration_date FROM policies WHERE policy_uid=?",
@@ -4181,49 +4209,20 @@ def policy_bound_confirm(
     if not policy:
         return HTMLResponse("", status_code=404)
 
-    # Guard: skip automations for opportunities
+    # Guard: skip automations for opportunities (preserves prior behavior)
     if policy["is_opportunity"]:
         return HTMLResponse('<div id="bound-confirm-prompt" hx-swap-oob="innerHTML"></div>')
 
-    policy_id = policy["id"]
-
-    # 1. Record bound_date
-    conn.execute("UPDATE policies SET bound_date=date('now') WHERE policy_uid=?", (uid,))
-
-    # 2. Log activity
-    conn.execute(
-        """INSERT INTO activity_log (client_id, policy_id, activity_type, subject, created_at)
-           VALUES (?, ?, 'Milestone', 'Renewal bound', datetime('now'))""",
-        (policy["client_id"], policy_id),
+    today_iso = _date.today().isoformat()
+    _handle_bound_transition(conn, uid, today_iso, bind_note=None)
+    _generate_post_bind_followups(
+        conn,
+        client_id=policy["client_id"],
+        bind_date=today_iso,
+        policy_id=policy["id"],
     )
-
-    # 3. Complete remaining timeline milestones (skip if program child)
-    if not policy["program_id"]:
-        from policydb.timeline_engine import complete_timeline_milestone
-        incomplete = conn.execute(
-            "SELECT milestone_name FROM policy_timeline WHERE policy_uid=? AND completed_date IS NULL",
-            (uid,),
-        ).fetchall()
-        for m in incomplete:
-            complete_timeline_milestone(conn, uid, m["milestone_name"])
-
-    # 4. Close all pending follow-ups
-    conn.execute(
-        """UPDATE activity_log
-           SET follow_up_done=1, auto_close_reason='renewal_bound',
-               auto_closed_at=datetime('now'), auto_closed_by='bound_status_change'
-           WHERE policy_id=? AND follow_up_done=0 AND follow_up_date IS NOT NULL""",
-        (policy_id,),
-    )
-    conn.execute("UPDATE policies SET follow_up_date=NULL WHERE policy_uid=?", (uid,))
-
-    # 5. Auto-resolve renewal issues + cascade
-    from policydb.renewal_issues import auto_resolve_renewal_issue, cascade_program_renewal_close
-    auto_resolve_renewal_issue(conn, policy_uid=uid)
-    cascade_program_renewal_close(conn, uid)
-
     conn.commit()
-    logger.info("Policy %s bound automations complete", uid)
+    logger.info("Policy %s bound automations complete (banner path)", uid)
 
     # Check if eligible for renewal term prompt
     has_successor = conn.execute(

--- a/src/policydb/web/routes/programs.py
+++ b/src/policydb/web/routes/programs.py
@@ -1581,58 +1581,81 @@ def program_bound_confirm(
     program_uid: str,
     conn: sqlite3.Connection = Depends(get_db),
 ):
-    """Execute all bound automations for a program after user confirms."""
+    """Execute all bound automations for a program (status badge banner path).
+
+    Fast path: marks every active child policy bound using today's date and the
+    panel-default new term dates. For richer control (selective children, custom
+    dates, bind notes) the user goes through the Bind Order panel instead.
+    """
+    from datetime import date as _date
+    from policydb.bind_order import (
+        BindChildPayload,
+        BindOrderPayload,
+        BindSubject,
+        BindSubjectPayload,
+        execute_bind_order,
+        preview_bind_panel,
+    )
+
     program = get_program_by_uid(conn, program_uid)
     if not program:
         return HTMLResponse("", status_code=404)
 
     program_id = program["id"]
 
-    # 1. Record bound_date
-    conn.execute("UPDATE programs SET bound_date=date('now') WHERE program_uid=?", (program_uid,))
+    # Build a default payload by previewing the panel — this gives us computed dates + child list
+    panel = preview_bind_panel(conn, [BindSubject(subject_type="program", subject_uid=program_uid)])
+    if not panel.sections:
+        # No active children — log a bare program-level "Renewal bound" entry and bail
+        conn.execute("UPDATE programs SET bound_date=date('now'), renewal_status='Bound' WHERE program_uid=?", (program_uid,))
+        conn.execute(
+            """INSERT INTO activity_log (client_id, program_id, activity_type, subject, created_at)
+               VALUES (?, ?, 'Milestone', 'Renewal bound', datetime('now'))""",
+            (program["client_id"], program_id),
+        )
+        conn.commit()
+        return HTMLResponse("")
 
-    # 2. Log activity
-    conn.execute(
-        """INSERT INTO activity_log (client_id, program_id, activity_type, subject, created_at)
-           VALUES (?, ?, 'Milestone', 'Renewal bound', datetime('now'))""",
-        (program["client_id"], program_id),
+    section = panel.sections[0]
+    payload = BindOrderPayload(
+        bind_date=_date.today().isoformat(),
+        bind_note="",
+        subjects=[BindSubjectPayload(
+            subject_type="program",
+            subject_uid=program_uid,
+            new_effective=section.new_effective,
+            new_expiration=section.new_expiration,
+            children=[
+                BindChildPayload(
+                    policy_uid=child.policy_uid,
+                    checked=(child.state != "already_bound"),
+                    disposition="Bound",
+                    new_premium=None,
+                )
+                for child in section.children
+            ],
+        )],
     )
 
-    # 3. Complete remaining timeline milestones for the program
-    from policydb.timeline_engine import complete_timeline_milestone
-    incomplete = conn.execute(
-        "SELECT milestone_name FROM policy_timeline WHERE policy_uid=? AND completed_date IS NULL",
-        (program_uid,),
-    ).fetchall()
-    for m in incomplete:
-        complete_timeline_milestone(conn, program_uid, m["milestone_name"])
+    try:
+        execute_bind_order(conn, payload)
+    except Exception as exc:
+        conn.rollback()
+        logger.exception("Program %s fast-path bind failed: %s", program_uid, exc)
+        return HTMLResponse(
+            f'<div id="bound-confirm-prompt" hx-swap-oob="innerHTML">'
+            f'<div class="text-xs text-red-600 p-2">Bind failed: {exc}</div></div>'
+        )
 
-    # 4. Close all pending follow-ups for this program
-    conn.execute(
-        """UPDATE activity_log
-           SET follow_up_done=1, auto_close_reason='renewal_bound',
-               auto_closed_at=datetime('now'), auto_closed_by='bound_status_change'
-           WHERE program_id=? AND follow_up_done=0 AND follow_up_date IS NOT NULL""",
-        (program_id,),
-    )
-    conn.execute("UPDATE programs SET follow_up_date=NULL WHERE program_uid=?", (program_uid,))
+    logger.info("Program %s bound (banner fast path)", program_uid)
 
-    # 5. Auto-resolve renewal issues
-    from policydb.renewal_issues import auto_resolve_renewal_issue
-    auto_resolve_renewal_issue(conn, program_uid=program_uid)
-
-    conn.commit()
-    logger.info("Program %s bound automations complete", program_uid)
-
-    # Check if eligible for renewal prompt
+    # Show renewal prompt offering to also create the next term row (preserves prior UX)
     children = get_program_child_policies(conn, program_id)
-    has_children = bool(children)
-    if has_children:
+    if children:
         return templates.TemplateResponse("programs/_program_bound_renew_prompt.html", {
             "request": request,
             "program_uid": program_uid,
         })
-
     return HTMLResponse("")
 
 

--- a/src/policydb/web/routes/settings.py
+++ b/src/policydb/web/routes/settings.py
@@ -189,6 +189,7 @@ def _build_tab_context(tab: str, conn) -> dict:
 
     if tab == "workflow":
         ctx["mandated_activities"] = cfg.get("mandated_activities", [])
+        ctx["post_bind_activities"] = cfg.get("post_bind_activities", [])
         ctx["milestone_profiles"] = cfg.get("milestone_profiles", [])
         ctx["milestone_profile_rules"] = cfg.get("milestone_profile_rules", [])
         ctx["timeline_engine"] = cfg.get("timeline_engine", {})
@@ -967,6 +968,67 @@ async def save_mandated_activity(request: Request, index: int):
                 activities[index][key] = val
         full = dict(cfg.load_config())
         full["mandated_activities"] = activities
+        cfg.save_config(full)
+        cfg.reload_config()
+    return HTMLResponse('<span class="text-green-600 text-xs">&#10003;</span>')
+
+
+# ── Post-Bind Activities ─────────────────────────────────────────────────────
+
+@router.post("/post-bind-activities/add", response_class=HTMLResponse)
+def post_bind_activity_add(
+    request: Request,
+    name: str = Form(...),
+    days_after_bind: int = Form(7),
+    activity_type: str = Form("Follow-up"),
+    subject: str = Form(""),
+):
+    full = dict(cfg.load_config())
+    rules = list(full.get("post_bind_activities", []))
+    rules.append({
+        "name": name.strip(),
+        "days_after_bind": days_after_bind,
+        "activity_type": activity_type,
+        "subject": subject.strip() or name.strip(),
+    })
+    full["post_bind_activities"] = rules
+    cfg.save_config(full)
+    cfg.reload_config()
+    return _render_post_bind_activities(request)
+
+
+@router.post("/post-bind-activities/remove", response_class=HTMLResponse)
+def post_bind_activity_remove(request: Request, name: str = Form(...)):
+    full = dict(cfg.load_config())
+    rules = [r for r in full.get("post_bind_activities", []) if r.get("name") != name]
+    full["post_bind_activities"] = rules
+    cfg.save_config(full)
+    cfg.reload_config()
+    return _render_post_bind_activities(request)
+
+
+def _render_post_bind_activities(request: Request) -> HTMLResponse:
+    return templates.TemplateResponse("settings/_post_bind_activities_rows.html", {
+        "request": request,
+        "post_bind_activities": cfg.get("post_bind_activities", []),
+        "activity_types": cfg.get("activity_types", []),
+    })
+
+
+@router.patch("/post-bind-activities/{index}", response_class=HTMLResponse)
+async def save_post_bind_activity(request: Request, index: int):
+    """PATCH a single field on a post-bind activity by index."""
+    form = await request.form()
+    activities = list(cfg.get("post_bind_activities", []))
+    if 0 <= index < len(activities):
+        for key in ("name", "days_after_bind", "activity_type", "subject"):
+            if key in form:
+                val = form[key]
+                if key == "days_after_bind":
+                    val = int(val) if val else 0
+                activities[index][key] = val
+        full = dict(cfg.load_config())
+        full["post_bind_activities"] = activities
         cfg.save_config(full)
         cfg.reload_config()
     return HTMLResponse('<span class="text-green-600 text-xs">&#10003;</span>')

--- a/src/policydb/web/templates/base.html
+++ b/src/policydb/web/templates/base.html
@@ -659,6 +659,9 @@
 
   <!-- Compose Slideover (content loaded via HTMX, template provides its own positioning) -->
   <div id="compose-slideover-body"></div>
+
+  <!-- Bind Order Slideover (content loaded via HTMX) -->
+  <div id="bind-order-slideover-body"></div>
 </div>
 
 <style>
@@ -763,6 +766,37 @@ function closeComposeSlideover() {
 document.addEventListener('keydown', function(e) {
   if (e.key === 'Escape' && document.getElementById('compose-panel')) {
     closeComposeSlideover();
+  }
+});
+
+// ── Bind Order slideover ─────────────────────────────────────────────────
+function openBindOrderSlideover(subjects) {
+  if (!subjects) return;
+  // Hide Working Notes so it doesn't overlap slideover action bar
+  var wn = document.getElementById('working-notes-float');
+  if (wn) wn.style.display = 'none';
+
+  htmx.ajax('GET', '/bind-order/panel?subjects=' + encodeURIComponent(subjects), {
+    target: '#bind-order-slideover-body',
+    swap: 'innerHTML'
+  }).then(function() {
+    document.body.style.overflow = 'hidden';
+  });
+}
+
+function closeBindOrderSlideover() {
+  var backdrop = document.getElementById('bind-order-backdrop');
+  var panel = document.getElementById('bind-order-panel');
+  if (backdrop) backdrop.remove();
+  if (panel) panel.remove();
+  document.body.style.overflow = '';
+  var wn = document.getElementById('working-notes-float');
+  if (wn) wn.style.display = '';
+}
+
+document.addEventListener('keydown', function(e) {
+  if (e.key === 'Escape' && document.getElementById('bind-order-panel')) {
+    closeBindOrderSlideover();
   }
 });
 </script>

--- a/src/policydb/web/templates/bind_order/_launch_button.html
+++ b/src/policydb/web/templates/bind_order/_launch_button.html
@@ -1,0 +1,10 @@
+{# Bind Order launch button — shared partial.
+   Expects: `subjects` (string, e.g., "program:PGM-042" or "policy:POL-017"),
+            optional `label` (default "Bind Order"),
+            optional `cls` (CSS classes for the button).
+#}
+{% set _label = label or 'Bind Order' %}
+{% set _cls = cls or 'bg-marsh hover:bg-marsh/90 text-white text-xs font-medium px-3 py-1.5 rounded-lg transition-colors' %}
+<button type="button"
+        onclick="openBindOrderSlideover('{{ subjects }}')"
+        class="{{ _cls }}">{{ _label }}</button>

--- a/src/policydb/web/templates/bind_order/_panel.html
+++ b/src/policydb/web/templates/bind_order/_panel.html
@@ -1,0 +1,299 @@
+{# Bind Order — slideover panel.
+   Renders one section per subject (program or standalone policy) with checkable
+   children, per-subject term dates, optional disposition for unchecked children.
+   Submitted as JSON to POST /bind-order/submit via window.submitBindOrder().
+
+   Expects:
+     panel: BindPanelData (bind_date, sections[], errors[])
+       sections[]: SubjectPanelSection
+         children[]: ChildPanelRow (state: needs_renew | ready_to_bind | already_bound)
+#}
+
+{# Backdrop #}
+<div id="bind-order-backdrop"
+     class="fixed inset-0 bg-black/30 z-40"
+     onclick="closeBindOrderSlideover()"></div>
+
+{# Panel — wider than compose to accommodate child tables #}
+<div id="bind-order-panel"
+     class="fixed top-0 right-0 bottom-0 w-[640px] max-sm:w-full bg-white shadow-xl z-50 flex flex-col">
+
+  <div class="flex items-center justify-between p-4 border-b shrink-0">
+    <div>
+      <h2 class="text-base font-semibold text-gray-900">Bind Order</h2>
+      <p class="text-xs text-gray-500 mt-0.5">Renew + bind in one action — review children, set new term dates, capture the bind note.</p>
+    </div>
+    <button onclick="closeBindOrderSlideover()"
+            class="text-gray-400 hover:text-gray-600 transition-colors"
+            aria-label="Close panel">
+      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+      </svg>
+    </button>
+  </div>
+
+  {% if panel.errors %}
+    <div class="border-b border-amber-100 bg-amber-50 px-4 py-2">
+      {% for err in panel.errors %}
+      <div class="text-xs text-amber-800">{{ err }}</div>
+      {% endfor %}
+    </div>
+  {% endif %}
+
+  <div class="flex-1 overflow-y-auto p-4 space-y-5" id="bind-order-body">
+
+    {# ── Top-level shared fields ── #}
+    <div class="grid grid-cols-2 gap-3">
+      <div>
+        <label class="text-[11px] font-medium text-gray-500 uppercase tracking-wide block mb-1">Bind Date</label>
+        <input type="date" id="bo-bind-date"
+               value="{{ panel.bind_date }}"
+               class="w-full text-sm border border-gray-200 rounded-lg px-3 py-2 focus:outline-none focus:border-marsh">
+      </div>
+      <div>
+        <label class="text-[11px] font-medium text-gray-500 uppercase tracking-wide block mb-1">Subjects</label>
+        <div class="text-sm text-gray-700 py-2">{{ panel.sections|length }} {{ 'item' if panel.sections|length == 1 else 'items' }}</div>
+      </div>
+    </div>
+
+    <div>
+      <label class="text-[11px] font-medium text-gray-500 uppercase tracking-wide block mb-1">Bind Note (optional)</label>
+      <textarea id="bo-bind-note" rows="2"
+                placeholder="e.g., Per Sarah Jones email 2026-04-10 — bind all lines"
+                class="w-full text-sm border border-gray-200 rounded-lg px-3 py-2 focus:outline-none focus:border-marsh resize-none"></textarea>
+    </div>
+
+    {# ── Subject sections ── #}
+    {% for section in panel.sections %}
+    <div class="border border-gray-200 rounded-lg overflow-hidden bo-section"
+         data-subject-type="{{ section.subject_type }}"
+         data-subject-uid="{{ section.subject_uid }}">
+
+      <div class="bg-gray-50 px-3 py-2 border-b border-gray-200 flex items-baseline justify-between">
+        <div>
+          <span class="text-[10px] uppercase tracking-wide text-gray-400 font-medium">
+            {{ section.subject_type }}
+          </span>
+          <span class="text-sm font-semibold text-gray-900 ml-2">{{ section.display_name }}</span>
+          <span class="text-xs text-gray-400 ml-2">{{ section.subject_uid }}</span>
+        </div>
+        <div class="text-xs text-gray-500">
+          {{ section.children|length }} {{ 'policy' if section.children|length == 1 else 'policies' }}
+        </div>
+      </div>
+
+      <div class="px-3 py-2 grid grid-cols-2 gap-3 border-b border-gray-100 bg-white">
+        <div>
+          <label class="text-[10px] font-medium text-gray-500 uppercase tracking-wide block mb-1">New Effective</label>
+          <input type="date" class="bo-eff w-full text-xs border border-gray-200 rounded px-2 py-1 focus:outline-none focus:border-marsh"
+                 value="{{ section.new_effective }}">
+        </div>
+        <div>
+          <label class="text-[10px] font-medium text-gray-500 uppercase tracking-wide block mb-1">New Expiration</label>
+          <input type="date" class="bo-exp w-full text-xs border border-gray-200 rounded px-2 py-1 focus:outline-none focus:border-marsh"
+                 value="{{ section.new_expiration }}">
+        </div>
+      </div>
+
+      <table class="w-full text-xs">
+        <thead class="bg-gray-50/50 border-b border-gray-100">
+          <tr class="text-left text-gray-500">
+            <th class="py-1.5 pl-3 pr-2 w-8"></th>
+            <th class="py-1.5 pr-2">Policy</th>
+            <th class="py-1.5 pr-2">LOB</th>
+            <th class="py-1.5 pr-2">Carrier</th>
+            <th class="py-1.5 pr-2 text-right">Premium</th>
+            <th class="py-1.5 pr-3">State</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-50">
+          {% for child in section.children %}
+          {% set is_locked = (child.state == 'already_bound') %}
+          <tr class="bo-child-row hover:bg-gray-50/30 {{ 'opacity-60' if is_locked else '' }}"
+              data-policy-uid="{{ child.policy_uid }}"
+              data-state="{{ child.state }}">
+            <td class="py-1.5 pl-3 pr-2">
+              <input type="checkbox" class="bo-check rounded border-gray-300 text-marsh focus:ring-marsh"
+                     {{ 'checked' if not is_locked else '' }}
+                     {{ 'disabled' if is_locked else '' }}
+                     onchange="onBindChildToggle(this)">
+            </td>
+            <td class="py-1.5 pr-2">
+              <span class="font-medium text-gray-700">{{ child.policy_uid }}</span>
+            </td>
+            <td class="py-1.5 pr-2 text-gray-600">{{ child.policy_type or '—' }}</td>
+            <td class="py-1.5 pr-2 text-gray-600">{{ child.carrier or '—' }}</td>
+            <td class="py-1.5 pr-2 text-right">
+              <input type="text" class="bo-premium w-24 text-xs text-right border border-transparent hover:border-gray-200 focus:border-marsh focus:outline-none rounded px-1 py-0.5"
+                     value="{{ '${:,.0f}'.format(child.premium) if child.premium else '' }}"
+                     placeholder="—"
+                     {{ 'disabled' if is_locked else '' }}>
+            </td>
+            <td class="py-1.5 pr-3">
+              {% if child.state == 'needs_renew' %}
+                <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-50 text-amber-700 border border-amber-100">needs renew</span>
+              {% elif child.state == 'ready_to_bind' %}
+                <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-50 text-blue-700 border border-blue-100">ready to bind</span>
+              {% else %}
+                <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-gray-100 text-gray-500 border border-gray-200">already bound</span>
+              {% endif %}
+            </td>
+          </tr>
+          {# Disposition row appears when checkbox is unchecked #}
+          <tr class="bo-dispo-row hidden bg-amber-50/30">
+            <td></td>
+            <td colspan="5" class="py-1.5 pr-3">
+              <div class="flex items-center gap-2">
+                <span class="text-[11px] text-gray-500">Disposition:</span>
+                <select class="bo-dispo text-xs border border-gray-200 rounded px-2 py-1 focus:outline-none focus:border-marsh">
+                  <option value="">— pick one —</option>
+                  <option value="Declined">Declined</option>
+                  <option value="Lost">Lost</option>
+                  <option value="Non-Renewed">Non-Renewed</option>
+                  <option value="Defer">Defer (keep working)</option>
+                </select>
+              </div>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% endfor %}
+
+  </div>
+
+  {# ── Action bar ── #}
+  <div class="border-t border-gray-200 px-4 py-3 flex items-center justify-between shrink-0 bg-white">
+    <button onclick="closeBindOrderSlideover()"
+            class="text-sm text-gray-500 hover:text-gray-700 px-3 py-1.5 rounded">
+      Cancel
+    </button>
+    <button id="bo-confirm-btn" onclick="submitBindOrder()"
+            class="bg-marsh hover:bg-marsh/90 text-white text-sm font-medium px-4 py-1.5 rounded-lg transition-colors">
+      Confirm Bind
+    </button>
+  </div>
+</div>
+
+<script>
+(function() {
+  // Toggle the disposition row when a child checkbox changes
+  window.onBindChildToggle = function(cb) {
+    var row = cb.closest('tr.bo-child-row');
+    var dispoRow = row.nextElementSibling;
+    if (!dispoRow || !dispoRow.classList.contains('bo-dispo-row')) return;
+    if (cb.checked) {
+      dispoRow.classList.add('hidden');
+    } else {
+      dispoRow.classList.remove('hidden');
+    }
+    updateBindConfirmBtn();
+  };
+
+  function updateBindConfirmBtn() {
+    var btn = document.getElementById('bo-confirm-btn');
+    if (!btn) return;
+    // Confirm enabled if at least one child is checked OR every unchecked has a disposition
+    var anyChecked = false;
+    var allUncheckedHaveDispo = true;
+    document.querySelectorAll('.bo-child-row').forEach(function(row) {
+      var cb = row.querySelector('.bo-check');
+      if (!cb || cb.disabled) return;
+      if (cb.checked) {
+        anyChecked = true;
+      } else {
+        var dispo = row.nextElementSibling && row.nextElementSibling.querySelector('.bo-dispo');
+        if (!dispo || !dispo.value) {
+          allUncheckedHaveDispo = false;
+        }
+      }
+    });
+    btn.disabled = !(anyChecked || allUncheckedHaveDispo);
+    btn.classList.toggle('opacity-50', btn.disabled);
+    btn.classList.toggle('cursor-not-allowed', btn.disabled);
+  }
+
+  // Hook disposition selects
+  document.querySelectorAll('.bo-dispo').forEach(function(sel) {
+    sel.addEventListener('change', updateBindConfirmBtn);
+  });
+
+  function parseCurrency(s) {
+    if (!s) return null;
+    var cleaned = String(s).replace(/[\$,\s]/g, '');
+    if (!cleaned) return null;
+    var n = parseFloat(cleaned);
+    return isNaN(n) ? null : n;
+  }
+
+  window.submitBindOrder = function() {
+    var btn = document.getElementById('bo-confirm-btn');
+    if (btn) { btn.disabled = true; btn.textContent = 'Binding…'; }
+
+    var bindDate = document.getElementById('bo-bind-date').value;
+    var bindNote = document.getElementById('bo-bind-note').value;
+
+    var subjects = [];
+    document.querySelectorAll('.bo-section').forEach(function(section) {
+      var subjectType = section.dataset.subjectType;
+      var subjectUid = section.dataset.subjectUid;
+      var newEff = section.querySelector('.bo-eff').value;
+      var newExp = section.querySelector('.bo-exp').value;
+      var children = [];
+      section.querySelectorAll('.bo-child-row').forEach(function(row) {
+        var cb = row.querySelector('.bo-check');
+        if (!cb) return;
+        var checked = cb.checked && !cb.disabled;
+        var dispoSel = row.nextElementSibling && row.nextElementSibling.querySelector('.bo-dispo');
+        var dispo = dispoSel ? dispoSel.value : null;
+        var premInput = row.querySelector('.bo-premium');
+        var premVal = premInput ? parseCurrency(premInput.value) : null;
+        // Skip already-bound rows entirely (no payload — they're informational)
+        if (cb.disabled) return;
+        children.push({
+          policy_uid: row.dataset.policyUid,
+          checked: checked,
+          disposition: checked ? 'Bound' : (dispo || 'Defer'),
+          new_premium: checked ? premVal : null,
+        });
+      });
+      subjects.push({
+        subject_type: subjectType,
+        subject_uid: subjectUid,
+        new_effective: newEff,
+        new_expiration: newExp,
+        children: children,
+      });
+    });
+
+    fetch('/bind-order/submit', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({
+        bind_date: bindDate,
+        bind_note: bindNote,
+        subjects: subjects,
+      }),
+    }).then(function(r) {
+      return r.json().then(function(data) { return {ok: r.ok, status: r.status, data: data}; });
+    }).then(function(res) {
+      if (res.ok && res.data.ok) {
+        if (typeof showToast === 'function') showToast(res.data.toast_message || 'Bind order complete', true);
+        closeBindOrderSlideover();
+        // Soft refresh: reload after a short delay to surface new state
+        setTimeout(function() { window.location.reload(); }, 600);
+      } else {
+        var msg = (res.data && (res.data.detail || res.data.error)) || ('HTTP ' + res.status);
+        if (typeof showToast === 'function') showToast('Bind failed: ' + msg, false);
+        if (btn) { btn.disabled = false; btn.textContent = 'Confirm Bind'; }
+      }
+    }).catch(function(err) {
+      if (typeof showToast === 'function') showToast('Network error: ' + err, false);
+      if (btn) { btn.disabled = false; btn.textContent = 'Confirm Bind'; }
+    });
+  };
+
+  updateBindConfirmBtn();
+})();
+</script>

--- a/src/policydb/web/templates/issues/detail.html
+++ b/src/policydb/web/templates/issues/detail.html
@@ -49,12 +49,27 @@
   {% endif %}
 
   {# ── Title (click-to-edit) ── #}
-  <h1 class="text-xl font-semibold text-gray-900 mb-1 cursor-pointer hover:bg-gray-50 rounded px-1 -mx-1 transition-colors"
-      contenteditable="true"
-      spellcheck="false"
-      data-original="{{ issue.subject }}"
-      onblur="saveIssueSubject(this)"
-      onkeydown="if(event.key==='Enter'){event.preventDefault();this.blur();}">{{ issue.subject }}</h1>
+  <div class="flex items-start justify-between gap-3 mb-1">
+    <h1 class="text-xl font-semibold text-gray-900 cursor-pointer hover:bg-gray-50 rounded px-1 -mx-1 transition-colors flex-1"
+        contenteditable="true"
+        spellcheck="false"
+        data-original="{{ issue.subject }}"
+        onblur="saveIssueSubject(this)"
+        onkeydown="if(event.key==='Enter'){event.preventDefault();this.blur();}">{{ issue.subject }}</h1>
+    {% if issue.is_renewal_issue and issue.renewal_term_key %}
+      {% set _rtk = issue.renewal_term_key %}
+      {% if _rtk.startswith('program:') %}
+        {% set _bind_subjects = _rtk %}
+      {% else %}
+        {% set _bind_subjects = 'policy:' + _rtk %}
+      {% endif %}
+      <button type="button"
+        onclick="openBindOrderSlideover('{{ _bind_subjects }}')"
+        class="shrink-0 px-3 py-1.5 text-xs font-medium rounded-lg bg-marsh hover:bg-marsh/90 text-white transition-colors">
+        Bind Order
+      </button>
+    {% endif %}
+  </div>
 
   {# ── Metadata row ── #}
   {% set days = (issue.days_open or 0)|int %}

--- a/src/policydb/web/templates/policies/_policy_renew_row.html
+++ b/src/policydb/web/templates/policies/_policy_renew_row.html
@@ -134,6 +134,9 @@
   {# Actions #}
   <td class="px-2 py-1.5 whitespace-nowrap">
     <div class="flex items-center gap-2">
+      <button type="button"
+        onclick="openBindOrderSlideover('policy:{{ p.policy_uid }}')"
+        class="text-marsh hover:underline font-medium">Bind</button>
       <button
         hx-get="/policies/{{ p.policy_uid }}/renew/log"
         hx-target="#renew-row-{{ p.policy_uid }}"

--- a/src/policydb/web/templates/policies/_program_renew_row.html
+++ b/src/policydb/web/templates/policies/_program_renew_row.html
@@ -1,6 +1,10 @@
 {# Program row for the renewal pipeline — rendered when p._is_program is True #}
 <tr id="pgm-row-{{ p.program_uid }}" class="hover:bg-indigo-50/30 border-l-2 border-indigo-400 bg-indigo-50/10 text-xs">
-  <td class="px-2 py-1.5 w-8"></td>
+  <td class="px-2 py-1.5 w-8">
+    <input type="checkbox" class="renewal-check rounded border-gray-300"
+      value="{{ p.program_uid }}" data-subject-type="program"
+      onchange="updateRenewalBulkBar()">
+  </td>
   <td class="px-2 py-1.5">
     <a href="/clients/{{ p.client_id }}" class="font-medium text-marsh hover:underline">{{ p.client_name }}</a>
     <div class="flex items-center gap-1 mt-0.5">
@@ -88,6 +92,9 @@
   </td>
   <td class="px-2 py-1.5 whitespace-nowrap">
     <div class="flex items-center gap-2">
+      <button type="button"
+        onclick="openBindOrderSlideover('program:{{ p.program_uid }}')"
+        class="text-marsh hover:underline font-medium">Bind</button>
       <button
         hx-get="/programs/{{ p.program_uid }}/renew/log"
         hx-target="#pgm-row-{{ p.program_uid }}"

--- a/src/policydb/web/templates/policies/edit.html
+++ b/src/policydb/web/templates/policies/edit.html
@@ -28,6 +28,12 @@
               class="px-3 py-1.5 text-xs font-medium rounded-lg border border-indigo-300 text-indigo-600 hover:bg-indigo-50 transition-colors">
         Import from AI
       </button>
+      {# Bind Order — single-policy launcher. For program-wide bind, use the program detail page. #}
+      <button type="button"
+        onclick="openBindOrderSlideover('policy:{{ policy.policy_uid }}')"
+        class="px-3 py-1.5 text-xs font-medium rounded-lg bg-marsh hover:bg-marsh/90 text-white transition-colors">
+        Bind Order
+      </button>
       {# ── More Actions kebab ── #}
       <div class="relative" id="more-actions-wrapper">
         <button type="button" id="more-actions-btn"

--- a/src/policydb/web/templates/programs/_tab_overview.html
+++ b/src/policydb/web/templates/programs/_tab_overview.html
@@ -39,9 +39,9 @@
     <div class="flex items-center gap-3">
       <span class="text-xs text-gray-400">{{ children | length }} assigned</span>
       {% if children %}
-      <button type="button" id="renew-program-btn"
+      <button type="button" id="bind-order-program-btn"
         class="no-print text-xs font-medium text-white bg-marsh px-3 py-1 rounded hover:bg-marsh/90 transition-colors"
-        onclick="renewProgram(this)">Renew Program</button>
+        onclick="openBindOrderSlideover('program:{{ program.program_uid }}')">Bind Order</button>
       {% endif %}
     </div>
   </div>

--- a/src/policydb/web/templates/renewals.html
+++ b/src/policydb/web/templates/renewals.html
@@ -171,6 +171,8 @@
       {% endfor %}
     </select>
     <button onclick="bulkSetStatus()" class="bg-marsh hover:bg-marsh-light text-white text-sm px-3 py-1.5 rounded transition-colors">Apply</button>
+    <span class="border-l border-gray-200 h-6 mx-1"></span>
+    <button onclick="bulkBindOrder()" class="bg-marsh hover:bg-marsh-light text-white text-sm px-3 py-1.5 rounded transition-colors">Bind Selected</button>
     <button onclick="clearRenewalChecks()" class="text-sm text-gray-400 hover:text-gray-600 ml-auto">Clear</button>
   </div>
 </div>
@@ -302,6 +304,21 @@ function bulkSetFollowUp() {
     document.getElementById('bulk-followup-date').value = '';
     clearRenewalChecks();
   });
+}
+
+function bulkBindOrder() {
+  // Collect checked rows + their subject type (program vs policy) into the
+  // bind-order panel `subjects` query param.
+  var tokens = [];
+  document.querySelectorAll('.renewal-check:checked').forEach(function(cb) {
+    var subjectType = cb.dataset.subjectType || 'policy';
+    tokens.push(subjectType + ':' + cb.value);
+  });
+  if (!tokens.length) {
+    showToast('Select at least one row to bind.', false);
+    return;
+  }
+  openBindOrderSlideover(tokens.join(','));
 }
 </script>
 

--- a/src/policydb/web/templates/settings/_post_bind_activities_editor.html
+++ b/src/policydb/web/templates/settings/_post_bind_activities_editor.html
@@ -1,0 +1,92 @@
+{# Post-Bind Activities — inline table editor with PATCH-on-blur saves #}
+<details class="card mb-6 overflow-hidden">
+  <summary class="px-5 py-3 cursor-pointer select-none list-none flex items-center gap-2 hover:bg-gray-50 transition-colors">
+    <span class="text-xs text-gray-400 details-arrow">&#9654;</span>
+    <h2 class="font-semibold text-gray-900 text-sm">Post-Bind Stewardship Activities</h2>
+    <span class="text-xs text-gray-400 ml-1">-- auto-created follow-ups when a Bind Order is submitted</span>
+  </summary>
+  <div class="px-5 pb-5">
+    <p class="text-xs text-gray-400 mb-4 pt-3">Follow-ups generated once per subject (program or standalone policy) when a Bind Order is submitted. Anchored on bind date. Edits save on blur.</p>
+
+    <div class="overflow-x-auto">
+      <table class="w-full text-xs">
+        <thead>
+          <tr class="border-b border-gray-200 text-left">
+            <th class="py-2 pr-2 text-gray-500 font-medium">Name</th>
+            <th class="py-2 pr-2 text-gray-500 font-medium w-24">Days After Bind</th>
+            <th class="py-2 pr-2 text-gray-500 font-medium">Activity Type</th>
+            <th class="py-2 pr-2 text-gray-500 font-medium">Subject</th>
+            <th class="py-2 w-8"></th>
+          </tr>
+        </thead>
+        <tbody id="pba-editor-body" hx-on::after-settle="initPbaCells()">
+          {% include "settings/_post_bind_activities_rows.html" %}
+        </tbody>
+      </table>
+    </div>
+
+    <div class="mt-3 pt-3 border-t border-gray-100">
+      <form hx-post="/settings/post-bind-activities/add" hx-target="#pba-editor-body" hx-swap="innerHTML"
+            hx-on::after-swap="this.reset()"
+            class="flex items-end gap-2 flex-wrap">
+        <div>
+          <label class="text-[10px] text-gray-500 block">Name</label>
+          <input type="text" name="name" required placeholder="Binder received from carrier"
+            class="border border-gray-200 rounded px-2 py-1 text-xs w-56 focus:outline-none focus:ring-1 focus:ring-marsh">
+        </div>
+        <div>
+          <label class="text-[10px] text-gray-500 block">Days After Bind</label>
+          <input type="number" name="days_after_bind" required value="7" min="0" max="365"
+            class="border border-gray-200 rounded px-2 py-1 text-xs w-20 focus:outline-none focus:ring-1 focus:ring-marsh">
+        </div>
+        <div>
+          <label class="text-[10px] text-gray-500 block">Activity Type</label>
+          <select name="activity_type" class="border border-gray-200 rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-marsh">
+            <option value="Follow-up" selected>Follow-up</option>
+            {% for at in activity_types %}
+            <option value="{{ at }}">{{ at }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div>
+          <label class="text-[10px] text-gray-500 block">Subject</label>
+          <input type="text" name="subject" placeholder="Auto: name"
+            class="border border-gray-200 rounded px-2 py-1 text-xs w-56 focus:outline-none focus:ring-1 focus:ring-marsh">
+        </div>
+        <button type="submit" class="text-xs text-marsh hover:underline font-medium py-1">+ Add</button>
+      </form>
+    </div>
+  </div>
+</details>
+
+<script>
+function savePbaField(el, idx, field, value) {
+  var body = new URLSearchParams();
+  body.append(field, value);
+  fetch('/settings/post-bind-activities/' + idx, {
+    method: 'PATCH',
+    body: body
+  }).then(function(r) { if (r.ok && typeof flashCell === 'function') flashCell(el); });
+}
+
+function initPbaCells() {
+  document.querySelectorAll('.pba-cell').forEach(function(cell) {
+    if (cell._pbaInit) return;
+    cell._pbaInit = true;
+    cell.addEventListener('blur', function() {
+      var idx = this.dataset.idx;
+      var field = this.dataset.field;
+      var val = this.textContent.trim();
+      if (val === this.dataset.original) return;
+      this.dataset.original = val;
+      savePbaField(this, idx, field, val);
+    });
+    cell.addEventListener('keydown', function(e) {
+      if (e.key === 'Enter') { e.preventDefault(); this.blur(); }
+      if (e.key === 'Escape') { this.textContent = this.dataset.original || ''; this.blur(); }
+    });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', initPbaCells);
+</script>

--- a/src/policydb/web/templates/settings/_post_bind_activities_rows.html
+++ b/src/policydb/web/templates/settings/_post_bind_activities_rows.html
@@ -1,0 +1,40 @@
+{# Post-Bind Activities — table rows partial (used by editor + HTMX add/remove responses) #}
+{% for r in post_bind_activities %}
+<tr class="border-b border-gray-50 hover:bg-gray-50/50 group" data-pba-idx="{{ loop.index0 }}">
+  <td class="py-1.5 pr-2">
+    <span class="text-gray-800 font-medium cursor-text pba-cell" contenteditable="true"
+      data-field="name" data-idx="{{ loop.index0 }}"
+      data-original="{{ r.name }}">{{ r.name }}</span>
+  </td>
+  <td class="py-1.5 pr-2">
+    <span class="text-gray-700 cursor-text pba-cell" contenteditable="true"
+      data-field="days_after_bind" data-idx="{{ loop.index0 }}"
+      data-original="{{ r.days_after_bind }}">{{ r.days_after_bind }}</span>
+  </td>
+  <td class="py-1.5 pr-2">
+    <select class="text-xs border border-gray-200 rounded px-1 py-0.5 focus:outline-none focus:ring-1 focus:ring-marsh bg-transparent"
+      data-field="activity_type" data-idx="{{ loop.index0 }}"
+      onchange="savePbaField(this, '{{ loop.index0 }}', 'activity_type', this.value)">
+      <option value="Follow-up" {{ 'selected' if r.get('activity_type') == 'Follow-up' }}>Follow-up</option>
+      {% for at in activity_types %}
+      <option value="{{ at }}" {{ 'selected' if r.get('activity_type') == at }}>{{ at }}</option>
+      {% endfor %}
+    </select>
+  </td>
+  <td class="py-1.5 pr-2">
+    <span class="text-gray-600 cursor-text pba-cell truncate max-w-[260px] inline-block" contenteditable="true"
+      data-field="subject" data-idx="{{ loop.index0 }}"
+      data-original="{{ r.get('subject', '') }}"
+      data-placeholder="Auto-generated">{{ r.get('subject', '') }}</span>
+  </td>
+  <td class="py-1.5">
+    <form hx-post="/settings/post-bind-activities/remove" hx-target="#pba-editor-body" hx-swap="innerHTML"
+      class="inline opacity-0 group-hover:opacity-100 transition-opacity">
+      <input type="hidden" name="name" value="{{ r.name }}">
+      <button type="submit" class="text-red-400 hover:text-red-600">&times;</button>
+    </form>
+  </td>
+</tr>
+{% else %}
+<tr><td colspan="5" class="py-4 text-gray-400 text-center">No post-bind activities configured.</td></tr>
+{% endfor %}

--- a/src/policydb/web/templates/settings/_tab_workflow.html
+++ b/src/policydb/web/templates/settings/_tab_workflow.html
@@ -2,6 +2,9 @@
   <div id="section-mandated-activities">
     {% include 'settings/_mandated_activities_editor.html' %}
   </div>
+  <div id="section-post-bind-activities">
+    {% include 'settings/_post_bind_activities_editor.html' %}
+  </div>
   <div id="section-milestone-profiles">
     {% include 'settings/_milestone_profiles_editor.html' %}
   </div>


### PR DESCRIPTION
## Summary
- Single Bind Order slideover that captures the bind event once, smart-detects per-child renew vs. just-bind, and cascades status + dates + activities + follow-ups + issue resolution in one transaction
- Replaces today's three-step dance (Renew Program → individually mark each child Bound → fight the silent-bound bug) with one panel from program detail, renewals pipeline rows, bulk select, policy edit, or renewal issue detail
- Auto-generates configurable post-bind stewardship follow-ups (binder received, binder sent to client, invoice issued, final policy doc) once per subject

## What's in the box
- **Migration 142** adds `bind_events` + `bind_event_children` audit tables
- **`bind_order.py`** module — `resolve_child_state`, `preview_bind_panel`, `execute_bind_order`, `_handle_bound_transition`, `_generate_post_bind_followups` (single SQL transaction, rolls back on failure)
- **`/bind-order/panel`** + **`/bind-order/submit`** routes
- **Slideover panel** with per-subject term dates, per-child checkboxes, inline disposition (Declined/Lost/Non-Renewed/Defer) for unchecked rows, optional premium override, bind note
- **Multi-subject support** — the renewals pipeline "Bind Selected" button collects checked program + standalone-policy rows into one panel
- **`renew_policy()`** extended with `new_effective` / `new_expiration` / `new_premium` kwargs (backward compatible)
- **Cell-edit silent-bound fix** — `policy_cell_save` Bound branch now funnels through `_handle_bound_transition` with a `needs_renew` 400 guard
- **`policy_bound_confirm`** + **`program_bound_confirm`** refactored to delegate to the same shared helpers (banner paths and panel paths share one code path)
- **`post_bind_activities`** config list with a Settings UI editor mirroring `mandated_activities`

## Test plan
- [x] Migration 142 applies cleanly to live DB and creates `bind_events` + `bind_event_children`
- [x] **Test 1**: Program with 3 bound + 1 declined children → bind_events row, bind_event_children rows, program rolled up to Bound, exactly 4 post-bind follow-ups generated
- [x] **Test 2**: needs_renew path → `renew_policy()` called inline with effective/expiration/premium overrides, old row archived, new row re-linked to program with tower mappings copied, new row marked Bound
- [x] **Test 3**: Standalone policy bind path produces policy-scoped (not program-scoped) follow-ups; cell-edit fast path produces correct state via `_handle_bound_transition` + `_generate_post_bind_followups`
- [ ] Live UI QA in browser — restart dev server, walk through all entry points (program detail, renewals pipeline row, Bind Selected bulk, policy edit header, issue detail)
- [ ] Confirm Settings UI editor for `post_bind_activities` renders + add/remove/PATCH all save correctly
- [ ] Confirm cell-edit Bound on an expired policy returns the 400 with friendly message and forces user through the panel
- [ ] Confirm the slideover Cancel button closes cleanly and the bulk Bind Selected gathers both program and policy tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)