### PR TITLE
Scope Rollup View link opens filtered RFI list

### DIFF
--- a/src/policydb/queries.py
+++ b/src/policydb/queries.py
@@ -5411,3 +5411,96 @@ def get_program_rollup(conn: sqlite3.Connection, program_id: int) -> dict:
     """
     linked = get_linked_policies_for_program(conn, program_id)
     return _build_rollup(conn, linked, exclude_issue_id=None)
+
+
+def get_scoped_rfi_bundles(
+    conn: sqlite3.Connection, client_id: int, policy_uids: list[str]
+) -> list[dict]:
+    """Return client request bundles with items filtered to a set of policies.
+
+    Bundles with zero in-scope items are omitted so the scoped page only
+    surfaces bundles that actually touch the scope. Each returned bundle has
+    an `items` list (in-scope items only), plus `scoped_total`, `scoped_done`,
+    and `scoped_pct` counts computed over the filtered set.
+    """
+    if not policy_uids:
+        return []
+
+    uid_ph = ",".join("?" * len(policy_uids))
+    rows = conn.execute(
+        f"""SELECT b.id AS bundle_id, b.rfi_uid, b.title, b.status, b.send_by_date,
+                   b.created_at, b.updated_at, b.sent_at, b.notes AS bundle_notes,
+                   b.client_id,
+                   i.id AS item_id, i.description, i.policy_uid, i.project_name,
+                   i.category, i.received, i.received_at, i.notes, i.sort_order,
+                   p.policy_type, p.carrier
+            FROM client_request_bundles b
+            JOIN client_request_items i ON i.bundle_id = b.id
+            LEFT JOIN policies p ON p.policy_uid = i.policy_uid
+            WHERE b.client_id = ?
+              AND i.policy_uid IN ({uid_ph})
+            ORDER BY
+                CASE b.status WHEN 'open' THEN 0 WHEN 'sent' THEN 1 WHEN 'partial' THEN 2 ELSE 3 END,
+                b.updated_at DESC,
+                i.received ASC, i.sort_order ASC, i.id ASC""",  # noqa: S608
+        [client_id] + list(policy_uids),
+    ).fetchall()
+
+    bundles_by_id: dict[int, dict] = {}
+    for r in rows:
+        bid = r["bundle_id"]
+        b = bundles_by_id.get(bid)
+        if b is None:
+            b = {
+                "id": bid,
+                "rfi_uid": r["rfi_uid"],
+                "title": r["title"],
+                "status": r["status"],
+                "send_by_date": r["send_by_date"],
+                "created_at": r["created_at"],
+                "updated_at": r["updated_at"],
+                "sent_at": r["sent_at"],
+                "notes": r["bundle_notes"],
+                "client_id": r["client_id"],
+                "items": [],
+                "scoped_total": 0,
+                "scoped_done": 0,
+            }
+            bundles_by_id[bid] = b
+        b["items"].append(
+            {
+                "id": r["item_id"],
+                "description": r["description"],
+                "policy_uid": r["policy_uid"],
+                "project_name": r["project_name"],
+                "category": r["category"],
+                "received": r["received"],
+                "received_at": r["received_at"],
+                "notes": r["notes"],
+                "sort_order": r["sort_order"],
+                "policy_type": r["policy_type"],
+                "carrier": r["carrier"],
+            }
+        )
+        b["scoped_total"] += 1
+        if r["received"]:
+            b["scoped_done"] += 1
+
+    out: list[dict] = []
+    for b in bundles_by_id.values():
+        b["scoped_pct"] = int(round(100 * b["scoped_done"] / b["scoped_total"])) if b["scoped_total"] else 0
+        out.append(b)
+    out.sort(
+        key=lambda b: (
+            {"open": 0, "sent": 1, "partial": 2}.get(b["status"], 3),
+            b.get("updated_at") or "",
+        ),
+        reverse=False,
+    )
+    # Within each status bucket we want newest-updated first; do a stable
+    # secondary sort on updated_at desc to achieve that.
+    out.sort(key=lambda b: (b.get("updated_at") or ""), reverse=True)
+    out.sort(
+        key=lambda b: {"open": 0, "sent": 1, "partial": 2}.get(b["status"], 3)
+    )
+    return out

--- a/src/policydb/web/routes/issues.py
+++ b/src/policydb/web/routes/issues.py
@@ -15,6 +15,7 @@ from policydb.queries import (
     auto_close_followups,
     get_issue_rollup,
     get_linked_policies_for_issue,
+    get_scoped_rfi_bundles,
 )
 from policydb.utils import round_duration
 from policydb.web.app import get_db, templates
@@ -885,6 +886,51 @@ def issue_detail(
         "checklist_items": _get_issue_checklist(conn, issue_id),
     }
     return templates.TemplateResponse("issues/detail.html", ctx)
+
+
+# ── Scoped RFI view: filtered to the issue's linked policies ────────────────
+
+
+@router.get("/issues/{issue_uid}/rfi", response_class=HTMLResponse)
+def issue_rfi_scoped(
+    issue_uid: str,
+    request: Request,
+    conn=Depends(get_db),
+):
+    """Filtered RFI list scoped to the policies linked to this issue.
+
+    Rendered as a standalone page reachable from the Scope Rollup "View →"
+    link on the issue detail page. Bundles with no items in scope are
+    omitted so the user sees only what's relevant.
+    """
+    issue = conn.execute(
+        """SELECT a.id, a.issue_uid, a.subject, a.client_id,
+                  c.name AS client_name
+           FROM activity_log a
+           LEFT JOIN clients c ON c.id = a.client_id
+           WHERE a.issue_uid = ? AND a.item_kind = 'issue'""",
+        (issue_uid,),
+    ).fetchone()
+    if not issue:
+        return RedirectResponse("/action-center?tab=issues", status_code=303)
+
+    linked = get_linked_policies_for_issue(conn, issue["id"])
+    scope_uids = [p["policy_uid"] for p in linked if p.get("policy_uid")]
+    bundles = get_scoped_rfi_bundles(conn, issue["client_id"], scope_uids) if scope_uids else []
+
+    ctx = {
+        "request": request,
+        "active": "action-center",
+        "client": {"id": issue["client_id"], "name": issue["client_name"]},
+        "bundles": bundles,
+        "scope_label": f"Issue {issue['issue_uid']} — {issue['subject']}",
+        "scope_back_url": f"/issues/{issue['issue_uid']}",
+        "scope_back_label": "Back to issue",
+        "scope_policies": linked,
+        "today_iso": date.today().isoformat(),
+        "request_categories": cfg.get("request_categories", []),
+    }
+    return templates.TemplateResponse("clients/rfi_scoped.html", ctx)
 
 
 # ── Log activity against issue ───────────────────────────────────────────────

--- a/src/policydb/web/routes/programs.py
+++ b/src/policydb/web/routes/programs.py
@@ -24,6 +24,8 @@ from policydb.queries import (
     remove_contact_from_program, set_program_placement_colleague,
     get_program_underwriter_rollup,
     get_program_rollup,
+    get_linked_policies_for_program,
+    get_scoped_rfi_bundles,
 )
 from policydb.web.app import get_db, templates
 
@@ -109,6 +111,36 @@ async def create_program_v2(
     logger.info("Created program v2 '%s' (%s) for client %d", name, uid, client_id)
 
     return JSONResponse({"ok": True, "redirect": f"/programs/{uid}"})
+
+
+@router.get("/programs/{program_uid}/rfi", response_class=HTMLResponse)
+def program_rfi_scoped(
+    request: Request,
+    program_uid: str,
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    """Filtered RFI list scoped to all child policies of a program."""
+    program = get_program_by_uid(conn, program_uid)
+    if not program:
+        return HTMLResponse("Program not found", status_code=404)
+    client = conn.execute(
+        "SELECT id, name FROM clients WHERE id = ?", (program["client_id"],)
+    ).fetchone()
+    linked = get_linked_policies_for_program(conn, program["id"])
+    scope_uids = [p["policy_uid"] for p in linked if p.get("policy_uid")]
+    bundles = get_scoped_rfi_bundles(conn, program["client_id"], scope_uids) if scope_uids else []
+    return templates.TemplateResponse("clients/rfi_scoped.html", {
+        "request": request,
+        "active": "clients",
+        "client": dict(client) if client else {"id": program["client_id"], "name": ""},
+        "bundles": bundles,
+        "scope_label": f"Program {program['program_uid']} — {program['name']}",
+        "scope_back_url": f"/programs/{program['program_uid']}",
+        "scope_back_label": "Back to program",
+        "scope_policies": linked,
+        "today_iso": date.today().isoformat(),
+        "request_categories": cfg.get("request_categories", []),
+    })
 
 
 @router.get("/programs/{program_uid}", response_class=HTMLResponse)

--- a/src/policydb/web/templates/clients/rfi_scoped.html
+++ b/src/policydb/web/templates/clients/rfi_scoped.html
@@ -1,0 +1,167 @@
+{% extends "base.html" %}
+{% block title %}RFI — {{ scope_label }}{% endblock %}
+
+{% block content %}
+<div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+
+  {# ── Breadcrumb ── #}
+  <div class="flex items-center gap-2 text-xs text-gray-500 mb-2">
+    <a href="{{ scope_back_url }}" class="hover:text-marsh">&larr; {{ scope_back_label }}</a>
+    <span class="text-gray-300">|</span>
+    <a href="/clients/{{ client.id }}" class="hover:text-marsh">{{ client.name }}</a>
+    <span class="text-gray-300">|</span>
+    <span class="text-gray-700">RFI (filtered)</span>
+  </div>
+
+  {# ── Page header ── #}
+  <div class="flex items-start justify-between gap-4 mb-4">
+    <div class="flex-1 min-w-0">
+      <h1 class="text-xl font-semibold text-gray-900">Information Requests</h1>
+      <div class="text-sm text-gray-500 mt-0.5">
+        Filtered to <span class="font-medium text-gray-700">{{ scope_label }}</span>
+      </div>
+    </div>
+    <a href="/clients/{{ client.id }}?tab=requests"
+       class="shrink-0 text-xs text-marsh hover:underline self-center">View all client RFIs &rarr;</a>
+  </div>
+
+  {# ── Scope banner ── #}
+  {% set _total_items = bundles | sum(attribute='scoped_total') %}
+  {% set _done_items = bundles | sum(attribute='scoped_done') %}
+  {% set _pct = (_done_items / _total_items * 100) | round(0) | int if _total_items > 0 else 0 %}
+  <div class="bg-amber-50/60 border border-amber-200 rounded-lg px-4 py-3 mb-4">
+    <div class="flex items-center justify-between gap-4 flex-wrap">
+      <div class="text-xs text-amber-900">
+        <span class="font-semibold">{{ bundles | length }}</span> bundle{{ 's' if bundles | length != 1 else '' }}
+        with items in scope &middot;
+        <span class="font-semibold tabular-nums">{{ _done_items }}/{{ _total_items }}</span> items received
+        {% if scope_policies %}
+        &middot; across <span class="font-semibold">{{ scope_policies | length }}</span> polic{{ 'y' if scope_policies | length == 1 else 'ies' }}
+        {% endif %}
+      </div>
+      {% if _total_items > 0 %}
+      <div class="flex items-center gap-2 shrink-0">
+        <div class="w-32 bg-amber-100 rounded-full h-2">
+          <div class="bg-amber-500 rounded-full h-2 transition-all" style="width: {{ _pct }}%"></div>
+        </div>
+        <span class="text-[10px] text-amber-800 tabular-nums">{{ _pct }}%</span>
+      </div>
+      {% endif %}
+    </div>
+    {% if scope_policies %}
+    <div class="flex flex-wrap gap-1 mt-2">
+      {% for p in scope_policies %}
+      <a href="/policies/{{ p.policy_uid }}/edit"
+         class="inline-flex items-center gap-1 text-[10px] bg-white border border-amber-200 text-amber-800 rounded-full px-2 py-0.5 hover:bg-amber-100">
+        <span class="font-mono">{{ p.policy_uid }}</span>
+        <span class="text-amber-400">·</span>
+        <span>{{ p.policy_type or '' }}</span>
+      </a>
+      {% endfor %}
+    </div>
+    {% endif %}
+  </div>
+
+  {# ── Bundles ── #}
+  {% if bundles %}
+  <div class="space-y-3">
+    {% for b in bundles %}
+    <div class="card">
+      {# Bundle header #}
+      <div class="flex items-center gap-3 px-4 py-2.5 bg-gray-50/50 border-b border-gray-100">
+        {% if b.rfi_uid %}
+        <button type="button" onclick="copyRefTag(this, '{{ b.rfi_uid }}')"
+          class="text-xs font-mono font-semibold text-marsh hover:text-marsh-light shrink-0 no-print"
+          title="Click to copy">{{ b.rfi_uid }}</button>
+        {% endif %}
+        <span class="text-sm font-medium text-gray-800 flex-1 min-w-0 truncate">{{ b.title }}</span>
+        {% if b.status == 'open' %}
+          <span class="text-[10px] bg-amber-100 text-amber-700 px-2 py-0.5 rounded font-medium">Open</span>
+          {% if not b.send_by_date %}
+          <span class="text-[10px] bg-amber-100 text-amber-700 px-2 py-0.5 rounded font-medium" title="Open to set a send-by date">⚠ No deadline</span>
+          {% elif b.send_by_date < today_iso %}
+          <span class="text-[10px] bg-red-100 text-red-600 px-2 py-0.5 rounded font-medium whitespace-nowrap">⚠ Overdue &middot; due {{ b.send_by_date }}</span>
+          {% else %}
+          <span class="text-[10px] text-gray-400 whitespace-nowrap">due {{ b.send_by_date }}</span>
+          {% endif %}
+        {% elif b.status == 'sent' %}
+          <span class="text-[10px] bg-blue-100 text-blue-700 px-2 py-0.5 rounded font-medium">Sent</span>
+        {% elif b.status == 'partial' %}
+          <span class="text-[10px] bg-purple-100 text-purple-700 px-2 py-0.5 rounded font-medium">Partial</span>
+        {% elif b.status == 'complete' %}
+          <span class="text-[10px] bg-green-100 text-green-700 px-2 py-0.5 rounded font-medium">Complete</span>
+        {% endif %}
+        <span class="text-xs text-gray-400 tabular-nums shrink-0">{{ b.scoped_done }}/{{ b.scoped_total }} in scope</span>
+        {% if b.scoped_total > 0 %}
+        <div class="w-16 bg-gray-200 rounded-full h-1.5 shrink-0">
+          <div class="bg-green-500 rounded-full h-1.5 transition-all" style="width: {{ b.scoped_pct }}%"></div>
+        </div>
+        {% endif %}
+        <a href="/clients/{{ client.id }}/requests/{{ b.id }}"
+           class="text-[10px] text-marsh hover:underline no-print shrink-0">Open full bundle &rarr;</a>
+      </div>
+
+      {# In-scope items #}
+      <div class="p-4 space-y-2">
+        {% for item in b['items'] %}
+        {% set bundle = b %}
+        {% include "clients/_request_item.html" %}
+        {% endfor %}
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+  {% else %}
+  <div class="card p-8 text-center">
+    <p class="text-sm text-gray-500">
+      No RFI items are linked to the policies in this scope.
+    </p>
+    <a href="/clients/{{ client.id }}?tab=requests"
+       class="inline-block mt-3 text-xs text-marsh hover:underline">Create a bundle on the client page &rarr;</a>
+  </div>
+  {% endif %}
+</div>
+
+{# Contenteditable save handler — mirrors the one in _request_policy_view.html so
+   description and notes fields persist on blur. Scoped to the page root. #}
+<script>
+(function() {
+  var root = document.querySelector('main') || document.body;
+  var CID = '{{ client.id }}';
+
+  root.addEventListener('focusout', function(e) {
+    var cell = e.target.closest('[data-field]');
+    if (!cell || !cell.hasAttribute('contenteditable')) return;
+    var itemEl = cell.closest('[data-item-id]');
+    if (!itemEl) return;
+    var itemId = itemEl.dataset.itemId;
+    var bundleEl = itemEl.closest('.card');
+    // Find bundle id from the "Open full bundle" link href
+    var bid = '';
+    if (bundleEl) {
+      var link = bundleEl.querySelector('a[href*="/requests/"]');
+      if (link) {
+        var m = link.getAttribute('href').match(/\/requests\/(\d+)/);
+        if (m) bid = m[1];
+      }
+    }
+    if (!bid) return;
+    var field = cell.dataset.field;
+    var val = cell.innerText.trim();
+    if (val === (cell.dataset.original || '')) return;
+    fetch('/clients/' + CID + '/requests/' + bid + '/items/' + itemId, {
+      method: 'PATCH',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({field: field, value: val})
+    });
+  });
+
+  root.addEventListener('focusin', function(e) {
+    var cell = e.target.closest('[data-field]');
+    if (cell && cell.hasAttribute('contenteditable')) {
+      cell.dataset.original = cell.innerText.trim();
+    }
+  });
+})();
+</script>
+{% endblock %}

--- a/src/policydb/web/templates/issues/_scope_rollup.html
+++ b/src/policydb/web/templates/issues/_scope_rollup.html
@@ -7,12 +7,25 @@
  # One or the other, not both. Resolves into local `rollup` below.
  #
  # Optional context vars:
- #   rollup_client_id — used for "View →" RFI link target
+ #   rollup_client_id — used as a fallback for the "View →" RFI link target
+ #   rollup_rfi_href  — full URL for the "View →" RFI link (scoped page);
+ #                      auto-derived from issue/program context if not set
  #   rollup_hide_nested — truthy to hide the nested issues sub-section
  #                        (program page sets this because program-level open
  #                         issues already have a dedicated section)
  ────────────────────────────────────────────────────────────────────────── #}
 {% set rollup = issue_rollup if issue_rollup is defined and issue_rollup else (program_rollup if program_rollup is defined and program_rollup else None) %}
+{% if rollup_rfi_href is not defined or not rollup_rfi_href %}
+  {% if issue_rollup is defined and issue_rollup and issue is defined %}
+    {% set rollup_rfi_href = '/issues/' ~ issue.issue_uid ~ '/rfi' %}
+  {% elif program_rollup is defined and program_rollup and program is defined %}
+    {% set rollup_rfi_href = '/programs/' ~ program.program_uid ~ '/rfi' %}
+  {% elif rollup_client_id %}
+    {% set rollup_rfi_href = '/clients/' ~ rollup_client_id ~ '?tab=requests' %}
+  {% else %}
+    {% set rollup_rfi_href = '' %}
+  {% endif %}
+{% endif %}
 {% if rollup and rollup.policies %}
 {% set _fin = rollup.financials %}
 {% set _rfi = rollup.rfi %}
@@ -47,8 +60,8 @@
       {% else %}
       <div class="text-[10px] text-gray-400 mt-0.5">{{ _rfi.open_bundles }} open bundle{{ '' if _rfi.open_bundles == 1 else 's' }}</div>
       {% endif %}
-      {% if rollup_client_id %}
-      <a href="/clients/{{ rollup_client_id }}?tab=requests" class="block text-[10px] text-marsh hover:underline mt-1">View →</a>
+      {% if rollup_rfi_href %}
+      <a href="{{ rollup_rfi_href }}" class="block text-[10px] text-marsh hover:underline mt-1">View →</a>
       {% endif %}
     </div>
 


### PR DESCRIPTION
## Summary

- The "View →" link on the Scope Rollup's Open RFIs stat card now takes users to a filtered RFI list instead of the full client Requests tab.
- New routes: `GET /issues/{uid}/rfi` and `GET /programs/{uid}/rfi` render a dedicated page showing only bundles that contain items touching the linked policies.
- Scope banner shows policies in scope as pills, bundle header shows "X/Y in scope", and all existing item interactions (toggle received, edit description/notes) work via the same endpoints.
- Empty state renders when no in-scope items exist (common for new programs), with a link back to the client page to create a bundle.

## Test plan

- [x] Issue with in-scope RFI items — shows filtered bundle with only matching items
- [x] Program with no RFIs — renders empty state with all policy pills visible
- [x] Per-item actions still work (toggle received, contenteditable description/notes)
- [x] Back link returns to the originating issue / program page
- [x] "View all client RFIs →" escape hatch reaches the full client Requests tab
- [x] Standalone issue with 0 linked policies gracefully returns empty bundle list

🤖 Generated with [Claude Code](https://claude.com/claude-code)