### PR TITLE
Add Scope Rollup: aggregate RFI, checklist, and workflow data on issue and program pages

### DIFF
--- a/src/policydb/queries.py
+++ b/src/policydb/queries.py
@@ -4669,3 +4669,745 @@ def get_vacation_checklist(conn: sqlite3.Connection, return_date: str) -> dict:
         "renewals": renewals_near_return,
         "milestones": milestones_during,
     }
+
+
+# ─── SCOPE ROLLUPS (issue + program detail) ──────────────────────────────────
+#
+# Shared rollup helpers that aggregate workflow data across a set of linked
+# policies. Used by both the renewal issue detail page and the program detail
+# page so the same numbers surface in both places.
+
+_POL_ROLLUP_COLS = """
+    p.id, p.policy_uid, p.policy_type, p.carrier, p.premium,
+    p.exposure_amount, p.exposure_basis,
+    p.expiration_date, p.renewal_status, p.is_opportunity,
+    p.follow_up_date AS policy_follow_up_date,
+    p.placement_colleague, p.placement_colleague_email,
+    p.underwriter_name, p.underwriter_contact,
+    p.program_id, pr.name AS location_name,
+    pg.program_uid, pg.name AS program_name
+"""
+_POL_ROLLUP_JOINS = """
+    LEFT JOIN projects pr ON pr.id = p.project_id
+    LEFT JOIN programs pg ON pg.id = p.program_id
+"""
+
+
+def get_linked_policies_for_issue(conn: sqlite3.Connection, issue_id: int) -> list[dict]:
+    """Gather all policies linked to an issue.
+
+    Covers four linkage sources, in priority order:
+      1. Direct FK (activity_log.policy_id on the issue header row)
+      2. Program siblings (all non-archived child policies of issue's program_id)
+      3. Junction table rows (issue_policies)
+      4. Policies inherited from merged-in source issues (merged_into_id == issue_id)
+
+    Returns a list of dicts (deduped by policy id) with the columns listed in
+    _POL_ROLLUP_COLS plus _junction / _from_merge markers.
+    """
+    issue = conn.execute(
+        "SELECT id, policy_id, program_id FROM activity_log WHERE id = ? AND item_kind = 'issue'",
+        (issue_id,),
+    ).fetchone()
+    if not issue:
+        return []
+
+    linked: list[dict] = []
+    seen_ids: set[int] = set()
+
+    # 1. Direct FK
+    if issue["policy_id"]:
+        for r in conn.execute(
+            f"SELECT {_POL_ROLLUP_COLS} FROM policies p {_POL_ROLLUP_JOINS} "  # noqa: S608
+            f"WHERE p.id = ? AND p.archived = 0",
+            (issue["policy_id"],),
+        ).fetchall():
+            d = dict(r)
+            if d["id"] not in seen_ids:
+                seen_ids.add(d["id"])
+                linked.append(d)
+
+    # 2. Program siblings
+    if issue["program_id"]:
+        for r in conn.execute(
+            f"SELECT {_POL_ROLLUP_COLS} FROM policies p {_POL_ROLLUP_JOINS} "  # noqa: S608
+            f"WHERE p.program_id = ? AND p.archived = 0 ORDER BY p.policy_type",
+            (issue["program_id"],),
+        ).fetchall():
+            d = dict(r)
+            if d["id"] not in seen_ids:
+                seen_ids.add(d["id"])
+                linked.append(d)
+
+    # 3. Junction table
+    for r in conn.execute(
+        f"SELECT {_POL_ROLLUP_COLS} FROM issue_policies ip "  # noqa: S608
+        f"JOIN policies p ON p.id = ip.policy_id {_POL_ROLLUP_JOINS} "
+        f"WHERE ip.issue_id = ? AND p.archived = 0 ORDER BY p.policy_uid",
+        (issue_id,),
+    ).fetchall():
+        d = dict(r)
+        if d["id"] not in seen_ids:
+            d["_junction"] = True
+            seen_ids.add(d["id"])
+            linked.append(d)
+
+    # 4. Inherit from merged-in source issues
+    merged_sources = conn.execute(
+        "SELECT id, policy_id, program_id FROM activity_log "
+        "WHERE merged_into_id = ? AND item_kind = 'issue'",
+        (issue_id,),
+    ).fetchall()
+    for src in merged_sources:
+        if src["policy_id"]:
+            for r in conn.execute(
+                f"SELECT {_POL_ROLLUP_COLS} FROM policies p {_POL_ROLLUP_JOINS} "  # noqa: S608
+                f"WHERE p.id = ? AND p.archived = 0",
+                (src["policy_id"],),
+            ).fetchall():
+                d = dict(r)
+                if d["id"] not in seen_ids:
+                    d["_from_merge"] = True
+                    seen_ids.add(d["id"])
+                    linked.append(d)
+        if src["program_id"]:
+            for r in conn.execute(
+                f"SELECT {_POL_ROLLUP_COLS} FROM policies p {_POL_ROLLUP_JOINS} "  # noqa: S608
+                f"WHERE p.program_id = ? AND p.archived = 0 ORDER BY p.policy_type",
+                (src["program_id"],),
+            ).fetchall():
+                d = dict(r)
+                if d["id"] not in seen_ids:
+                    d["_from_merge"] = True
+                    seen_ids.add(d["id"])
+                    linked.append(d)
+        for r in conn.execute(
+            f"SELECT {_POL_ROLLUP_COLS} FROM issue_policies ip "  # noqa: S608
+            f"JOIN policies p ON p.id = ip.policy_id {_POL_ROLLUP_JOINS} "
+            f"WHERE ip.issue_id = ? AND p.archived = 0 ORDER BY p.policy_uid",
+            (src["id"],),
+        ).fetchall():
+            d = dict(r)
+            if d["id"] not in seen_ids:
+                d["_from_merge"] = True
+                seen_ids.add(d["id"])
+                linked.append(d)
+
+    return linked
+
+
+def get_linked_policies_for_program(conn: sqlite3.Connection, program_id: int) -> list[dict]:
+    """All non-archived policies in a program, with the same column shape as
+    get_linked_policies_for_issue() so the rollup helpers can consume either."""
+    return [
+        dict(r)
+        for r in conn.execute(
+            f"SELECT {_POL_ROLLUP_COLS} FROM policies p {_POL_ROLLUP_JOINS} "  # noqa: S608
+            f"WHERE p.program_id = ? AND p.archived = 0 "
+            f"ORDER BY p.policy_type, p.policy_uid",
+            (program_id,),
+        ).fetchall()
+    ]
+
+
+def get_milestone_progress_for_policies(
+    conn: sqlite3.Connection, policy_uids: list[str]
+) -> dict[str, dict]:
+    """Return {policy_uid: {done, total, weighted_done, weighted_total, percent}}
+    for the given policies. Pure lookup — does not mutate any rows.
+
+    Used by both _attach_milestone_progress() (mutating wrapper, for pipeline
+    rows) and the issue rollup helpers.
+    """
+    all_milestones = cfg.get("renewal_milestones", [])
+    milestone_weights = cfg.get("readiness_milestone_weights", {})
+    total = len(all_milestones)
+    weighted_total = sum(milestone_weights.get(m, 1) for m in all_milestones)
+
+    if not policy_uids or not total:
+        return {
+            uid: {
+                "done": 0,
+                "total": total,
+                "weighted_done": 0,
+                "weighted_total": weighted_total,
+                "percent": 0,
+            }
+            for uid in policy_uids
+        }
+
+    placeholders = ",".join("?" * len(policy_uids))
+    ms_ph = ",".join("?" * len(all_milestones))
+    rows = conn.execute(
+        f"SELECT policy_uid, milestone FROM policy_milestones "  # noqa: S608
+        f"WHERE policy_uid IN ({placeholders}) AND milestone IN ({ms_ph}) AND completed = 1",
+        list(policy_uids) + list(all_milestones),
+    ).fetchall()
+    completed_by_policy: dict[str, set[str]] = {}
+    for r in rows:
+        completed_by_policy.setdefault(r["policy_uid"], set()).add(r["milestone"])
+
+    result: dict[str, dict] = {}
+    for uid in policy_uids:
+        completed = completed_by_policy.get(uid, set())
+        done = len(completed)
+        weighted_done = sum(milestone_weights.get(m, 1) for m in completed)
+        result[uid] = {
+            "done": done,
+            "total": total,
+            "weighted_done": weighted_done,
+            "weighted_total": weighted_total,
+            "percent": int(round(100 * done / total)) if total else 0,
+        }
+    return result
+
+
+def get_linked_policy_contacts(
+    conn: sqlite3.Connection, policy_ids: list[int]
+) -> dict[str, list[dict]]:
+    """Return distinct placement colleagues and underwriters across a set of
+    policies, each annotated with the policy UIDs they touch.
+
+    Pulls from two sources:
+      1. contact_policy_assignments + contacts (authoritative)
+      2. policies.placement_colleague / underwriter_name string fields
+         (legacy fallback — merged by lowercase name when contact_id is absent)
+    """
+    if not policy_ids:
+        return {"placement_colleagues": [], "underwriters": []}
+
+    placeholders = ",".join("?" * len(policy_ids))
+    pc_acc: dict[tuple, dict] = {}
+    uw_acc: dict[tuple, dict] = {}
+
+    # Source 1: contact_policy_assignments
+    rows = conn.execute(
+        f"""SELECT cpa.policy_id, p.policy_uid, p.carrier,
+                   co.name, co.email, co.phone, co.mobile,
+                   cpa.role, cpa.is_placement_colleague
+            FROM contact_policy_assignments cpa
+            JOIN contacts co ON co.id = cpa.contact_id
+            JOIN policies p ON p.id = cpa.policy_id
+            WHERE cpa.policy_id IN ({placeholders}) AND p.archived = 0""",  # noqa: S608
+        policy_ids,
+    ).fetchall()
+    for r in rows:
+        name = (r["name"] or "").strip()
+        if not name:
+            continue
+        email = (r["email"] or "").strip().lower()
+        key = (name.lower(), email)
+        role = (r["role"] or "").strip().lower()
+        is_pc = r["is_placement_colleague"] or role in ("placement", "broker", "placement colleague")
+        is_uw = role in ("underwriter", "uw")
+
+        bucket = None
+        if is_pc:
+            bucket = pc_acc
+        elif is_uw:
+            bucket = uw_acc
+        if bucket is None:
+            continue
+        entry = bucket.setdefault(
+            key,
+            {
+                "name": name,
+                "email": r["email"] or "",
+                "phone": r["phone"] or r["mobile"] or "",
+                "carrier": r["carrier"] or "",
+                "policy_uids": [],
+            },
+        )
+        if r["policy_uid"] not in entry["policy_uids"]:
+            entry["policy_uids"].append(r["policy_uid"])
+
+    # Source 2: legacy string fields on policies
+    legacy_rows = conn.execute(
+        f"""SELECT p.policy_uid, p.carrier,
+                   p.placement_colleague, p.placement_colleague_email,
+                   p.underwriter_name, p.underwriter_contact
+            FROM policies p
+            WHERE p.id IN ({placeholders}) AND p.archived = 0""",  # noqa: S608
+        policy_ids,
+    ).fetchall()
+    for r in legacy_rows:
+        pc_name = (r["placement_colleague"] or "").strip()
+        if pc_name:
+            email = (r["placement_colleague_email"] or "").strip().lower()
+            key = (pc_name.lower(), email)
+            entry = pc_acc.setdefault(
+                key,
+                {
+                    "name": pc_name,
+                    "email": r["placement_colleague_email"] or "",
+                    "phone": "",
+                    "carrier": r["carrier"] or "",
+                    "policy_uids": [],
+                },
+            )
+            if r["policy_uid"] not in entry["policy_uids"]:
+                entry["policy_uids"].append(r["policy_uid"])
+        uw_name = (r["underwriter_name"] or "").strip()
+        if uw_name:
+            uw_contact = (r["underwriter_contact"] or "").strip()
+            key = (uw_name.lower(), uw_contact.lower())
+            entry = uw_acc.setdefault(
+                key,
+                {
+                    "name": uw_name,
+                    "email": uw_contact if "@" in uw_contact else "",
+                    "phone": "" if "@" in uw_contact else uw_contact,
+                    "carrier": r["carrier"] or "",
+                    "policy_uids": [],
+                },
+            )
+            if r["policy_uid"] not in entry["policy_uids"]:
+                entry["policy_uids"].append(r["policy_uid"])
+
+    def _sort_list(acc: dict) -> list[dict]:
+        items = list(acc.values())
+        items.sort(key=lambda e: (-len(e["policy_uids"]), e["name"].lower()))
+        return items
+
+    return {
+        "placement_colleagues": _sort_list(pc_acc),
+        "underwriters": _sort_list(uw_acc),
+    }
+
+
+def _rollup_rfi(conn: sqlite3.Connection, policy_uids: list[str]) -> dict:
+    """RFI aggregate across a set of policies."""
+    empty = {
+        "open_bundles": 0,
+        "total_items": 0,
+        "received_items": 0,
+        "overdue_items": 0,
+        "by_policy": {},
+    }
+    if not policy_uids:
+        return empty
+    placeholders = ",".join("?" * len(policy_uids))
+    rows = conn.execute(
+        f"""SELECT i.policy_uid, i.received, b.status AS bundle_status, b.send_by_date,
+                   b.id AS bundle_id
+            FROM client_request_items i
+            JOIN client_request_bundles b ON b.id = i.bundle_id
+            WHERE i.policy_uid IN ({placeholders})""",  # noqa: S608
+        policy_uids,
+    ).fetchall()
+    today = date.today().isoformat()
+    open_bundles: set[int] = set()
+    by_policy: dict[str, dict] = {}
+    total = 0
+    received = 0
+    overdue = 0
+    for r in rows:
+        uid = r["policy_uid"]
+        bucket = by_policy.setdefault(uid, {"open": 0, "received": 0, "total": 0, "overdue": 0})
+        bucket["total"] += 1
+        total += 1
+        if r["received"]:
+            bucket["received"] += 1
+            received += 1
+        else:
+            bucket["open"] += 1
+            if r["send_by_date"] and r["send_by_date"] < today:
+                bucket["overdue"] += 1
+                overdue += 1
+            if (r["bundle_status"] or "").lower() != "complete":
+                open_bundles.add(r["bundle_id"])
+    return {
+        "open_bundles": len(open_bundles),
+        "total_items": total,
+        "received_items": received,
+        "overdue_items": overdue,
+        "by_policy": by_policy,
+    }
+
+
+def _rollup_timeline_accountability(
+    conn: sqlite3.Connection, policy_uids: list[str]
+) -> dict:
+    """Count open timeline milestones grouped by accountability/waiting_on."""
+    result = {"waiting": {}, "my_action": 0, "scheduled": 0, "total_open": 0}
+    if not policy_uids:
+        return result
+    placeholders = ",".join("?" * len(policy_uids))
+    rows = conn.execute(
+        f"""SELECT accountability, waiting_on, COUNT(*) AS n
+            FROM policy_timeline
+            WHERE policy_uid IN ({placeholders}) AND completed_date IS NULL
+            GROUP BY accountability, waiting_on""",  # noqa: S608
+        policy_uids,
+    ).fetchall()
+    for r in rows:
+        n = r["n"] or 0
+        result["total_open"] += n
+        acct = r["accountability"] or ""
+        if acct == "waiting_external":
+            label = (r["waiting_on"] or "External").strip() or "External"
+            result["waiting"][label] = result["waiting"].get(label, 0) + n
+        elif acct == "scheduled":
+            result["scheduled"] += n
+        else:
+            result["my_action"] += n
+    return result
+
+
+def _rollup_open_followups(
+    conn: sqlite3.Connection,
+    policy_ids: list[int],
+    exclude_issue_id: Optional[int] = None,
+) -> dict:
+    """Open follow-ups attached to the given policies, excluding any already
+    linked to `exclude_issue_id` (to avoid duplicating what the issue's
+    activity thread already shows).
+
+    Returns {total, overdue, by_policy: [...]}. Each by_policy entry has:
+        policy_uid, policy_type, follow_up_date, days_overdue, source, subject.
+
+    Applies the same dedup rule as get_all_followups(): policy-source rows are
+    suppressed when an activity-source row exists on the same policy.
+    """
+    result = {"total": 0, "overdue": 0, "by_policy": []}
+    if not policy_ids:
+        return result
+    placeholders = ",".join("?" * len(policy_ids))
+    today = date.today()
+
+    # Activity-source follow-ups
+    params: list = list(policy_ids)
+    exclude_clause = ""
+    if exclude_issue_id is not None:
+        exclude_clause = " AND (a.issue_id IS NULL OR a.issue_id != ?)"
+        params.append(exclude_issue_id)
+    activity_rows = conn.execute(
+        f"""SELECT a.id, a.policy_id, a.follow_up_date, a.subject, a.activity_type,
+                   a.disposition, p.policy_uid, p.policy_type
+            FROM activity_log a
+            JOIN policies p ON p.id = a.policy_id
+            WHERE a.follow_up_done = 0
+              AND a.follow_up_date IS NOT NULL
+              AND a.item_kind = 'followup'
+              AND a.policy_id IN ({placeholders})
+              {exclude_clause}
+            ORDER BY a.follow_up_date""",  # noqa: S608
+        params,
+    ).fetchall()
+    seen_policy_ids: set[int] = set()
+    for r in activity_rows:
+        seen_policy_ids.add(r["policy_id"])
+        fu = r["follow_up_date"]
+        days_overdue = 0
+        try:
+            days_overdue = (today - date.fromisoformat(fu)).days
+        except (ValueError, TypeError):
+            pass
+        entry = {
+            "policy_uid": r["policy_uid"],
+            "policy_type": r["policy_type"],
+            "follow_up_date": fu,
+            "days_overdue": days_overdue,
+            "source": "activity",
+            "subject": r["subject"] or r["activity_type"] or "Follow-up",
+            "disposition": r["disposition"] or "",
+        }
+        result["by_policy"].append(entry)
+        result["total"] += 1
+        if days_overdue > 0:
+            result["overdue"] += 1
+
+    # Policy-source follow-ups (suppressed where an activity-source row exists)
+    remaining = [pid for pid in policy_ids if pid not in seen_policy_ids]
+    if remaining:
+        ph = ",".join("?" * len(remaining))
+        policy_rows = conn.execute(
+            f"""SELECT p.policy_uid, p.policy_type, p.follow_up_date
+                FROM policies p
+                WHERE p.id IN ({ph})
+                  AND p.follow_up_date IS NOT NULL
+                ORDER BY p.follow_up_date""",  # noqa: S608
+            remaining,
+        ).fetchall()
+        for r in policy_rows:
+            fu = r["follow_up_date"]
+            days_overdue = 0
+            try:
+                days_overdue = (today - date.fromisoformat(fu)).days
+            except (ValueError, TypeError):
+                pass
+            entry = {
+                "policy_uid": r["policy_uid"],
+                "policy_type": r["policy_type"],
+                "follow_up_date": fu,
+                "days_overdue": days_overdue,
+                "source": "policy",
+                "subject": "Policy follow-up",
+                "disposition": "",
+            }
+            result["by_policy"].append(entry)
+            result["total"] += 1
+            if days_overdue > 0:
+                result["overdue"] += 1
+
+    result["by_policy"].sort(key=lambda e: (-e["days_overdue"], e["follow_up_date"]))
+    return result
+
+
+def _rollup_working_notes(
+    conn: sqlite3.Connection, policy_ids: list[int], truncate_at: int = 400
+) -> list[dict]:
+    """Aggregate policy scratchpad + project scratchpad for each policy.
+
+    Returns a list of {policy_uid, policy_type, notes, project_scratchpad,
+    has_more} entries, one per policy that has any non-empty content.
+    """
+    if not policy_ids:
+        return []
+    placeholders = ",".join("?" * len(policy_ids))
+    rows = conn.execute(
+        f"""SELECT p.policy_uid, p.policy_type,
+                   ps.content AS scratchpad,
+                   prj.content AS project_scratch
+            FROM policies p
+            LEFT JOIN policy_scratchpad ps ON ps.policy_uid = p.policy_uid
+            LEFT JOIN project_scratchpad prj ON prj.project_id = p.project_id
+            WHERE p.id IN ({placeholders}) AND p.archived = 0""",  # noqa: S608
+        policy_ids,
+    ).fetchall()
+
+    out: list[dict] = []
+    for r in rows:
+        notes = (r["scratchpad"] or "").strip()
+        prj = (r["project_scratch"] or "").strip()
+        if not notes and not prj:
+            continue
+        has_more = False
+        if len(notes) > truncate_at:
+            notes = notes[:truncate_at].rstrip() + "…"
+            has_more = True
+        if len(prj) > truncate_at:
+            prj = prj[:truncate_at].rstrip() + "…"
+            has_more = True
+        out.append(
+            {
+                "policy_uid": r["policy_uid"],
+                "policy_type": r["policy_type"],
+                "notes": notes,
+                "project_scratchpad": prj,
+                "has_more": has_more,
+            }
+        )
+    return out
+
+
+def _rollup_nested_issues(
+    conn: sqlite3.Connection, policy_ids: list[int], exclude_issue_id: int
+) -> list[dict]:
+    """Other open issues touching the given policies, excluding one.
+
+    Uses v_issue_policy_coverage so program-level and merged issues are
+    covered correctly.
+    """
+    if not policy_ids:
+        return []
+    placeholders = ",".join("?" * len(policy_ids))
+    rows = conn.execute(
+        f"""SELECT DISTINCT a.id, a.issue_uid, a.subject,
+                   a.issue_status, a.issue_severity, a.is_renewal_issue,
+                   a.due_date, a.activity_date
+            FROM activity_log a
+            JOIN v_issue_policy_coverage ipc ON ipc.issue_id = a.id
+            WHERE ipc.policy_id IN ({placeholders})
+              AND a.item_kind = 'issue'
+              AND (a.issue_status IS NULL OR a.issue_status NOT IN ('Resolved', 'Closed'))
+              AND a.id != ?
+            ORDER BY
+                CASE a.issue_severity
+                    WHEN 'Critical' THEN 0
+                    WHEN 'High' THEN 1
+                    WHEN 'Normal' THEN 2
+                    WHEN 'Low' THEN 3
+                    ELSE 4
+                END,
+                a.activity_date DESC""",  # noqa: S608
+        list(policy_ids) + [exclude_issue_id],
+    ).fetchall()
+    if not rows:
+        return []
+
+    # Back-fill affected policy_uids per issue via a second small query
+    issue_ids = [r["id"] for r in rows]
+    iph = ",".join("?" * len(issue_ids))
+    pph = ",".join("?" * len(policy_ids))
+    coverage = conn.execute(
+        f"""SELECT ipc.issue_id, p.policy_uid
+            FROM v_issue_policy_coverage ipc
+            JOIN policies p ON p.id = ipc.policy_id
+            WHERE ipc.issue_id IN ({iph}) AND ipc.policy_id IN ({pph})
+            ORDER BY p.policy_uid""",  # noqa: S608
+        issue_ids + policy_ids,
+    ).fetchall()
+    uids_by_issue: dict[int, list[str]] = {}
+    for r in coverage:
+        uids_by_issue.setdefault(r["issue_id"], []).append(r["policy_uid"])
+
+    out: list[dict] = []
+    for r in rows:
+        d = dict(r)
+        d["policy_uids"] = uids_by_issue.get(r["id"], [])
+        out.append(d)
+    return out
+
+
+def _rollup_financials(linked: list[dict]) -> dict:
+    """Premium / exposure totals from already-fetched linked policy rows."""
+    terminal = set(cfg.get("renewal_terminal_statuses", ["Bound", "Lost", "Non-Renewed", "Declined"]))
+    total_premium = 0.0
+    total_exposure = 0.0
+    premium_at_risk = 0.0
+    terminal_count = 0
+    for p in linked:
+        premium = p.get("premium") or 0
+        total_premium += premium
+        exposure = p.get("exposure_amount") or 0
+        total_exposure += exposure
+        if (p.get("renewal_status") or "") in terminal:
+            terminal_count += 1
+        else:
+            premium_at_risk += premium
+    return {
+        "total_premium": total_premium,
+        "total_exposure": total_exposure,
+        "premium_at_risk": premium_at_risk,
+        "policy_count": len(linked),
+        "at_risk_count": len(linked) - terminal_count,
+        "bound_count": terminal_count,
+    }
+
+
+def _rollup_renewal_status(linked: list[dict]) -> dict[str, int]:
+    """Counter of renewal_status across linked policies."""
+    counts: dict[str, int] = {}
+    for p in linked:
+        label = (p.get("renewal_status") or "Not Started").strip() or "Not Started"
+        counts[label] = counts.get(label, 0) + 1
+    return counts
+
+
+def _worst_health(healths: list[str]) -> str:
+    """Return the worst milestone health from a list."""
+    order = ["critical", "at_risk", "compressed", "drifting", "on_track", ""]
+    present = {h for h in healths if h}
+    for h in order:
+        if h in present:
+            return h
+    return ""
+
+
+def _rollup_per_policy_health(
+    conn: sqlite3.Connection, policy_uids: list[str]
+) -> dict[str, str]:
+    """Return {policy_uid: worst_health_label} based on open timeline rows."""
+    if not policy_uids:
+        return {}
+    placeholders = ",".join("?" * len(policy_uids))
+    rows = conn.execute(
+        f"""SELECT policy_uid, health
+            FROM policy_timeline
+            WHERE policy_uid IN ({placeholders}) AND completed_date IS NULL""",  # noqa: S608
+        policy_uids,
+    ).fetchall()
+    by_uid: dict[str, list[str]] = {}
+    for r in rows:
+        by_uid.setdefault(r["policy_uid"], []).append(r["health"] or "")
+    return {uid: _worst_health(healths) for uid, healths in by_uid.items()}
+
+
+def _enrich_linked_policies(conn, linked: list[dict]) -> None:
+    """Attach milestone_progress and worst_health to each linked policy row."""
+    if not linked:
+        return
+    uids = [p["policy_uid"] for p in linked if p.get("policy_uid")]
+    progress = get_milestone_progress_for_policies(conn, uids)
+    health_by_uid = _rollup_per_policy_health(conn, uids)
+    for p in linked:
+        uid = p.get("policy_uid")
+        p["milestone_progress"] = progress.get(uid, {"done": 0, "total": 0, "percent": 0})
+        p["worst_health"] = health_by_uid.get(uid, "")
+
+
+def _build_rollup(
+    conn: sqlite3.Connection, linked: list[dict], exclude_issue_id: Optional[int]
+) -> dict:
+    """Build the rollup dict from an already-materialized linked policy list.
+
+    Shared by get_issue_rollup() and get_program_rollup() so both entry points
+    produce the same shape. Caller is responsible for providing `linked`.
+    """
+    _enrich_linked_policies(conn, linked)
+
+    policy_ids = [p["id"] for p in linked]
+    policy_uids = [p["policy_uid"] for p in linked if p.get("policy_uid")]
+
+    rfi = _rollup_rfi(conn, policy_uids)
+    timeline_acct = _rollup_timeline_accountability(conn, policy_uids)
+    renewal_status = _rollup_renewal_status(linked)
+    financials = _rollup_financials(linked)
+    open_followups = _rollup_open_followups(conn, policy_ids, exclude_issue_id)
+    contacts = get_linked_policy_contacts(conn, policy_ids)
+    working_notes = _rollup_working_notes(conn, policy_ids)
+
+    # Checklist aggregate
+    total_done = sum(p["milestone_progress"]["done"] for p in linked)
+    total_items = sum(p["milestone_progress"]["total"] for p in linked)
+    checklist = {
+        "by_policy": {p["policy_uid"]: p["milestone_progress"] for p in linked},
+        "done_total": total_done,
+        "item_total": total_items,
+        "percent": int(round(100 * total_done / total_items)) if total_items else 0,
+    }
+
+    # Worst health across all linked policies (single badge for the top stat)
+    worst = _worst_health([p.get("worst_health", "") for p in linked])
+
+    return {
+        "policies": linked,
+        "rfi": rfi,
+        "checklist": checklist,
+        "timeline_accountability": timeline_acct,
+        "renewal_status": renewal_status,
+        "open_followups": open_followups,
+        "contacts": contacts,
+        "nested_issues": [],  # populated by issue variant only
+        "financials": financials,
+        "working_notes": working_notes,
+        "worst_health": worst,
+    }
+
+
+def get_issue_rollup(conn: sqlite3.Connection, issue_id: int) -> dict:
+    """Aggregate workflow state across all policies linked to an issue.
+
+    Returns a dict with keys: policies, rfi, checklist, timeline_accountability,
+    renewal_status, open_followups, contacts, nested_issues, financials,
+    working_notes, worst_health. See the plan at
+    .claude/plans/stateless-launching-valiant.md for the full shape.
+    """
+    linked = get_linked_policies_for_issue(conn, issue_id)
+    rollup = _build_rollup(conn, linked, exclude_issue_id=issue_id)
+    rollup["nested_issues"] = _rollup_nested_issues(
+        conn, [p["id"] for p in linked], issue_id
+    )
+    return rollup
+
+
+def get_program_rollup(conn: sqlite3.Connection, program_id: int) -> dict:
+    """Aggregate workflow state across all child policies of a program.
+
+    Same shape as get_issue_rollup() except `nested_issues` is always empty —
+    program-level issues already surface via a dedicated section on the program
+    detail page.
+    """
+    linked = get_linked_policies_for_program(conn, program_id)
+    return _build_rollup(conn, linked, exclude_issue_id=None)

--- a/src/policydb/web/routes/issues.py
+++ b/src/policydb/web/routes/issues.py
@@ -11,7 +11,11 @@ from rapidfuzz import fuzz
 
 import policydb.config as cfg
 from policydb.db import generate_issue_uid
-from policydb.queries import auto_close_followups
+from policydb.queries import (
+    auto_close_followups,
+    get_issue_rollup,
+    get_linked_policies_for_issue,
+)
 from policydb.utils import round_duration
 from policydb.web.app import get_db, templates
 
@@ -665,10 +669,7 @@ def remove_issue_policy(issue_id: int, policy_id: int, conn=Depends(get_db)):
 
 def _render_linked_policies_panel(issue_id: int, conn) -> HTMLResponse:
     """Return the updated linked-policies panel partial."""
-    issue = conn.execute(
-        "SELECT policy_id, program_id FROM activity_log WHERE id = ?", (issue_id,)
-    ).fetchone()
-    linked = _get_linked_policies(conn, issue_id, issue)
+    linked = get_linked_policies_for_issue(conn, issue_id)
     html_parts = []
     for p in linked:
         is_junction = p.get("_junction")
@@ -724,107 +725,6 @@ def _render_linked_policies_panel(issue_id: int, conn) -> HTMLResponse:
     )
     body = f'<div class="divide-y divide-gray-100">{"".join(html_parts)}</div>' if html_parts else ""
     return HTMLResponse(header + body)
-
-
-def _get_linked_policies(conn, issue_id: int, issue) -> list[dict]:
-    """Gather all linked policies: direct FK + program + junction table."""
-    linked = []
-    seen_ids = set()
-
-    _pol_cols = """
-        p.id, p.policy_uid, p.policy_type, p.carrier, p.premium,
-        p.expiration_date, p.renewal_status, p.is_opportunity,
-        p.program_id, pr.name AS location_name,
-        pg.program_uid, pg.name AS program_name
-    """
-    _pol_joins = """
-        LEFT JOIN projects pr ON pr.id = p.project_id
-        LEFT JOIN programs pg ON pg.id = p.program_id
-    """
-
-    # Direct FK
-    if issue and issue["policy_id"]:
-        rows = conn.execute(f"""
-            SELECT {_pol_cols} FROM policies p {_pol_joins}
-            WHERE p.id = ? AND p.archived = 0
-        """, (issue["policy_id"],)).fetchall()
-        for r in rows:
-            d = dict(r)
-            seen_ids.add(d["id"])
-            linked.append(d)
-
-    # Program siblings
-    if issue and issue["program_id"]:
-        rows = conn.execute(f"""
-            SELECT {_pol_cols} FROM policies p {_pol_joins}
-            WHERE p.program_id = ? AND p.archived = 0
-            ORDER BY p.policy_type
-        """, (issue["program_id"],)).fetchall()
-        for r in rows:
-            d = dict(r)
-            if d["id"] not in seen_ids:
-                seen_ids.add(d["id"])
-                linked.append(d)
-
-    # Junction table
-    rows = conn.execute(f"""
-        SELECT {_pol_cols} FROM issue_policies ip
-        JOIN policies p ON p.id = ip.policy_id
-        {_pol_joins}
-        WHERE ip.issue_id = ? AND p.archived = 0
-        ORDER BY p.policy_uid
-    """, (issue_id,)).fetchall()
-    for r in rows:
-        d = dict(r)
-        if d["id"] not in seen_ids:
-            d["_junction"] = True
-            seen_ids.add(d["id"])
-            linked.append(d)
-
-    # Inherit from merged-in source issues (direct FK + program + junction)
-    merged_sources = conn.execute("""
-        SELECT id, policy_id, program_id FROM activity_log
-        WHERE merged_into_id = ? AND item_kind = 'issue'
-    """, (issue_id,)).fetchall()
-    for src in merged_sources:
-        if src["policy_id"]:
-            rows = conn.execute(f"""
-                SELECT {_pol_cols} FROM policies p {_pol_joins}
-                WHERE p.id = ? AND p.archived = 0
-            """, (src["policy_id"],)).fetchall()
-            for r in rows:
-                d = dict(r)
-                if d["id"] not in seen_ids:
-                    d["_from_merge"] = True
-                    seen_ids.add(d["id"])
-                    linked.append(d)
-        if src["program_id"]:
-            rows = conn.execute(f"""
-                SELECT {_pol_cols} FROM policies p {_pol_joins}
-                WHERE p.program_id = ? AND p.archived = 0
-                ORDER BY p.policy_type
-            """, (src["program_id"],)).fetchall()
-            for r in rows:
-                d = dict(r)
-                if d["id"] not in seen_ids:
-                    d["_from_merge"] = True
-                    seen_ids.add(d["id"])
-                    linked.append(d)
-        rows = conn.execute(f"""
-            SELECT {_pol_cols} FROM issue_policies ip
-            JOIN policies p ON p.id = ip.policy_id
-            {_pol_joins}
-            WHERE ip.issue_id = ? AND p.archived = 0
-            ORDER BY p.policy_uid
-        """, (src["id"],)).fetchall()
-        for r in rows:
-            d = dict(r)
-            if d["id"] not in seen_ids:
-                d["_from_merge"] = True
-                seen_ids.add(d["id"])
-                linked.append(d)
-
-    return linked
 
 
 # ── Issue detail page ────────────────────────────────────────────────────────
@@ -937,8 +837,11 @@ def issue_detail(
                 ORDER BY pt.ideal_date
             """, (issue["program_id"],)).fetchall()]
 
-    # Linked policies: direct FK + program siblings + junction table
-    linked_policies = _get_linked_policies(conn, issue_id, issue)
+    # Linked policies + scope rollup (RFI, checklist, timeline accountability,
+    # renewal status, open follow-ups, contacts, working notes, nested issues).
+    # Single call replaces the old _get_linked_policies() helper.
+    issue_rollup = get_issue_rollup(conn, issue_id)
+    linked_policies = issue_rollup["policies"]
 
     # Build bind subjects from linked policies. Group policies that share a
     # program_uid into a single program: token (so program children render as
@@ -968,6 +871,7 @@ def issue_detail(
         "merged_from_issues": merged_from_issues,
         "merged_from_flash": merged_from or "",
         "linked_policies": linked_policies,
+        "issue_rollup": issue_rollup,
         "bind_subjects_csv": bind_subjects_csv,
         "issue_lifecycle_states": cfg.get("issue_lifecycle_states", []),
         "issue_severities": cfg.get("issue_severities", []),

--- a/src/policydb/web/routes/programs.py
+++ b/src/policydb/web/routes/programs.py
@@ -23,6 +23,7 @@ from policydb.queries import (
     get_or_create_contact, get_program_contacts, assign_contact_to_program,
     remove_contact_from_program, set_program_placement_colleague,
     get_program_underwriter_rollup,
+    get_program_rollup,
 )
 from policydb.web.app import get_db, templates
 
@@ -221,6 +222,8 @@ def program_tab_overview(
         LIMIT 1
     """, (f"program:{program_uid}",)).fetchone()
 
+    program_rollup = get_program_rollup(conn, program["id"])
+
     return templates.TemplateResponse("programs/_tab_overview.html", {
         "request": request,
         "program": program,
@@ -236,6 +239,8 @@ def program_tab_overview(
         "all_clients": all_clients,
         "issue_severities": cfg.get("issue_severities", []),
         "renewal_issue": dict(renewal_issue) if renewal_issue else None,
+        "program_rollup": program_rollup,
+        "rollup_client_id": program["client_id"],
     })
 
 

--- a/src/policydb/web/templates/issues/_scope_rollup.html
+++ b/src/policydb/web/templates/issues/_scope_rollup.html
@@ -1,0 +1,308 @@
+{# ─────────────────────────────────────────────────────────────────────────
+ # Scope Rollup panel — shared by issue detail + program detail.
+ #
+ # Expects one of these in template context:
+ #   issue_rollup  — set on the issue detail page
+ #   program_rollup — set on the program detail page
+ # One or the other, not both. Resolves into local `rollup` below.
+ #
+ # Optional context vars:
+ #   rollup_client_id — used for "View →" RFI link target
+ #   rollup_hide_nested — truthy to hide the nested issues sub-section
+ #                        (program page sets this because program-level open
+ #                         issues already have a dedicated section)
+ ────────────────────────────────────────────────────────────────────────── #}
+{% set rollup = issue_rollup if issue_rollup is defined and issue_rollup else (program_rollup if program_rollup is defined and program_rollup else None) %}
+{% if rollup and rollup.policies %}
+{% set _fin = rollup.financials %}
+{% set _rfi = rollup.rfi %}
+{% set _check = rollup.checklist %}
+{% set _wait = rollup.timeline_accountability.waiting %}
+{% set _rstat = rollup.renewal_status %}
+{% set _fu = rollup.open_followups %}
+{% set _contacts = rollup.contacts %}
+{% set _notes = rollup.working_notes %}
+{% set _nested = rollup.nested_issues %}
+{% set _multi = rollup.policies | length > 1 %}
+
+<div class="card">
+  <div class="px-4 py-2.5 bg-gray-50 border-b border-gray-200 flex items-center justify-between">
+    <span class="text-[10px] font-semibold text-gray-500 uppercase tracking-wide">Scope Rollup</span>
+    <span class="text-[10px] text-gray-400 normal-case">{{ rollup.policies | length }} polic{{ 'y' if rollup.policies | length == 1 else 'ies' }}</span>
+  </div>
+
+  {# ── Stat cards ── #}
+  <div class="grid grid-cols-2 md:grid-cols-4 gap-2 p-3 border-b border-gray-100">
+    {# Open RFIs #}
+    <div class="bg-white border border-gray-200 rounded-md px-3 py-2">
+      <div class="text-[10px] text-gray-400 uppercase tracking-wide mb-0.5">Open RFIs</div>
+      <div class="flex items-baseline gap-1">
+        <span class="text-base font-semibold text-gray-800 tabular-nums">{{ _rfi.received_items }}<span class="text-gray-400">/{{ _rfi.total_items }}</span></span>
+        <span class="text-[10px] text-gray-500">items</span>
+      </div>
+      {% if _rfi.overdue_items %}
+      <div class="text-[10px] text-red-600 mt-0.5 font-medium">{{ _rfi.overdue_items }} overdue</div>
+      {% elif _rfi.total_items == 0 %}
+      <div class="text-[10px] text-gray-300 mt-0.5">No requests</div>
+      {% else %}
+      <div class="text-[10px] text-gray-400 mt-0.5">{{ _rfi.open_bundles }} open bundle{{ '' if _rfi.open_bundles == 1 else 's' }}</div>
+      {% endif %}
+      {% if rollup_client_id %}
+      <a href="/clients/{{ rollup_client_id }}?tab=requests" class="block text-[10px] text-marsh hover:underline mt-1">View →</a>
+      {% endif %}
+    </div>
+
+    {# Checklist #}
+    <div class="bg-white border border-gray-200 rounded-md px-3 py-2">
+      <div class="text-[10px] text-gray-400 uppercase tracking-wide mb-0.5">Checklist</div>
+      <div class="flex items-baseline gap-1">
+        <span class="text-base font-semibold text-gray-800 tabular-nums">{{ _check.done_total }}<span class="text-gray-400">/{{ _check.item_total }}</span></span>
+        <span class="text-[10px] text-gray-500">steps</span>
+      </div>
+      <div class="mt-1 h-1 bg-gray-100 rounded-full overflow-hidden">
+        <div class="h-full bg-emerald-400 transition-all" style="width: {{ _check.percent }}%"></div>
+      </div>
+    </div>
+
+    {# Waiting On #}
+    <div class="bg-white border border-gray-200 rounded-md px-3 py-2">
+      <div class="text-[10px] text-gray-400 uppercase tracking-wide mb-0.5">Waiting On</div>
+      {% if _wait %}
+        {% set _top_label, _top_count = (_wait.items() | list | sort(attribute=1, reverse=true))[0] %}
+        <div class="flex items-baseline gap-1">
+          <span class="text-sm font-semibold text-gray-800 truncate">{{ _top_label }}</span>
+          <span class="text-sm text-amber-600 tabular-nums">({{ _top_count }})</span>
+        </div>
+        {% if _wait | length > 1 %}
+        <div class="text-[10px] text-gray-400 mt-0.5">+{{ (_wait | length) - 1 }} more</div>
+        {% endif %}
+      {% else %}
+        <div class="text-sm text-gray-400">—</div>
+        <div class="text-[10px] text-gray-300 mt-0.5">All in hand</div>
+      {% endif %}
+    </div>
+
+    {# Renewal Status #}
+    <div class="bg-white border border-gray-200 rounded-md px-3 py-2">
+      <div class="text-[10px] text-gray-400 uppercase tracking-wide mb-0.5">Renewal Status</div>
+      {% if _rstat %}
+        {% set _top_s, _top_n = (_rstat.items() | list | sort(attribute=1, reverse=true))[0] %}
+        <div class="flex items-baseline gap-1">
+          <span class="text-sm font-semibold text-gray-800 truncate">{{ _top_s }}</span>
+          <span class="text-sm text-gray-500 tabular-nums">({{ _top_n }}/{{ rollup.policies | length }})</span>
+        </div>
+        {% if _rstat | length > 1 %}
+        <div class="flex flex-wrap gap-1 mt-1">
+          {% for _s, _n in _rstat.items() %}
+          {% if _s != _top_s %}
+          <span class="text-[9px] text-gray-500">{{ _s }} {{ _n }}</span>
+          {% endif %}
+          {% endfor %}
+        </div>
+        {% endif %}
+      {% endif %}
+    </div>
+  </div>
+
+  {# ── Per-policy breakdown table ── #}
+  {% if _multi %}
+  <div class="overflow-x-auto border-b border-gray-100">
+    <table class="w-full text-xs">
+      <thead class="bg-gray-50">
+        <tr class="text-[10px] text-gray-400 uppercase tracking-wide">
+          <th class="text-left px-3 py-1.5 font-medium">Policy</th>
+          <th class="text-left px-3 py-1.5 font-medium">Type</th>
+          <th class="text-right px-3 py-1.5 font-medium">RFI</th>
+          <th class="text-right px-3 py-1.5 font-medium">Checklist</th>
+          <th class="text-left px-3 py-1.5 font-medium">Status</th>
+          <th class="text-right px-3 py-1.5 font-medium">F/U</th>
+          <th class="text-left px-3 py-1.5 font-medium">Health</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for p in rollup.policies %}
+        {% set _pr = _check.by_policy[p.policy_uid] if p.policy_uid in _check.by_policy else {'done':0,'total':0} %}
+        {% set _rfi_p = _rfi.by_policy.get(p.policy_uid, {'open':0,'received':0,'total':0,'overdue':0}) %}
+        {% set _fu_count = namespace(n=0, overdue=0) %}
+        {% for f in _fu.by_policy %}{% if f.policy_uid == p.policy_uid %}{% set _fu_count.n = _fu_count.n + 1 %}{% if f.days_overdue > 0 %}{% set _fu_count.overdue = _fu_count.overdue + 1 %}{% endif %}{% endif %}{% endfor %}
+        <tr class="border-t border-gray-100 hover:bg-gray-50">
+          <td class="px-3 py-1.5">
+            <a href="/policies/{{ p.policy_uid }}/edit" class="font-mono text-marsh hover:underline">{{ p.policy_uid }}</a>
+          </td>
+          <td class="px-3 py-1.5 text-gray-700 truncate max-w-[140px]">{{ p.policy_type or '—' }}</td>
+          <td class="px-3 py-1.5 text-right tabular-nums">
+            {% if _rfi_p.total %}
+              <span class="{% if _rfi_p.overdue %}text-red-600 font-medium{% elif _rfi_p.open %}text-amber-700{% else %}text-gray-500{% endif %}">{{ _rfi_p.received }}/{{ _rfi_p.total }}</span>
+            {% else %}
+              <span class="text-gray-300">—</span>
+            {% endif %}
+          </td>
+          <td class="px-3 py-1.5 text-right tabular-nums text-gray-700">{{ _pr.done }}/{{ _pr.total }}</td>
+          <td class="px-3 py-1.5">
+            {% if p.renewal_status %}
+            <span class="text-[10px] px-1.5 py-0.5 rounded-full
+              {% if p.renewal_status == 'Bound' %}bg-green-100 text-green-700
+              {% elif p.renewal_status == 'In Progress' %}bg-blue-100 text-blue-700
+              {% else %}bg-gray-100 text-gray-600{% endif %}">{{ p.renewal_status }}</span>
+            {% endif %}
+          </td>
+          <td class="px-3 py-1.5 text-right tabular-nums">
+            {% if _fu_count.n %}
+              <span class="{% if _fu_count.overdue %}text-red-600 font-medium{% else %}text-gray-600{% endif %}">
+                {{ _fu_count.n }}{% if _fu_count.overdue %} <span class="text-[9px]">({{ _fu_count.overdue }} od)</span>{% endif %}
+              </span>
+            {% else %}
+              <span class="text-gray-300">—</span>
+            {% endif %}
+          </td>
+          <td class="px-3 py-1.5">
+            {% set _h = p.worst_health or '' %}
+            {% if _h == 'critical' %}
+              <span class="inline-flex items-center gap-1 text-[10px] text-red-700"><span class="w-1.5 h-1.5 rounded-full bg-red-500"></span>Critical</span>
+            {% elif _h == 'at_risk' %}
+              <span class="inline-flex items-center gap-1 text-[10px] text-amber-700"><span class="w-1.5 h-1.5 rounded-full bg-amber-500"></span>At Risk</span>
+            {% elif _h in ('compressed', 'drifting') %}
+              <span class="inline-flex items-center gap-1 text-[10px] text-blue-700"><span class="w-1.5 h-1.5 rounded-full bg-blue-400"></span>{{ _h | replace('_', ' ') | title }}</span>
+            {% elif _h == 'on_track' %}
+              <span class="inline-flex items-center gap-1 text-[10px] text-green-700"><span class="w-1.5 h-1.5 rounded-full bg-green-500"></span>On Track</span>
+            {% else %}
+              <span class="text-gray-300">—</span>
+            {% endif %}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% endif %}
+
+  {# ── Open Follow-ups sub-section ── #}
+  {% if _fu.total %}
+  <div class="px-4 py-3 border-b border-gray-100">
+    <div class="flex items-center justify-between mb-2">
+      <span class="text-[10px] font-semibold text-gray-500 uppercase tracking-wide">Open Follow-ups</span>
+      <span class="text-[10px] text-gray-400">
+        {{ _fu.total }} total{% if _fu.overdue %} &middot; <span class="text-red-600 font-medium">{{ _fu.overdue }} overdue</span>{% endif %}
+      </span>
+    </div>
+    <div class="space-y-1">
+      {% for f in _fu.by_policy %}
+      <div class="flex items-center gap-2 text-xs">
+        <a href="/policies/{{ f.policy_uid }}/edit" class="font-mono text-[10px] text-marsh hover:underline shrink-0">{{ f.policy_uid }}</a>
+        <span class="text-[9px] text-gray-400 uppercase tracking-wide shrink-0">{{ f.source }}</span>
+        <span class="text-gray-700 truncate flex-1">{{ f.subject }}</span>
+        {% if f.days_overdue > 0 %}
+        <span class="text-red-600 font-medium text-[10px] shrink-0">⚠ {{ f.days_overdue }}d overdue</span>
+        {% else %}
+        <span class="text-gray-500 text-[10px] shrink-0">Due {{ f.follow_up_date }}</span>
+        {% endif %}
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+  {% endif %}
+
+  {# ── Contacts sub-section ── #}
+  {% if _contacts.placement_colleagues or _contacts.underwriters %}
+  <div class="px-4 py-3 border-b border-gray-100">
+    <div class="text-[10px] font-semibold text-gray-500 uppercase tracking-wide mb-2">Scope Contacts</div>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+      {% if _contacts.placement_colleagues %}
+      <div>
+        <div class="text-[9px] text-gray-400 uppercase tracking-wide mb-1">Placement Colleagues</div>
+        <div class="flex flex-wrap gap-1">
+          {% for c in _contacts.placement_colleagues %}
+          <a {% if c.email %}href="mailto:{{ c.email }}"{% endif %}
+             title="{{ c.policy_uids | join(', ') }}{% if c.email %} — {{ c.email }}{% endif %}"
+             class="inline-flex items-center gap-1 text-[10px] bg-blue-50 text-blue-700 border border-blue-200 rounded-full px-2 py-0.5 hover:bg-blue-100 transition-colors">
+            {{ c.name }}
+            <span class="font-semibold tabular-nums text-blue-500">· {{ c.policy_uids | length }}</span>
+          </a>
+          {% endfor %}
+        </div>
+      </div>
+      {% endif %}
+      {% if _contacts.underwriters %}
+      <div>
+        <div class="text-[9px] text-gray-400 uppercase tracking-wide mb-1">Underwriters</div>
+        <div class="flex flex-wrap gap-1">
+          {% for c in _contacts.underwriters %}
+          <a {% if c.email %}href="mailto:{{ c.email }}"{% endif %}
+             title="{{ c.policy_uids | join(', ') }}{% if c.carrier %} — {{ c.carrier }}{% endif %}{% if c.email %} — {{ c.email }}{% endif %}"
+             class="inline-flex items-center gap-1 text-[10px] bg-violet-50 text-violet-700 border border-violet-200 rounded-full px-2 py-0.5 hover:bg-violet-100 transition-colors">
+            {{ c.name }}{% if c.carrier %} <span class="text-violet-400">· {{ c.carrier }}</span>{% endif %}
+            <span class="font-semibold tabular-nums text-violet-500">· {{ c.policy_uids | length }}</span>
+          </a>
+          {% endfor %}
+        </div>
+      </div>
+      {% endif %}
+    </div>
+  </div>
+  {% endif %}
+
+  {# ── Working Notes sub-section (collapsed by default) ── #}
+  {% if _notes %}
+  <details class="px-4 py-3 border-b border-gray-100">
+    <summary class="flex items-center justify-between cursor-pointer text-[10px] font-semibold text-gray-500 uppercase tracking-wide hover:text-gray-700">
+      <span>Working Notes ({{ _notes | length }})</span>
+      <span class="text-gray-300 text-[9px] normal-case">click to expand</span>
+    </summary>
+    <div class="mt-2 space-y-3">
+      {% for n in _notes %}
+      <div>
+        <div class="flex items-center gap-2 mb-1">
+          <a href="/policies/{{ n.policy_uid }}/edit" class="font-mono text-[10px] text-marsh hover:underline">{{ n.policy_uid }}</a>
+          <span class="text-[10px] text-gray-500">{{ n.policy_type or '' }}</span>
+        </div>
+        {% if n.notes %}
+        <div class="text-xs text-gray-700 whitespace-pre-wrap font-mono bg-gray-50 rounded px-2 py-1.5 border border-gray-100">{{ n.notes }}</div>
+        {% endif %}
+        {% if n.project_scratchpad %}
+        <div class="text-xs text-gray-700 whitespace-pre-wrap font-mono bg-amber-50/40 rounded px-2 py-1.5 border border-amber-100 mt-1">
+          <span class="text-[9px] text-amber-700 uppercase tracking-wide block mb-0.5">Project note</span>
+          {{ n.project_scratchpad }}
+        </div>
+        {% endif %}
+        {% if n.has_more %}
+        <a href="/policies/{{ n.policy_uid }}/edit" class="text-[10px] text-marsh hover:underline">Read more →</a>
+        {% endif %}
+      </div>
+      {% endfor %}
+    </div>
+  </details>
+  {% endif %}
+
+  {# ── Nested Issues sub-section ── #}
+  {% if _nested and not rollup_hide_nested %}
+  <div class="px-4 py-3">
+    <div class="flex items-center justify-between mb-2">
+      <span class="text-[10px] font-semibold text-gray-500 uppercase tracking-wide">Other Open Issues</span>
+      <span class="text-[10px] text-gray-400">{{ _nested | length }} touching scope</span>
+    </div>
+    <div class="space-y-1">
+      {% for ni in _nested %}
+      <div class="flex items-center gap-2 text-xs">
+        {% set sev = ni.issue_severity or 'Normal' %}
+        <span class="w-2 h-2 rounded-full shrink-0
+          {% if sev == 'Critical' %}bg-red-500
+          {% elif sev == 'High' %}bg-amber-500
+          {% elif sev == 'Normal' %}bg-blue-400
+          {% else %}bg-gray-300{% endif %}"></span>
+        <a href="/issues/{{ ni.issue_uid }}" class="font-mono text-[10px] text-marsh hover:underline shrink-0">{{ ni.issue_uid }}</a>
+        <span class="text-gray-700 truncate flex-1">{{ ni.subject }}</span>
+        {% if ni.issue_status %}
+        <span class="text-[9px] px-1.5 py-0.5 rounded-full shrink-0
+          {% if ni.issue_status == 'Open' %}bg-blue-50 text-blue-700
+          {% elif ni.issue_status == 'Waiting' %}bg-amber-50 text-amber-700
+          {% elif ni.issue_status == 'In Hand' %}bg-purple-50 text-purple-700
+          {% else %}bg-gray-50 text-gray-600{% endif %}">{{ ni.issue_status }}</span>
+        {% endif %}
+        <span class="text-[9px] text-gray-400 shrink-0">{{ ni.policy_uids | join(', ') }}</span>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+  {% endif %}
+</div>
+{% endif %}

--- a/src/policydb/web/templates/issues/detail.html
+++ b/src/policydb/web/templates/issues/detail.html
@@ -114,6 +114,17 @@
     {% endif %}
     <span class="text-gray-300">&middot;</span>
     <span>{{ activities|length }} activit{{ 'y' if activities|length == 1 else 'ies' }}{% if total_hours %} &middot; {{ total_hours | format_hours }}{% endif %}</span>
+    {% if issue_rollup and issue_rollup.financials.policy_count %}
+    {% set _fin = issue_rollup.financials %}
+    <span class="text-gray-300">&middot;</span>
+    <span class="text-gray-600 tabular-nums">
+      {{ _fin.total_premium | currency_short }} prem
+      {% if _fin.total_exposure %}&middot; {{ _fin.total_exposure | currency_short }} exp{% endif %}
+      {% if _fin.policy_count > 1 %}
+      &middot; <span class="{% if _fin.at_risk_count > 0 %}text-amber-700 font-medium{% else %}text-green-700{% endif %}">{{ _fin.at_risk_count }}/{{ _fin.policy_count }} at risk</span>
+      {% endif %}
+    </span>
+    {% endif %}
   </div>
 
   {# ── Status pill control ── #}
@@ -378,6 +389,12 @@
         </div>
       </div>
 
+      {# ── Scope Rollup ── #}
+      {% if issue_rollup and linked_policies %}
+      {% set rollup_client_id = issue.client_id %}
+      {% include "issues/_scope_rollup.html" %}
+      {% endif %}
+
       {# ── Files & Attachments ── #}
       <div class="card p-4">
         <div class="text-[10px] text-gray-400 uppercase tracking-wide mb-2">Files & Attachments</div>
@@ -483,6 +500,17 @@
           <span class="text-[10px] text-emerald-800 uppercase tracking-wide font-semibold">Timeline Milestones</span>
           <span class="inline-flex items-center text-[9px] font-medium bg-emerald-50 text-emerald-700 border border-emerald-200 rounded-full px-1.5 py-0.5">Renewal Issue</span>
         </div>
+        {% if issue_rollup and issue_rollup.timeline_accountability.waiting %}
+        <div class="flex flex-wrap gap-1 mb-2">
+          {% for label, n in issue_rollup.timeline_accountability.waiting.items() %}
+          <span class="inline-flex items-center gap-1 text-[10px] bg-amber-50 text-amber-700 border border-amber-200 rounded-full px-2 py-0.5">
+            <svg class="w-2.5 h-2.5" fill="currentColor" viewBox="0 0 20 20"><circle cx="10" cy="10" r="6"/></svg>
+            {{ label }}
+            <span class="font-semibold tabular-nums">{{ n }}</span>
+          </span>
+          {% endfor %}
+        </div>
+        {% endif %}
         <div class="text-[10px] text-gray-400 mb-2">Severity auto-managed by timeline health</div>
         <div class="space-y-1.5">
           {% for ms in timeline_milestones %}

--- a/src/policydb/web/templates/programs/_tab_overview.html
+++ b/src/policydb/web/templates/programs/_tab_overview.html
@@ -7,6 +7,14 @@
   <span><strong class="text-gray-700">{{ aggregates.total_premium | currency }}</strong> total premium</span>
 </div>
 
+{# -- Workflow Snapshot (Scope Rollup) -- #}
+{% if program_rollup and program_rollup.policies %}
+<div class="mb-4">
+  {% set rollup_hide_nested = true %}
+  {% include "issues/_scope_rollup.html" %}
+</div>
+{% endif %}
+
 {# -- Renewal Issue Banner (if active) -- #}
 {% if renewal_issue %}
 {% set ri_sev = renewal_issue.issue_severity or 'Normal' %}


### PR DESCRIPTION
## Summary

- Renewal issue detail and program overview now surface what's happening across all linked policies in a single **Scope Rollup** panel — open RFI items, checklist progress, timeline accountability ("waiting on" summary), renewal status breakdown, open follow-ups, distinct placement colleagues and underwriters, working notes, nested child-policy issues, plus a premium/exposure header stat.
- Replaces policy-by-policy tab-hopping during mid-renewal status checks. For a program renewal covering 10 children, a single glance now answers "what's still missing?" and "who are we waiting on?"
- New shared `get_issue_rollup()` / `get_program_rollup()` helpers in `queries.py` share private aggregators so both pages produce identical shapes from one code path.

## What's in the rollup

Stat cards: **Open RFIs** · **Checklist** · **Waiting On** · **Renewal Status**
Per-policy table (shown when > 1 linked policy): Policy · Type · RFI · Checklist · Status · Open F/U · Health
Sub-sections: **Open Follow-ups** (policy-level not tied to the issue) · **Scope Contacts** (placement colleagues + underwriters deduped across policies) · **Working Notes** (collapsed) · **Other Open Issues** (nested, issue page only) · **Waiting Summary pills** on the Timeline Milestones sidebar card

## Test plan

- [x] Standalone policy issue with RFI data — stat cards populated, per-policy table hidden
- [x] Program renewal issue covering 15 child policies — all stat cards + per-policy breakdown table render
- [x] Rich issue with open follow-ups, multiple contacts, and nested issues — all sub-sections render correctly
- [x] Program detail Overview tab — Workflow Snapshot section renders with `rollup_hide_nested=true`
- [x] Financial header stat shows premium + exposure + at-risk count on program issues
- [x] Working notes sub-section collapsed by default, expand/collapse works
- [x] Contact pills with email open `mailto:`; tooltip shows affected policy UIDs
- [x] Standalone issue with single policy hides per-policy table (single-row case)
- [x] No Jinja errors, no layout overflow, pills wrap on narrow viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)