### PR TITLE
Bug sweep + Location/Project page redesign

### DIFF
--- a/src/policydb/db.py
+++ b/src/policydb/db.py
@@ -1877,6 +1877,15 @@ def _init_db_inner(conn: sqlite3.Connection, db_path: Path) -> None:
         conn.commit()
         logger.info("Migration 142: added bind_events and bind_event_children tables")
 
+    if 143 not in applied:
+        conn.executescript((_MIGRATIONS_DIR / "143_project_scratchpad.sql").read_text())
+        conn.execute(
+            "INSERT INTO schema_version (version, description) VALUES (?, ?)",
+            (143, "Add project_scratchpad table for per-project working notes"),
+        )
+        conn.commit()
+        logger.info("Migration 143: added project_scratchpad table")
+
     # Data hygiene: fix 'None' string corruption in text fields (runs every startup, fast no-op if clean)
     conn.execute("UPDATE clients SET cn_number = NULL WHERE cn_number = 'None'")
 

--- a/src/policydb/migrations/143_project_scratchpad.sql
+++ b/src/policydb/migrations/143_project_scratchpad.sql
@@ -1,0 +1,15 @@
+-- Per-project/location working notes (scratchpad) with auto-save support.
+-- Mirrors the client_scratchpad (migration 014) and policy_scratchpad (040) pattern.
+
+CREATE TABLE IF NOT EXISTS project_scratchpad (
+    project_id INTEGER PRIMARY KEY REFERENCES projects(id) ON DELETE CASCADE,
+    content    TEXT NOT NULL DEFAULT '',
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TRIGGER IF NOT EXISTS project_scratchpad_updated
+    AFTER UPDATE ON project_scratchpad
+BEGIN
+    UPDATE project_scratchpad SET updated_at = CURRENT_TIMESTAMP
+    WHERE project_id = NEW.project_id;
+END;

--- a/src/policydb/web/routes/clients.py
+++ b/src/policydb/web/routes/clients.py
@@ -3222,12 +3222,34 @@ def client_edit_form(request: Request, client_id: int, conn=Depends(get_db)):
     if not client:
         return HTMLResponse("Client not found", status_code=404)
     from policydb.queries import REVIEW_CYCLE_LABELS as _REVIEW_CYCLE_LABELS
+
+    scratch_row = conn.execute(
+        "SELECT content, updated_at FROM client_scratchpad WHERE client_id=?",
+        (client_id,),
+    ).fetchone()
+    client_scratchpad = scratch_row["content"] if scratch_row else ""
+    client_scratchpad_updated = scratch_row["updated_at"] if scratch_row else ""
+
+    open_issues = [dict(r) for r in conn.execute(
+        """SELECT a.id, a.issue_uid, a.subject
+           FROM activity_log a
+           WHERE a.client_id = ? AND a.item_kind = 'issue' AND a.issue_id IS NULL
+             AND a.merged_into_id IS NULL
+             AND (a.issue_status IS NULL OR a.issue_status NOT IN ('Resolved', 'Closed'))
+           ORDER BY a.activity_date DESC""",
+        (client_id,),
+    ).fetchall()]
+
     return templates.TemplateResponse("clients/edit.html", {
         "request": request,
         "active": "clients",
         "client": dict(client),
         "industry_segments": cfg.get("industry_segments"),
         "cycle_labels": _REVIEW_CYCLE_LABELS,
+        "client_scratchpad": client_scratchpad,
+        "client_scratchpad_updated": client_scratchpad_updated,
+        "activity_types": cfg.get("activity_types"),
+        "open_issues": open_issues,
     })
 
 
@@ -4037,6 +4059,36 @@ def project_notes_autosave(
     return JSONResponse({"ok": True, "saved_at": saved_at})
 
 
+@router.post("/{client_id}/projects/{project_id}/scratchpad")
+def project_scratchpad_autosave(
+    client_id: int,
+    project_id: int,
+    content: str = Form(""),
+    conn=Depends(get_db),
+):
+    """Auto-save the project's working-notes scratchpad (upsert)."""
+    from fastapi import HTTPException
+    row = conn.execute(
+        "SELECT 1 FROM projects WHERE id = ? AND client_id = ?",
+        (project_id, client_id),
+    ).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Project not found")
+    conn.execute(
+        """INSERT INTO project_scratchpad (project_id, content, updated_at)
+           VALUES (?, ?, CURRENT_TIMESTAMP)
+           ON CONFLICT(project_id) DO UPDATE SET
+               content = excluded.content,
+               updated_at = CURRENT_TIMESTAMP""",
+        (project_id, content),
+    )
+    conn.commit()
+    saved_at = babel_format_datetime(
+        datetime.now(), "MMM d 'at' h:mma", locale="en_US"
+    ).replace("AM", "am").replace("PM", "pm")
+    return JSONResponse({"ok": True, "saved_at": saved_at})
+
+
 @router.get("/{client_id}/projects/{project_id}", response_class=HTMLResponse)
 def project_detail(
     client_id: int,
@@ -4096,6 +4148,50 @@ def project_detail(
     from policydb.queries import get_programs_for_project
     location_programs = get_programs_for_project(conn, project_id)
 
+    # Project scratchpad (working notes with activity conversion)
+    scratch_row = conn.execute(
+        "SELECT content, updated_at FROM project_scratchpad WHERE project_id = ?",
+        (project_id,),
+    ).fetchone()
+    project_scratchpad = scratch_row["content"] if scratch_row else ""
+    project_scratchpad_updated = scratch_row["updated_at"] if scratch_row else ""
+
+    # Open issues assigned to this location (direct project_id + linked policies'
+    # issues), deduped by activity_log id, newest first.
+    policy_ids = [p["id"] for p in policies]
+    _placeholders = ",".join("?" * len(policy_ids)) if policy_ids else ""
+    _where_parts = ["(a.project_id = ?)"]
+    _params: list = [project_id]
+    if policy_ids:
+        _where_parts.append(f"(a.policy_id IN ({_placeholders}))")
+        _params.extend(policy_ids)
+    _where = " OR ".join(_where_parts)
+    open_project_issues = [dict(r) for r in conn.execute(
+        f"""SELECT a.id, a.issue_uid, a.subject, a.issue_status, a.issue_severity,
+                   a.activity_date, a.policy_id, a.is_renewal_issue,
+                   p.policy_uid, p.policy_type,
+                   CAST(julianday(date('now')) - julianday(a.activity_date) AS INTEGER) AS days_open
+            FROM activity_log a
+            LEFT JOIN policies p ON p.id = a.policy_id
+            WHERE a.item_kind = 'issue'
+              AND a.client_id = ?
+              AND ({_where})
+              AND a.merged_into_id IS NULL
+              AND (a.issue_status IS NULL OR a.issue_status NOT IN ('Resolved', 'Closed'))
+            ORDER BY CASE a.issue_severity
+                       WHEN 'Critical' THEN 1 WHEN 'High' THEN 2
+                       WHEN 'Normal' THEN 3 ELSE 4 END,
+                     a.activity_date DESC""",  # noqa: S608 — placeholders built from static counts
+        [client_id, *_params],
+    ).fetchall()]
+
+    # Attachment count for the Files card header
+    attachment_count = conn.execute(
+        """SELECT COUNT(DISTINCT ra.attachment_id) FROM record_attachments ra
+           WHERE ra.record_type = 'project' AND ra.record_id = ?""",
+        (project_id,),
+    ).fetchone()[0]
+
     return templates.TemplateResponse(
         "clients/project.html",
         {
@@ -4110,6 +4206,11 @@ def project_detail(
             "pinned_scope": "project",
             "pinned_scope_id": str(project_id),
             "pinned_client_id": str(client_id),
+            "project_scratchpad": project_scratchpad,
+            "project_scratchpad_updated": project_scratchpad_updated,
+            "open_project_issues": open_project_issues,
+            "attachment_count": attachment_count,
+            "activity_types": cfg.get("activity_types", []),
         },
     )
 

--- a/src/policydb/web/routes/inbox.py
+++ b/src/policydb/web/routes/inbox.py
@@ -144,6 +144,12 @@ def scratchpad_clear(source: str = Form(...), source_id: str = Form(""), scope_i
     elif source == "policy":
         uid = sid.split("/")[2] if sid.count("/") >= 2 else sid
         conn.execute("UPDATE policy_scratchpad SET content='', updated_at=CURRENT_TIMESTAMP WHERE policy_uid=?", (uid,))
+    elif source == "project":
+        try:
+            pid = int(sid.split("/")[-1]) if "/" in sid else int(sid)
+        except (ValueError, IndexError):
+            return HTMLResponse("Invalid project ID", status_code=400)
+        conn.execute("UPDATE project_scratchpad SET content='', updated_at=CURRENT_TIMESTAMP WHERE project_id=?", (pid,))
     conn.commit()
     return HTMLResponse("", headers={
         "HX-Trigger": '{"activityLogged": "Scratchpad cleared"}'
@@ -170,6 +176,7 @@ def scratchpad_process(
     sid = scope_id or source_id
     resolved_client_id = client_id
     resolved_policy_uid = None
+    resolved_project_id = 0
     content_for_note = details or ""
 
     if source == "client" and not resolved_client_id:
@@ -190,6 +197,19 @@ def scratchpad_process(
             resolved_client_id = row["client_id"]
         if not content_for_note:
             row2 = conn.execute("SELECT content FROM policy_scratchpad WHERE policy_uid=?", (resolved_policy_uid,)).fetchone()
+            if row2:
+                content_for_note = row2["content"] or ""
+    elif source == "project":
+        try:
+            resolved_project_id = int(sid.split("/")[-1]) if "/" in sid else int(sid)
+        except (ValueError, IndexError):
+            resolved_project_id = 0
+        if resolved_project_id and not resolved_client_id:
+            row = conn.execute("SELECT client_id FROM projects WHERE id=?", (resolved_project_id,)).fetchone()
+            if row:
+                resolved_client_id = row["client_id"]
+        if resolved_project_id and not content_for_note:
+            row2 = conn.execute("SELECT content FROM project_scratchpad WHERE project_id=?", (resolved_project_id,)).fetchone()
             if row2:
                 content_for_note = row2["content"] or ""
     elif source == "dashboard" and not content_for_note:
@@ -217,10 +237,11 @@ def scratchpad_process(
     # 1. Create activity
     cursor = conn.execute(
         """INSERT INTO activity_log
-           (activity_date, client_id, policy_id, activity_type, subject, details,
+           (activity_date, client_id, policy_id, project_id, activity_type, subject, details,
             follow_up_date, account_exec, duration_hours)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-        (date.today().isoformat(), resolved_client_id or None, resolved_policy_id or None, activity_type,
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (date.today().isoformat(), resolved_client_id or None, resolved_policy_id or None,
+         resolved_project_id or None, activity_type,
          subject or "Scratchpad note", content_for_note or None,
          follow_up_date or None, account_exec, dur),
     )
@@ -238,6 +259,8 @@ def scratchpad_process(
     elif source == "policy":
         puid = resolved_policy_uid or (sid.split("/")[2] if "/" in sid else sid)
         conn.execute("UPDATE policy_scratchpad SET content='', updated_at=CURRENT_TIMESTAMP WHERE policy_uid=?", (puid,))
+    elif source == "project" and resolved_project_id:
+        conn.execute("UPDATE project_scratchpad SET content='', updated_at=CURRENT_TIMESTAMP WHERE project_id=?", (resolved_project_id,))
 
     conn.commit()
 

--- a/src/policydb/web/routes/issues.py
+++ b/src/policydb/web/routes/issues.py
@@ -940,6 +940,25 @@ def issue_detail(
     # Linked policies: direct FK + program siblings + junction table
     linked_policies = _get_linked_policies(conn, issue_id, issue)
 
+    # Build bind subjects from linked policies. Group policies that share a
+    # program_uid into a single program: token (so program children render as
+    # one section); emit standalone policies as their own policy: tokens.
+    _bind_tokens: list[str] = []
+    _seen_programs: set[str] = set()
+    _seen_standalone: set[str] = set()
+    for lp in linked_policies:
+        pgm_uid = lp.get("program_uid")
+        if pgm_uid:
+            if pgm_uid not in _seen_programs:
+                _seen_programs.add(pgm_uid)
+                _bind_tokens.append(f"program:{pgm_uid}")
+        else:
+            pol_uid = lp.get("policy_uid")
+            if pol_uid and pol_uid not in _seen_standalone:
+                _seen_standalone.add(pol_uid)
+                _bind_tokens.append(f"policy:{pol_uid}")
+    bind_subjects_csv = ",".join(_bind_tokens)
+
     ctx = {
         "request": request,
         "active": "action-center",
@@ -949,6 +968,7 @@ def issue_detail(
         "merged_from_issues": merged_from_issues,
         "merged_from_flash": merged_from or "",
         "linked_policies": linked_policies,
+        "bind_subjects_csv": bind_subjects_csv,
         "issue_lifecycle_states": cfg.get("issue_lifecycle_states", []),
         "issue_severities": cfg.get("issue_severities", []),
         "issue_resolution_types": cfg.get("issue_resolution_types", []),

--- a/src/policydb/web/templates/base.html
+++ b/src/policydb/web/templates/base.html
@@ -1823,7 +1823,7 @@ function policyStatusPill(btn, uid, status) {
 {# ── Follow-up edit slideover ── #}
 <div id="fu-edit-backdrop" class="fixed inset-0 bg-black/30 z-40 hidden" onclick="closeFollowupEdit()"></div>
 <div id="fu-edit-panel" class="fixed top-0 right-0 bottom-0 w-[480px] max-sm:w-full z-50 hidden flex-col bg-white shadow-xl">
-  <div id="fu-edit-content"></div>
+  <div id="fu-edit-content" class="flex-1 min-h-0 flex flex-col"></div>
 </div>
 <script>
 function openFollowupEdit() {

--- a/src/policydb/web/templates/clients/_project_scratchpad.html
+++ b/src/policydb/web/templates/clients/_project_scratchpad.html
@@ -1,0 +1,124 @@
+<div id="project-scratchpad-{{ project.id }}" class="card p-4">
+  <div class="flex items-center justify-between mb-2">
+    <h2 class="font-semibold text-gray-900 text-sm flex items-center gap-2">
+      <svg class="w-4 h-4 text-marsh" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
+      </svg>
+      Working Notes
+    </h2>
+    <span id="proj-scratch-ts-{{ project.id }}" class="text-xs text-gray-400 italic">
+      {% if project_scratchpad_updated %}saved {{ project_scratchpad_updated[:16] }}{% endif %}
+    </span>
+  </div>
+  <textarea
+    id="proj-scratch-ta-{{ project.id }}"
+    name="content"
+    rows="4"
+    placeholder="Working notes about this location — type here, then log as an activity when ready…"
+    class="w-full text-sm text-gray-800 bg-transparent resize-none focus:outline-none placeholder-gray-300 leading-relaxed">{{ project_scratchpad }}</textarea>
+  <div class="flex justify-end gap-1 mt-1">
+    <button type="button" id="proj-scratch-log-{{ project.id }}"
+      onclick="logProjectScratch('{{ project.id }}')"
+      {% if not project_scratchpad or not project_scratchpad.strip() %}disabled{% endif %}
+      class="text-xs bg-marsh text-white px-3 py-1 rounded hover:bg-marsh-light disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
+      Log as Activity
+    </button>
+    <button type="button" id="proj-scratch-clear-{{ project.id }}"
+      onclick="clearProjectScratch('{{ project.id }}')"
+      {% if not project_scratchpad or not project_scratchpad.strip() %}disabled{% endif %}
+      class="text-xs text-gray-400 border border-gray-200 px-3 py-1 rounded hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
+      Clear
+    </button>
+  </div>
+</div>
+
+<script>
+(function() {
+  var PID = "{{ project.id }}";
+  var CID = "{{ client.id }}";
+  var ta = document.getElementById('proj-scratch-ta-' + PID);
+  var ts = document.getElementById('proj-scratch-ts-' + PID);
+  var logBtn = document.getElementById('proj-scratch-log-' + PID);
+  var clearBtn = document.getElementById('proj-scratch-clear-' + PID);
+  if (!ta) return;
+
+  function updateBtns() {
+    var hasContent = (ta.value || '').trim().length > 0;
+    if (logBtn) logBtn.disabled = !hasContent;
+    if (clearBtn) clearBtn.disabled = !hasContent;
+  }
+
+  var saveTimer = null;
+  var saving = false;
+  function autoSave() {
+    if (saving) return;
+    saving = true;
+    var fd = new FormData();
+    fd.set('content', ta.value);
+    fetch('/clients/' + CID + '/projects/' + PID + '/scratchpad', {
+      method: 'POST', body: fd,
+      headers: {'Accept': 'application/json'}
+    }).then(function(r) { return r.json(); }).then(function(data) {
+      if (data.ok && ts) ts.textContent = 'saved ' + data.saved_at;
+    }).catch(function() {}).finally(function() { saving = false; });
+  }
+
+  ta.addEventListener('input', function() {
+    updateBtns();
+    clearTimeout(saveTimer);
+    saveTimer = setTimeout(autoSave, 800);
+  });
+
+  window.logProjectScratch = function(projectId) {
+    var el = document.getElementById('proj-scratch-ta-' + projectId);
+    if (!el || !el.value.trim()) return;
+    var fd = new FormData();
+    fd.set('source', 'project');
+    fd.set('scope_id', projectId);
+    fd.set('activity_type', 'Note');
+    fd.set('subject', 'Working note');
+    fd.set('details', el.value.trim());
+    fetch('/inbox/scratchpad/process', {
+      method: 'POST', body: fd,
+      headers: {'Accept': 'application/json'}
+    }).then(function(r) { return r.json(); }).then(function(data) {
+      if (data && data.ok) {
+        el.value = '';
+        var _log = document.getElementById('proj-scratch-log-' + projectId);
+        var _clr = document.getElementById('proj-scratch-clear-' + projectId);
+        if (_log) _log.disabled = true;
+        if (_clr) _clr.disabled = true;
+        var _ts = document.getElementById('proj-scratch-ts-' + projectId);
+        if (_ts) _ts.textContent = 'processed';
+        if (typeof showToast === 'function') showToast('Note logged as activity', true);
+      } else if (typeof showToast === 'function') {
+        showToast((data && data.error) || 'Failed to log activity', false);
+      }
+    }).catch(function() {
+      if (typeof showToast === 'function') showToast('Failed to log activity', false);
+    });
+  };
+
+  window.clearProjectScratch = function(projectId) {
+    var el = document.getElementById('proj-scratch-ta-' + projectId);
+    if (!el) return;
+    var fd = new FormData();
+    fd.set('source', 'project');
+    fd.set('scope_id', projectId);
+    fetch('/inbox/scratchpad/clear', {method: 'POST', body: fd})
+      .then(function(r) {
+        if (r.ok) {
+          el.value = '';
+          var _log = document.getElementById('proj-scratch-log-' + projectId);
+          var _clr = document.getElementById('proj-scratch-clear-' + projectId);
+          if (_log) _log.disabled = true;
+          if (_clr) _clr.disabled = true;
+          var _ts = document.getElementById('proj-scratch-ts-' + projectId);
+          if (_ts) _ts.textContent = 'cleared';
+          if (typeof showToast === 'function') showToast('Scratchpad cleared', true);
+        }
+      })
+      .catch(function() { if (typeof showToast === 'function') showToast('Failed to clear', false); });
+  };
+})();
+</script>

--- a/src/policydb/web/templates/clients/edit.html
+++ b/src/policydb/web/templates/clients/edit.html
@@ -229,5 +229,9 @@
 </div>
 {% endif %}
 
+{% if client %}
+{# ── Floating Working Notes Panel ── #}
+{% include "clients/_working_notes_float.html" %}
+{% endif %}
 
 {% endblock %}

--- a/src/policydb/web/templates/clients/project.html
+++ b/src/policydb/web/templates/clients/project.html
@@ -38,45 +38,27 @@
     {# ── Pinned Notes Banner ── #}
     {% include "_pinned_notes_banner.html" %}
 
-    <div class="card p-4">
+    {# ── Working Notes Scratchpad (with activity conversion) ── #}
+    {% include "clients/_project_scratchpad.html" %}
+
+    <div class="card p-4 mt-4">
       <textarea id="proj-notes-ta" rows="20"
         class="w-full text-sm text-gray-800 bg-transparent resize-none focus:outline-none">{{ project.notes or '' }}</textarea>
     </div>
 
-    {# ── Project Exposures ── #}
-    <div class="mt-6" id="project-exposures-section"
-         hx-get="/clients/{{ client.id }}/projects/{{ project.id }}/exposures"
-         hx-trigger="load"
-         hx-swap="innerHTML">
-      <div class="text-center py-6 text-gray-300 text-xs">Loading exposures...</div>
-    </div>
-
-    {# ── Compliance / Contract Review ── #}
-    <div class="mt-6" id="project-compliance-section"
-         hx-get="/compliance/client/{{ client.id }}/location/{{ project.id }}/embed"
-         hx-trigger="load"
-         hx-swap="innerHTML">
-      <div class="text-center py-6 text-gray-300 text-xs">Loading compliance review...</div>
-    </div>
-
-  </div>
-
-  {# ── Right sidebar ── #}
-  <div class="sm:w-72 shrink-0 space-y-4">
-
-    {# Policies #}
-    <div class="card overflow-hidden">
+    {# ── Policies at this location (moved from right sidebar) ── #}
+    <div class="card overflow-hidden mt-6">
       <div class="px-4 py-2.5 bg-gray-50 border-b border-gray-200 flex items-center justify-between">
-        <span class="text-[10px] font-semibold text-gray-500 uppercase tracking-wide">
+        <span class="text-[11px] font-semibold text-gray-500 uppercase tracking-wide">
           Policies at this location
           <span class="text-gray-400 normal-case">({{ policies | length }})</span>
         </span>
-        <div class="flex gap-2 no-print">
+        <div class="flex gap-3 no-print">
           <button type="button"
             onclick="copyPolicyTable('/clients/{{ client.id }}/copy-table?project={{ project.name | urlencode }}', this)"
-            class="text-[10px] text-gray-400 hover:text-marsh">Copy Table</button>
+            class="text-[11px] text-gray-500 hover:text-marsh">Copy Table</button>
           <a href="/policies/new?client={{ client.id }}&project={{ project.id }}"
-             class="text-[10px] text-marsh hover:underline">+ Add Policy</a>
+             class="text-[11px] text-marsh hover:underline">+ Add Policy</a>
         </div>
       </div>
       {% if policies %}
@@ -132,7 +114,6 @@
             </tr>
             {% endfor %}
           </tbody>
-          {% if policies %}
           <tfoot>
             <tr class="bg-gray-50/50 border-t border-gray-200">
               <td colspan="4" class="px-3 py-2 text-xs font-medium text-gray-500">Total</td>
@@ -142,7 +123,6 @@
               <td colspan="2"></td>
             </tr>
           </tfoot>
-          {% endif %}
         </table>
       </div>
       {% else %}
@@ -152,6 +132,90 @@
       </div>
       {% endif %}
     </div>
+
+    {# ── Issues assigned to this location ── #}
+    <div class="card overflow-hidden mt-6">
+      <div class="px-4 py-2.5 bg-gray-50 border-b border-gray-200 flex items-center justify-between">
+        <span class="text-[11px] font-semibold text-gray-500 uppercase tracking-wide">
+          Issues
+          <span class="text-gray-400 normal-case">({{ open_project_issues | length }})</span>
+        </span>
+        <button type="button"
+          onclick='openIssueCreateSlideover({client_id: {{ client.id }}, client_name: {{ client.name | tojson }} })'
+          class="text-[11px] text-marsh hover:underline no-print">+ New Issue</button>
+      </div>
+      {% if open_project_issues %}
+      <ul class="divide-y divide-gray-100">
+        {% for iss in open_project_issues %}
+        <li class="px-4 py-2.5 hover:bg-gray-50">
+          <div class="flex items-start gap-3">
+            <span class="text-[10px] font-mono px-1.5 py-0.5 rounded shrink-0 mt-0.5
+              {% if iss.issue_severity == 'Critical' %}bg-red-100 text-red-700
+              {% elif iss.issue_severity == 'High' %}bg-amber-100 text-amber-700
+              {% elif iss.issue_severity == 'Normal' %}bg-blue-100 text-blue-700
+              {% else %}bg-gray-100 text-gray-600{% endif %}">
+              {{ iss.issue_severity or 'Normal' }}
+            </span>
+            <div class="flex-1 min-w-0">
+              <a href="/issues/{{ iss.issue_uid }}"
+                 class="text-sm text-gray-900 hover:text-marsh truncate block">{{ iss.subject }}</a>
+              <div class="flex items-center gap-2 text-[10px] text-gray-400 mt-0.5">
+                <span class="font-mono">{{ iss.issue_uid }}</span>
+                {% if iss.policy_uid %}
+                <span>·</span>
+                <a href="/policies/{{ iss.policy_uid }}/edit" class="hover:text-marsh">{{ iss.policy_uid }}{% if iss.policy_type %} · {{ iss.policy_type }}{% endif %}</a>
+                {% endif %}
+                <span>·</span>
+                <span>{{ iss.days_open or 0 }}d open</span>
+                {% if iss.issue_status %}<span>·</span><span>{{ iss.issue_status }}</span>{% endif %}
+              </div>
+            </div>
+          </div>
+        </li>
+        {% endfor %}
+      </ul>
+      {% else %}
+      <div class="px-4 py-6 text-center">
+        <p class="text-xs text-gray-400 italic">No open issues at this location.</p>
+      </div>
+      {% endif %}
+    </div>
+
+    {# ── Files & Attachments (moved from right sidebar) ── #}
+    <div class="card mt-6">
+      <div class="px-4 py-2.5 bg-gray-50 border-b border-gray-200 flex items-center justify-between">
+        <span class="text-[11px] font-semibold text-gray-500 uppercase tracking-wide">
+          Files
+          {% if attachment_count %}<span class="text-gray-400 normal-case">({{ attachment_count }})</span>{% endif %}
+        </span>
+      </div>
+      <div class="p-4" id="project-files-panel"
+           hx-get="/api/attachments/panel?record_type=project&record_id={{ project.id }}"
+           hx-trigger="load" hx-swap="innerHTML">
+        <p class="text-xs text-gray-400 italic">Loading files...</p>
+      </div>
+    </div>
+
+    {# ── Project Exposures ── #}
+    <div class="mt-6" id="project-exposures-section"
+         hx-get="/clients/{{ client.id }}/projects/{{ project.id }}/exposures"
+         hx-trigger="load"
+         hx-swap="innerHTML">
+      <div class="text-center py-6 text-gray-300 text-xs">Loading exposures...</div>
+    </div>
+
+    {# ── Compliance / Contract Review ── #}
+    <div class="mt-6" id="project-compliance-section"
+         hx-get="/compliance/client/{{ client.id }}/location/{{ project.id }}/embed"
+         hx-trigger="load"
+         hx-swap="innerHTML">
+      <div class="text-center py-6 text-gray-300 text-xs">Loading compliance review...</div>
+    </div>
+
+  </div>
+
+  {# ── Right sidebar ── #}
+  <div class="sm:w-72 shrink-0 space-y-4">
 
     {# Programs at this location #}
     <div class="card p-4">
@@ -318,14 +382,6 @@
     </div>
     {% endif %}
 
-    {# Files & Attachments #}
-    <div class="card p-4">
-      <div hx-get="/api/attachments/panel?record_type=project&record_id={{ project.id }}"
-           hx-trigger="load" hx-swap="innerHTML">
-        <p class="text-xs text-gray-400 italic">Loading...</p>
-      </div>
-    </div>
-
     {# References #}
     <div class="card p-4">
       <div class="flex items-center justify-between mb-2">
@@ -372,6 +428,9 @@
 
   </div>
 </div>
+
+{# Issue Create Slideover (for the "+ New Issue" button on the Issues card) #}
+{% include "_issue_create_slideover.html" %}
 
 <script>
 /* References panel */

--- a/src/policydb/web/templates/issues/detail.html
+++ b/src/policydb/web/templates/issues/detail.html
@@ -56,18 +56,28 @@
         data-original="{{ issue.subject }}"
         onblur="saveIssueSubject(this)"
         onkeydown="if(event.key==='Enter'){event.preventDefault();this.blur();}">{{ issue.subject }}</h1>
-    {% if issue.is_renewal_issue and issue.renewal_term_key %}
-      {% set _rtk = issue.renewal_term_key %}
-      {% if _rtk.startswith('program:') %}
-        {% set _bind_subjects = _rtk %}
+    {% if issue.is_renewal_issue %}
+      {# Prefer linked_policies (covers merged-in source issues + junction +
+         program siblings); fall back to renewal_term_key if nothing linked. #}
+      {% if bind_subjects_csv %}
+        {% set _bind_subjects = bind_subjects_csv %}
+      {% elif issue.renewal_term_key %}
+        {% set _rtk = issue.renewal_term_key %}
+        {% if _rtk.startswith('program:') %}
+          {% set _bind_subjects = _rtk %}
+        {% else %}
+          {% set _bind_subjects = 'policy:' + _rtk %}
+        {% endif %}
       {% else %}
-        {% set _bind_subjects = 'policy:' + _rtk %}
+        {% set _bind_subjects = '' %}
       {% endif %}
+      {% if _bind_subjects %}
       <button type="button"
         onclick="openBindOrderSlideover('{{ _bind_subjects }}')"
         class="shrink-0 px-3 py-1.5 text-xs font-medium rounded-lg bg-marsh hover:bg-marsh/90 text-white transition-colors">
         Bind Order
       </button>
+      {% endif %}
     {% endif %}
   </div>
 


### PR DESCRIPTION
## Summary
- **Client edit scratchpad** — Working Notes panel was missing from `/clients/{id}/edit`; wired context + include.
- **Slideover scroll fix** — One-line fix in `base.html` so all 6 slideovers (inbox process, edit client/policy/issue/activity/contact) can scroll to their save buttons.
- **Bind Order on issues** — Button now passes all linked policies (including those inherited from merged-in source issues), grouped by program, instead of just `renewal_term_key`.
- **Location/Project page redesign** — Files + Policies moved to the main left column (more room), new Issues card (open issues for the location + `+ New Issue`), new Working Notes scratchpad with Log-as-Activity conversion.

## What changed
- Migration 143: `project_scratchpad(project_id PK, content, updated_at)` + update trigger, wired into `init_db`.
- `inbox.py` scratchpad/clear + scratchpad/process now handle `source='project'`; persist `project_id` on the created `activity_log` row.
- New `POST /clients/{id}/projects/{pid}/scratchpad` autosave route.
- `project_detail` loads scratchpad, deduped open issues (direct + via linked policies), attachment count.
- New partial `clients/_project_scratchpad.html`.
- `clients/project.html` layout: Scratchpad → Notes → Policies → Issues → Files → Exposures → Compliance in the left column; Programs / Address / COPE / References / Metadata remain in the narrow sidebar.
- `issues/detail.html` Bind Order button prefers `bind_subjects_csv` (built in the route from `_get_linked_policies`), falling back to `renewal_term_key` when no links exist.

## Test plan
- [x] `/clients/{id}/edit` renders the Working Notes floating panel
- [x] Inbox process slideover body scrolls; save buttons visible at bottom
- [x] Issue 099B20EE Bind Order button renders both POL-005 and POL-006 sections
- [x] Project scratchpad auto-saves, `Log as Activity` creates `activity_log` row with `project_id` and clears the textarea
- [x] Project Issues card shows open issues (verified on project 2 with 2 issues)
- [x] Project Policies + Files render in the left column; sidebar only has narrow cards
- [x] `+ New Issue` on project page opens the existing issue create slideover with the client pre-filled

🤖 Generated with [Claude Code](https://claude.com/claude-code)