### PR TITLE
Focus Queue: dedup + data-dense metrics strip, retire Follow-ups tab

### DIFF
--- a/src/policydb/focus_queue.py
+++ b/src/policydb/focus_queue.py
@@ -76,6 +76,7 @@ def _normalize_followup(item: dict, today: date) -> dict:
         "policy_uid": item.get("policy_uid"),
         "policy_type": item.get("policy_type"),
         "carrier": item.get("carrier"),
+        "renewal_status": item.get("renewal_status"),
         "subject": item.get("subject") or item.get("reason_line") or "",
         "follow_up_date": fu_date,
         "expiration_date": exp_date,
@@ -88,6 +89,8 @@ def _normalize_followup(item: dict, today: date) -> dict:
         "escalation_tier": item.get("escalation_tier"),
         "nudge_count": item.get("nudge_count", 0),
         "cadence": item.get("cadence"),
+        "days_fu_to_expiry": None,
+        "policy_hours_30d": 0.0,
         "is_milestone": item.get("is_milestone", False),
         "milestone_name": item.get("milestone_name"),
         "project_id": item.get("project_id"),
@@ -1108,6 +1111,94 @@ def build_focus_queue(
             item["contact_person"] = name
         if email:
             item["contact_email"] = email
+
+    # --- Metric enrichment: nudge tier, cadence, hours_30d, fu_to_expiry ---
+    # Previously computed only in _followups_ctx for the legacy Follow-ups tab.
+    # Moving the work here gives Focus Queue rows parity on every "how long has
+    # this been drifting" signal.
+    _policy_uids_with_activity = sorted({
+        item.get("policy_uid") for item in all_items
+        if item.get("policy_uid")
+        and item.get("kind") == "followup"
+        and item.get("source") in ("activity", "project")
+    })
+
+    # Batch-fetch hours logged on each policy in the last 30 days
+    _hours_30d: dict[str, float] = {}
+    if _policy_uids_with_activity:
+        ph = ",".join("?" * len(_policy_uids_with_activity))
+        for row in conn.execute(f"""
+            SELECT p.policy_uid,
+                   COALESCE(SUM(a.duration_hours), 0) AS hours
+            FROM policies p
+            LEFT JOIN activity_log a ON a.policy_id = p.id
+                AND a.duration_hours IS NOT NULL
+                AND a.activity_date >= date('now', '-30 days')
+            WHERE p.policy_uid IN ({ph})
+            GROUP BY p.policy_uid
+        """, _policy_uids_with_activity).fetchall():
+            _hours_30d[row["policy_uid"]] = float(row["hours"] or 0)
+
+    # Nudge tier cache — one compute_nudge_tier call per unique policy
+    _nudge_cache: dict[str, tuple[int, str]] = {}
+
+    # Disposition default_days map for cadence scoring
+    _disp_days_map: dict[str, int] = {}
+    for _d in cfg.get("follow_up_dispositions", []):
+        _label = (_d.get("label") or "").lower()
+        _dd = _d.get("default_days", 0)
+        if _dd and _dd > 0:
+            _disp_days_map[_label] = _dd
+
+    from policydb.queries import compute_nudge_tier
+
+    for item in all_items:
+        puid = item.get("policy_uid")
+
+        # Hours logged on the policy over the last 30 days
+        if puid:
+            item["policy_hours_30d"] = _hours_30d.get(puid, 0.0)
+
+        # Days from follow-up date to policy expiration (negative = already expired)
+        fu = item.get("follow_up_date") or ""
+        exp = item.get("expiration_date") or ""
+        if fu and exp:
+            try:
+                _fu_d = datetime.strptime(fu[:10], "%Y-%m-%d").date()
+                _exp_d = datetime.strptime(exp[:10], "%Y-%m-%d").date()
+                item["days_fu_to_expiry"] = (_exp_d - _fu_d).days
+            except ValueError:
+                pass
+
+        # Nudge tier for waiting items (activity follow-ups only)
+        if (item.get("kind") == "followup"
+                and item.get("source") in ("activity", "project")
+                and item.get("accountability") == "waiting_external"
+                and puid):
+            if puid not in _nudge_cache:
+                try:
+                    _nudge_cache[puid] = compute_nudge_tier(conn, puid)
+                except Exception:
+                    logger.debug("compute_nudge_tier failed for %s", puid, exc_info=True)
+                    _nudge_cache[puid] = (1, "normal")
+            count, tier = _nudge_cache[puid]
+            item["nudge_count"] = count
+            item["escalation_tier"] = tier
+
+        # Cadence vs. disposition default_days (activity/project only)
+        if (item.get("kind") == "followup"
+                and item.get("source") in ("activity", "project")):
+            disp_label = (item.get("disposition") or "").lower()
+            default_days = _disp_days_map.get(disp_label, 0)
+            if default_days > 0:
+                # days_until_deadline < 0 means overdue; cadence_over uses absolute overdue
+                days_over = max(0, -(item.get("days_until_deadline") or 0))
+                if days_over <= default_days:
+                    item["cadence"] = "on_cadence"
+                elif days_over <= default_days * 2:
+                    item["cadence"] = "mild"
+                else:
+                    item["cadence"] = "severe"
 
     # --- Dedup: suppress lower-priority items when higher-priority exists ---
     # Priority: activity follow-up > issue > milestone > suggested > policy follow-up

--- a/src/policydb/focus_queue.py
+++ b/src/policydb/focus_queue.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
+import logging
 import sqlite3
 from datetime import date, datetime, timedelta
 
 import policydb.config as cfg
 from policydb.queries import (
+    auto_close_stale_followups,
     get_all_followups,
     get_insurance_deadline_suggestions,
     get_suggested_followups,
 )
+
+logger = logging.getLogger("policydb.focus_queue")
 
 
 # ---------------------------------------------------------------------------
@@ -912,6 +916,53 @@ def _normalize_opportunity(item: dict, today: date) -> dict:
     }
 
 
+def _dedup_activity_siblings(all_items: list[dict]) -> tuple[list[dict], int]:
+    """Collapse multiple pending activity follow-ups on the same policy.
+
+    When two or more normalized Focus Queue items share the same ``policy_uid``
+    and both have ``kind == 'followup'`` with ``source in ('activity','project')``,
+    keep the one with the *earliest* ``follow_up_date`` (the most urgent /
+    oldest-unresolved), tie-breaking on highest id (most recently written).
+    Drop the rest.
+
+    Why earliest and not latest: the write-side invariant (Step 1 of this
+    cleanup) guarantees new follow-ups supersede old ones, so any surviving
+    duplicates are legacy data where the user manually created overlapping
+    rows. In that case the oldest one represents the real bottleneck, and
+    it is also more likely to survive the downstream time-horizon filter
+    (``horizon_days <= 0`` drops future-dated items).
+
+    Returns ``(kept_items, dropped_count)``.
+    """
+    # Group activity/project followups by policy_uid
+    by_policy: dict[str, list[dict]] = {}
+    other: list[dict] = []
+    for item in all_items:
+        if (item.get("kind") == "followup"
+                and item.get("source") in ("activity", "project")
+                and item.get("policy_uid")):
+            by_policy.setdefault(item["policy_uid"], []).append(item)
+        else:
+            other.append(item)
+
+    kept: list[dict] = list(other)
+    dropped = 0
+    for puid, group in by_policy.items():
+        if len(group) == 1:
+            kept.append(group[0])
+            continue
+        # Winner: earliest follow_up_date (most urgent). Put items with no
+        # date at the end. Tie-break on largest id (most recently written).
+        def _sort_key(x: dict) -> tuple:
+            fu = x.get("follow_up_date") or "9999-99-99"
+            return (fu, -(x.get("id") or 0))
+        group.sort(key=_sort_key)
+        kept.append(group[0])
+        dropped += len(group) - 1
+
+    return kept, dropped
+
+
 def build_focus_queue(
     conn: sqlite3.Connection,
     horizon_days: int = 0,
@@ -935,6 +986,14 @@ def build_focus_queue(
     excluded = cfg.get("renewal_statuses_excluded", [])
     auto_promote_days = cfg.get("focus_auto_promote_days", 14)
     nudge_alert_days = cfg.get("focus_nudge_alert_days", 10)
+
+    # Run the stale sweeper before gathering sources so users who never visit
+    # the legacy Follow-ups tab still get stale auto-close. Idempotent —
+    # already safe to call from multiple request paths.
+    try:
+        auto_close_stale_followups(conn)
+    except Exception:
+        logger.debug("auto_close_stale_followups failed", exc_info=True)
 
     client_ids = [client_id] if client_id else None
 
@@ -982,6 +1041,50 @@ def build_focus_queue(
 
     for item in opportunities:
         all_items.append(_normalize_opportunity(item, today))
+
+    # --- Enrich activity follow-ups with linked issue data ---
+    # _normalize_followup hard-codes linked_issue_uid=None because
+    # get_all_followups doesn't JOIN the issue row. Without this enrichment,
+    # Dedup Pass 3 (suppress issue rows whose follow-up already shows) is dead
+    # code and duplicate rows appear: one for the activity, one for the issue.
+    activity_ids = [
+        item["id"] for item in all_items
+        if item.get("kind") == "followup"
+        and item.get("source") in ("activity", "project")
+        and item.get("id")
+    ]
+    if activity_ids:
+        ph = ",".join("?" * len(activity_ids))
+        issue_link_rows = conn.execute(
+            f"""SELECT a.id AS activity_id, a.issue_id,
+                       iss.issue_uid AS linked_issue_uid,
+                       iss.subject AS linked_issue_subject,
+                       iss.issue_severity AS linked_issue_severity
+                FROM activity_log a
+                LEFT JOIN activity_log iss ON a.issue_id = iss.id AND iss.item_kind = 'issue'
+                WHERE a.id IN ({ph})""",
+            activity_ids,
+        ).fetchall()
+        _issue_link_map = {r["activity_id"]: dict(r) for r in issue_link_rows}
+        for item in all_items:
+            if (item.get("kind") == "followup"
+                    and item.get("source") in ("activity", "project")
+                    and item.get("id")):
+                link = _issue_link_map.get(item["id"])
+                if link and link.get("linked_issue_uid"):
+                    item["linked_issue_uid"] = link["linked_issue_uid"]
+                    item["linked_issue_subject"] = link["linked_issue_subject"]
+                    item["linked_issue_severity"] = link["linked_issue_severity"]
+
+    # --- Dedup sibling activity follow-ups on the same policy ---
+    # Defensive read-side fix: when two or more pending activity follow-ups
+    # exist for the same policy, only the most recent survives into Focus.
+    all_items, _sibling_dropped = _dedup_activity_siblings(all_items)
+    if _sibling_dropped:
+        logger.info(
+            "Focus Queue: dropped %d duplicate sibling activity follow-up(s) at render time",
+            _sibling_dropped,
+        )
 
     # --- Auto-suggest contacts from policy team for items missing a contact ---
     _contact_cache: dict[str, tuple[str, str]] = {}  # policy_uid -> (name, email)

--- a/src/policydb/queries.py
+++ b/src/policydb/queries.py
@@ -925,6 +925,46 @@ def get_policy_total_hours(conn: sqlite3.Connection, policy_id: int) -> float:
     return float(row["t"])
 
 
+def compute_nudge_tier(
+    conn,
+    policy_uid: str,
+    dispositions: list[dict] | None = None,
+) -> tuple[int, str]:
+    """Count ``waiting_external`` activities for a policy in the last 90 days.
+
+    Returns ``(count, tier)`` where tier is one of ``normal``, ``elevated``,
+    or ``urgent``. ``count`` is the total waiting-disposition activities we've
+    logged against the policy (minimum 1) and determines the tier.
+
+    Shared by the legacy Follow-ups tab (action_center._followups_ctx) and
+    the Focus Queue so both views report the same escalation level.
+    """
+    if dispositions is None:
+        dispositions = cfg.get("follow_up_dispositions", [])
+    waiting_labels = [
+        d["label"] for d in dispositions
+        if d.get("accountability") == "waiting_external"
+    ]
+    if not waiting_labels or not policy_uid:
+        return 1, "normal"
+
+    placeholders = ",".join("?" * len(waiting_labels))
+    count = conn.execute(
+        f"""SELECT COUNT(*) FROM activity_log a
+            WHERE (a.policy_id = (SELECT id FROM policies WHERE policy_uid = ?)
+                   OR (a.issue_id IN (SELECT ipc.issue_id FROM v_issue_policy_coverage ipc
+                                      WHERE ipc.policy_id = (SELECT id FROM policies WHERE policy_uid = ?))
+                       AND a.item_kind != 'issue'))
+              AND a.disposition IN ({placeholders})
+              AND a.activity_date >= date('now', '-90 days')""",
+        [policy_uid, policy_uid] + waiting_labels,
+    ).fetchone()[0]
+
+    count = max(count, 1)
+    tier = "urgent" if count >= 3 else "elevated" if count >= 2 else "normal"
+    return count, tier
+
+
 def auto_close_followups(
     conn,
     *,

--- a/src/policydb/web/routes/action_center.py
+++ b/src/policydb/web/routes/action_center.py
@@ -33,35 +33,8 @@ router = APIRouter()
 
 
 # ── Nudge escalation ─────────────────────────────────────────────────────────
-
-
-def _compute_nudge_tier(conn, policy_uid: str, dispositions: list[dict]) -> tuple[int, str]:
-    """Count waiting_external activities for a policy in last 90 days.
-
-    Returns (count, tier) where tier is 'normal', 'elevated', or 'urgent'.
-    """
-    waiting_labels = [
-        d["label"] for d in dispositions
-        if d.get("accountability") == "waiting_external"
-    ]
-    if not waiting_labels or not policy_uid:
-        return 1, "normal"
-
-    placeholders = ",".join("?" * len(waiting_labels))
-    count = conn.execute(
-        f"""SELECT COUNT(*) FROM activity_log a
-            WHERE (a.policy_id = (SELECT id FROM policies WHERE policy_uid = ?)
-                   OR (a.issue_id IN (SELECT ipc.issue_id FROM v_issue_policy_coverage ipc
-                                      WHERE ipc.policy_id = (SELECT id FROM policies WHERE policy_uid = ?))
-                       AND a.item_kind != 'issue'))
-              AND a.disposition IN ({placeholders})
-              AND a.activity_date >= date('now', '-90 days')""",
-        [policy_uid, policy_uid] + waiting_labels,
-    ).fetchone()[0]
-
-    count = max(count, 1)
-    tier = "urgent" if count >= 3 else "elevated" if count >= 2 else "normal"
-    return count, tier
+# _compute_nudge_tier was moved to policydb.queries.compute_nudge_tier so the
+# Focus Queue can reuse the same escalation model.
 
 
 # ── Classification ───────────────────────────────────────────────────────────
@@ -287,7 +260,8 @@ def _followups_ctx(conn, window: int, activity_type: str, q: str,
 
     # Compute nudge escalation tiers for nudge_due items
     for item in buckets["nudge_due"]:
-        count, tier = _compute_nudge_tier(conn, item.get("policy_uid"), dispositions)
+        from policydb.queries import compute_nudge_tier
+        count, tier = compute_nudge_tier(conn, item.get("policy_uid"), dispositions)
         item["nudge_count"] = count
         item["escalation_tier"] = tier
 

--- a/src/policydb/web/routes/action_center.py
+++ b/src/policydb/web/routes/action_center.py
@@ -963,8 +963,11 @@ def _data_health_ctx(conn) -> dict:
 def action_center_page(request: Request, tab: str = "", conn=Depends(get_db)):
     """Main Action Center page — renders shell with tabs and sidebar."""
     sidebar = _sidebar_ctx(conn)
-    # Default tab content: follow-ups (loaded server-side for first render)
+    # Default tab content: Focus Queue (loaded server-side for first render).
+    # The legacy Follow-ups tab has been retired; aliased to focus.
     initial_tab = tab or "focus"
+    if initial_tab == "followups":
+        initial_tab = "focus"
     tab_ctx = {}
     if initial_tab == "focus":
         focus_items, waiting_items, fq_stats = build_focus_queue(conn, horizon_days=-999)
@@ -989,8 +992,6 @@ def action_center_page(request: Request, tab: str = "", conn=Depends(get_db)):
             "activity_types": cfg.get("activity_types", []),
             "all_contact_names": all_contact_names_fq,
         }
-    elif initial_tab == "followups":
-        tab_ctx = _followups_ctx(conn, window=30, activity_type="", q="")
     elif initial_tab == "inbox":
         tab_ctx = _inbox_ctx(conn)
     elif initial_tab == "activities":
@@ -1178,17 +1179,17 @@ def action_center_focus(
 
 
 @router.get("/action-center/followups", response_class=HTMLResponse)
-def ac_followups(
-    request: Request,
-    window: int = 30,
-    activity_type: str = "",
-    q: str = "",
-    client_id: int = 0,
-    conn=Depends(get_db),
-):
-    ctx = _followups_ctx(conn, window, activity_type, q, client_id=client_id)
-    ctx["request"] = request
-    return templates.TemplateResponse("action_center/_followups.html", ctx)
+def ac_followups(request: Request):
+    """Legacy Follow-ups tab partial. Retired — redirects to Focus Queue.
+
+    We keep the route alive so deep-links and HTMX loads from older cached
+    pages do not 404. The full Follow-ups bucket view is superseded by the
+    Focus Queue, which is the single source of truth for active work.
+    """
+    return HTMLResponse(
+        "",
+        headers={"HX-Redirect": "/action-center?tab=focus"},
+    )
 
 
 @router.get("/action-center/inbox", response_class=HTMLResponse)

--- a/src/policydb/web/routes/activities.py
+++ b/src/policydb/web/routes/activities.py
@@ -324,6 +324,13 @@ def activity_complete(
     if abandon and note:
         note = f"[Abandoned] {note}"
 
+    # Fetch the activity's policy_id / issue_id before we mark it done — we use
+    # these to close sibling pending follow-ups so the Focus Queue doesn't
+    # show duplicate rows for the same policy/issue.
+    sibling_row = conn.execute(
+        "SELECT policy_id, issue_id FROM activity_log WHERE id=?", (activity_id,)
+    ).fetchone()
+
     # Mark done
     conn.execute(
         "UPDATE activity_log SET follow_up_done=1 WHERE id=?", (activity_id,)
@@ -349,6 +356,30 @@ def activity_complete(
             "UPDATE activity_log SET details=CASE WHEN details IS NOT NULL AND details!='' THEN details||char(10)||? ELSE ? END WHERE id=?",
             (note, note, activity_id),
         )
+
+    # Close any sibling pending follow-ups on the same policy or issue. This is
+    # the dedup invariant already held by /activities/{id}/followup: after a
+    # completion there should be at most one pending follow-up left for the
+    # policy/issue. Without this, "Mark Done" via the overflow menu left sibling
+    # rows alive and they reappeared on the next Focus Queue render.
+    from policydb.queries import auto_close_followups
+    if sibling_row:
+        if sibling_row["policy_id"]:
+            auto_close_followups(
+                conn,
+                policy_id=sibling_row["policy_id"],
+                reason="superseded",
+                closed_by="activity_complete",
+                exclude_id=activity_id,
+            )
+        elif sibling_row["issue_id"]:
+            auto_close_followups(
+                conn,
+                issue_id=sibling_row["issue_id"],
+                reason="superseded",
+                closed_by="activity_complete",
+                exclude_id=activity_id,
+            )
 
     # If this is a mandated activity, update the linked milestone
     mandated = conn.execute(
@@ -381,6 +412,77 @@ def activity_complete(
     })
     resp.headers["HX-Trigger"] = '{"reorderActivities": "", "activityLogged": "Activity updated"}'
     return resp
+
+
+@router.post("/activities/{activity_id}/abandon", response_class=HTMLResponse)
+def activity_abandon(
+    request: Request,
+    activity_id: int,
+    note: str = Form(""),
+    conn=Depends(get_db),
+):
+    """One-click "Clear" from the Focus Queue.
+
+    Marks the activity done with an ``[Abandoned]`` note prefix, closes
+    sibling follow-ups on the same policy/issue, and returns an empty HTMX
+    response so the Focus Queue row is removed. Mandated milestones stay
+    incomplete — the abandon path is explicit about that.
+    """
+    final_note = f"[Abandoned] {(note or 'Cleared from Focus Queue').strip()}"
+
+    # Fetch sibling keys and item_kind before we modify the row
+    sibling_row = conn.execute(
+        "SELECT policy_id, issue_id, item_kind FROM activity_log WHERE id=?", (activity_id,)
+    ).fetchone()
+    if not sibling_row:
+        return HTMLResponse("", status_code=404)
+
+    conn.execute(
+        "UPDATE activity_log SET follow_up_done=1 WHERE id=?", (activity_id,)
+    )
+    conn.execute(
+        "UPDATE activity_log SET details=CASE WHEN details IS NOT NULL AND details!='' "
+        "THEN details||char(10)||? ELSE ? END WHERE id=?",
+        (final_note, final_note, activity_id),
+    )
+
+    # For issue rows, also move the status to Closed so get_open_issues_with_due
+    # stops pulling them back into the Focus Queue on the next render.
+    if sibling_row["item_kind"] == "issue":
+        conn.execute(
+            "UPDATE activity_log SET issue_status='Closed', resolved_date=date('now'), "
+            "resolution_type=COALESCE(resolution_type, 'Withdrawn') "
+            "WHERE id=?",
+            (activity_id,),
+        )
+
+    # Close sibling follow-ups on the same policy/issue (dedup invariant)
+    from policydb.queries import auto_close_followups
+    if sibling_row["policy_id"]:
+        auto_close_followups(
+            conn,
+            policy_id=sibling_row["policy_id"],
+            reason="superseded",
+            closed_by="activity_abandon",
+            exclude_id=activity_id,
+        )
+    elif sibling_row["issue_id"]:
+        auto_close_followups(
+            conn,
+            issue_id=sibling_row["issue_id"],
+            reason="superseded",
+            closed_by="activity_abandon",
+            exclude_id=activity_id,
+        )
+
+    conn.commit()
+    logger.info("Follow-up %d abandoned from Focus Queue", activity_id)
+    return HTMLResponse(
+        "",
+        headers={
+            "HX-Trigger": '{"refreshFollowups": "", "activityLogged": "Cleared"}',
+        },
+    )
 
 
 def _activity_row_dict(conn, activity_id: int) -> dict | None:

--- a/src/policydb/web/templates/action_center/_focus_item.html
+++ b/src/policydb/web/templates/action_center/_focus_item.html
@@ -81,10 +81,114 @@
         → {{ item.suggested_action_detail }}
       </div>
       {% endif %}
+      {# ─── Metrics strip ───────────────────────────────────────────
+         Data-dense horizontal row of compact chips. Each chip is only rendered
+         when its underlying signal is meaningful, so the row naturally grows
+         with how much the system "knows" about the item. #}
+      {% set _d = item.days_until_deadline %}
+      {% set _show_overdue = _d is not none and _d < 0 %}
+      {% set _show_due_in = _d is not none and _d >= 0 and _d <= 30 %}
+      {% set _show_fu_expiry = item.days_fu_to_expiry is not none and item.days_fu_to_expiry <= 14 %}
+      {% set _show_hours = item.policy_hours_30d and item.policy_hours_30d > 0 %}
+      {% set _show_nudge = item.nudge_count and item.nudge_count >= 2 %}
+      {% set _show_cadence = item.cadence %}
+      {% set _show_linked_issue = item.linked_issue_uid %}
+      {% set _show_program = item.program_name %}
+      {% set _show_project = item.project_name and not item.program_name %}
+      {% set _show_renewal_status = item.renewal_status %}
+      {% if _show_overdue or _show_due_in or _show_fu_expiry or _show_hours or _show_nudge or _show_cadence or _show_linked_issue or _show_program or _show_project or _show_renewal_status %}
+      <div class="flex items-center gap-1.5 mt-1 flex-wrap text-[10px] font-medium">
+        {# Urgency: overdue or upcoming #}
+        {% if _show_overdue %}
+          <span class="bg-red-50 text-red-700 border border-red-200 px-1.5 py-0.5 rounded" title="Days past follow-up date">
+            +{{ -_d }}d over
+          </span>
+        {% elif _show_due_in %}
+          <span class="bg-blue-50 text-blue-700 border border-blue-200 px-1.5 py-0.5 rounded" title="Days until follow-up is due">
+            {% if _d == 0 %}today{% else %}in {{ _d }}d{% endif %}
+          </span>
+        {% endif %}
+        {# Follow-up runway to expiration #}
+        {% if _show_fu_expiry %}
+          {% set _fx = item.days_fu_to_expiry %}
+          <span class="bg-amber-50 text-amber-800 border border-amber-200 px-1.5 py-0.5 rounded"
+                title="Days between follow-up and policy expiration">
+            {% if _fx < 0 %}exp {{ -_fx }}d ago{% elif _fx == 0 %}expires today{% else %}exp in {{ _fx }}d{% endif %}
+          </span>
+        {% endif %}
+        {# Cadence vs. disposition default_days #}
+        {% if _show_cadence %}
+          {% if item.cadence == 'on_cadence' %}
+            <span class="bg-green-50 text-green-700 border border-green-200 px-1.5 py-0.5 rounded" title="Follow-up is on cadence with the disposition's expected interval">on cadence</span>
+          {% elif item.cadence == 'mild' %}
+            <span class="bg-amber-50 text-amber-700 border border-amber-200 px-1.5 py-0.5 rounded" title="Mild drift past the disposition's expected interval">drifting</span>
+          {% else %}
+            <span class="bg-red-50 text-red-700 border border-red-200 px-1.5 py-0.5 rounded" title="Past 2× the disposition's expected interval">2× cadence</span>
+          {% endif %}
+        {% endif %}
+        {# Nudge tier #}
+        {% if _show_nudge %}
+          {% if item.escalation_tier == 'urgent' %}
+            <span class="bg-red-100 text-red-800 px-1.5 py-0.5 rounded font-semibold" title="Third+ nudge sent on this policy in the last 90 days">
+              ⚠ nudge #{{ item.nudge_count }}
+            </span>
+          {% else %}
+            <span class="bg-amber-50 text-amber-800 px-1.5 py-0.5 rounded" title="{{ item.nudge_count }} waiting-disposition activities in the last 90 days">
+              nudge #{{ item.nudge_count }}
+            </span>
+          {% endif %}
+        {% endif %}
+        {# Linked issue badge #}
+        {% if _show_linked_issue %}
+          {% set _sev = item.linked_issue_severity or 'Normal' %}
+          <span class="{% if _sev in ('Critical','High') %}bg-red-50 text-red-700 border border-red-200{% else %}bg-purple-50 text-purple-700 border border-purple-200{% endif %} px-1.5 py-0.5 rounded"
+                title="{{ item.linked_issue_subject or '' }}">
+            ⊗ {{ item.linked_issue_uid }}
+          </span>
+        {% endif %}
+        {# Hours logged on this policy last 30d #}
+        {% if _show_hours %}
+          <span class="bg-gray-50 text-gray-600 border border-gray-200 px-1.5 py-0.5 rounded" title="Hours logged on this policy in the last 30 days">
+            ⏱ {{ '%.1f'|format(item.policy_hours_30d) }}h / 30d
+          </span>
+        {% endif %}
+        {# Program / project context #}
+        {% if _show_program %}
+          <span class="bg-[#EDEAE4] text-[#6B6860] px-1.5 py-0.5 rounded truncate max-w-[180px]" title="Program: {{ item.program_name }}">
+            ⌘ {{ item.program_name }}
+          </span>
+        {% elif _show_project %}
+          <span class="bg-[#EDEAE4] text-[#6B6860] px-1.5 py-0.5 rounded truncate max-w-[180px]" title="Project/location: {{ item.project_name }}">
+            ⌘ {{ item.project_name }}
+          </span>
+        {% endif %}
+        {# Renewal status inline #}
+        {% if _show_renewal_status %}
+          <span class="bg-gray-50 text-gray-500 border border-gray-200 px-1.5 py-0.5 rounded">
+            {{ item.renewal_status }}
+          </span>
+        {% endif %}
+      </div>
+      {% endif %}
+      {# Prior disposition summary — "what happened last time" #}
+      {% if item.prev_disposition %}
+      <div class="text-[11px] text-[#9B9790] mt-0.5">
+        prev: <span class="text-[#6B6860]">{{ item.prev_disposition }}</span>
+        {% if item.prev_days_ago is not none %} · {{ item.prev_days_ago }}d ago{% endif %}
+        {% if item.disposition %} → now: <span class="text-[#6B6860]">{{ item.disposition }}</span>{% endif %}
+      </div>
+      {% elif item.disposition %}
+      <div class="text-[11px] text-[#9B9790] mt-0.5">
+        disposition: <span class="text-[#6B6860]">{{ item.disposition }}</span>
+      </div>
+      {% endif %}
       {# Last action + contact + waiting indicator #}
       <div class="flex items-center gap-2 mt-1 flex-wrap">
         {% if item.activity_type %}
           <span class="text-[10px] bg-gray-100 text-gray-500 px-1.5 py-0.5 rounded">Last: {{ item.activity_type }}</span>
+        {% endif %}
+        {% if item.days_since_activity is not none and item.days_since_activity > 0 %}
+          <span class="text-[10px] text-gray-400" title="Days since the most recent activity on this item">{{ item.days_since_activity }}d since last touch</span>
         {% endif %}
         {% if item.contact_person %}
           <span class="text-[10px] text-gray-500">↳ {{ item.contact_person }}</span>

--- a/src/policydb/web/templates/action_center/_focus_item.html
+++ b/src/policydb/web/templates/action_center/_focus_item.html
@@ -74,6 +74,13 @@
         {% endif %}
       </div>
       {% endif %}
+      {# Suggested next action — always visible (Guide Me mode shows an upscaled version below).
+         This is the "where should this be directed" hint that used to be hidden behind a toggle. #}
+      {% if item.suggested_action_detail and not (is_highlighted and guide_me) %}
+      <div class="text-[12px] text-[#0B4BFF] mt-0.5">
+        → {{ item.suggested_action_detail }}
+      </div>
+      {% endif %}
       {# Last action + contact + waiting indicator #}
       <div class="flex items-center gap-2 mt-1 flex-wrap">
         {% if item.activity_type %}
@@ -120,6 +127,11 @@
         </div>
       {% endif %}
 
+      {# Primary action. For activity-backed items this is a Send Nudge / Follow Up /
+         Review button that expands the inline completion form. Items promoted from the
+         Waiting sidebar also hit this branch because build_focus_queue already sets
+         their suggested_action to "Send Nudge" or "Escalate" — re-diary from the
+         inline form IS the nudge. Kind-specific branches handle inbox/milestone/suggested. #}
       <button class="bg-[#0B4BFF] text-white text-xs font-semibold px-3 py-1.5 rounded-md hover:bg-blue-700 whitespace-nowrap"
               {% if item.kind == 'inbox' %}
                 hx-get="/inbox/{{ item.inbox_id }}/process-slideover"
@@ -136,6 +148,36 @@
               {% endif %}>
         {{ item.suggested_action }}
       </button>
+
+      {# Clear — one-click "this is handled, take it off my list".
+         For activity-backed items, posts to /activities/{id}/abandon which marks
+         the row done with an [Abandoned] prefix and closes sibling follow-ups.
+         For other kinds, routes to the kind-specific clearer. #}
+      {% if has_activity_id %}
+        <button class="text-[11px] text-[#B05454] hover:text-[#8B3A3A] hover:bg-red-50 px-2 py-1.5 rounded-md"
+                hx-post="/activities/{{ item.id }}/abandon"
+                hx-target="#fq-{{ row_id }}" hx-swap="delete"
+                hx-confirm="Mark this as handled and remove from Focus Queue?"
+                title="Clear — mark handled and remove">
+          Clear
+        </button>
+      {% elif item.kind == 'suggested' and item.policy_uid %}
+        <button class="text-[11px] text-[#B05454] hover:text-[#8B3A3A] hover:bg-red-50 px-2 py-1.5 rounded-md"
+                hx-post="/policies/{{ item.policy_uid }}/clear-followup"
+                hx-target="#fq-{{ row_id }}" hx-swap="delete"
+                hx-confirm="Clear the renewal follow-up suggestion for this policy?"
+                title="Clear — no follow-up needed">
+          Clear
+        </button>
+      {% elif item.kind == 'inbox' %}
+        <button class="text-[11px] text-[#B05454] hover:text-[#8B3A3A] hover:bg-red-50 px-2 py-1.5 rounded-md"
+                hx-post="/inbox/{{ item.inbox_id }}/dismiss"
+                hx-target="#fq-{{ row_id }}" hx-swap="delete"
+                hx-confirm="Dismiss this inbox item?"
+                title="Dismiss">
+          Clear
+        </button>
+      {% endif %}
 
       <button class="bg-[#EDEAE4] text-[#6B6860] text-xs px-2 py-1.5 rounded-md hover:bg-gray-200"
               onclick="fqToggleMenu('{{ row_id }}')">

--- a/src/policydb/web/templates/action_center/page.html
+++ b/src/policydb/web/templates/action_center/page.html
@@ -29,14 +29,10 @@
             <span class="tab-badge" style="background:#ef4444;color:white">{{ _focus_badge }}</span>
           {% endif %}
         </button>
-        <button class="tab-btn" data-tab="followups" data-tab-url="/action-center/followups">
-          Follow-ups
-          {% if _fu_badge %}
-            <span class="tab-badge" style="background:#ef4444;color:white">{{ _fu_badge }}</span>
-          {% elif overdue is defined and overdue|length %}
-            <span class="tab-badge" style="background:#ef4444;color:white">{{ overdue|length }}</span>
-          {% endif %}
-        </button>
+
+        {# The legacy Follow-ups tab has been retired — the Focus Queue is the single
+           source of truth for active work. /action-center/followups still redirects so
+           deep-links keep working. #}
 
         {# ── More ▾ dropdown ── #}
         <div class="relative" style="margin-left:auto;">

--- a/tests/test_followup_dedup.py
+++ b/tests/test_followup_dedup.py
@@ -1,19 +1,21 @@
-"""Tests for Focus Queue follow-up dedup invariants.
+"""Tests for Focus Queue follow-up dedup + metric enrichment invariants.
 
 Covers:
 1. ``activity_complete`` closes sibling pending follow-ups on the same policy.
-2. ``_dedup_activity_siblings`` keeps only the most recent follow-up per policy.
+2. ``_dedup_activity_siblings`` keeps only the most urgent follow-up per policy.
 3. ``activity_abandon`` marks the row done with an ``[Abandoned]`` prefix and
    closes siblings.
+4. ``build_focus_queue`` enriches activity items with nudge tier, cadence,
+   hours logged in last 30 days, and days-from-follow-up-to-expiry.
 """
 
-from datetime import date
+from datetime import date, timedelta
 
 import pytest
 from fastapi.testclient import TestClient
 
 from policydb.db import get_connection, init_db
-from policydb.focus_queue import _dedup_activity_siblings
+from policydb.focus_queue import _dedup_activity_siblings, build_focus_queue
 
 
 @pytest.fixture
@@ -235,4 +237,130 @@ def test_activity_abandon_also_supersedes_siblings(tmp_db, app_client):
     assert r2["follow_up_done"] == 1
     assert r2["auto_close_reason"] == "superseded"
     assert r2["auto_closed_by"] == "activity_abandon"
+
+
+# ── Metric enrichment ────────────────────────────────────────────────────────
+
+
+def _find_fu_item(focus_items, subject):
+    for item in focus_items:
+        if item.get("subject") == subject and item.get("kind") == "followup":
+            return item
+    return None
+
+
+def test_focus_item_exposes_hours_logged_30d(tmp_db):
+    """An activity follow-up on a policy with logged hours should surface
+    ``policy_hours_30d`` so the Focus Queue can render the chip."""
+    conn = get_connection(tmp_db)
+    cid, pid = _seed_client_and_policy(conn)
+    overdue = (date.today() - timedelta(days=2)).isoformat()
+    # Pending follow-up
+    _insert_followup(conn, cid, pid, "hours test fu", overdue)
+    # Separate logged activity on the same policy with duration_hours
+    conn.execute(
+        "INSERT INTO activity_log (activity_date, client_id, policy_id, activity_type, "
+        "subject, duration_hours, follow_up_done, item_kind, account_exec) "
+        "VALUES (?, ?, ?, 'Call', 'time log', 2.5, 1, 'followup', 'Grant')",
+        (date.today().isoformat(), cid, pid),
+    )
+    conn.commit()
+
+    focus, _waiting, _stats = build_focus_queue(conn, horizon_days=-999)
+    item = _find_fu_item(focus, "hours test fu")
+    assert item is not None
+    assert item["policy_hours_30d"] == pytest.approx(2.5)
+    conn.close()
+
+
+def test_focus_item_computes_days_fu_to_expiry(tmp_db):
+    conn = get_connection(tmp_db)
+    conn.execute(
+        "INSERT INTO clients (name, industry_segment) VALUES ('Expiry Test', 'Test')"
+    )
+    cid = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+    fu = (date.today() - timedelta(days=1)).isoformat()
+    exp = (date.today() + timedelta(days=9)).isoformat()
+    conn.execute(
+        "INSERT INTO policies (policy_uid, client_id, policy_type, carrier, effective_date, expiration_date) "
+        "VALUES ('POL-EXP', ?, 'GL', 'Test', '2026-01-01', ?)",
+        (cid, exp),
+    )
+    pid = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+    _insert_followup(conn, cid, pid, "expiry test fu", fu)
+    conn.commit()
+
+    focus, _waiting, _stats = build_focus_queue(conn, horizon_days=-999)
+    item = _find_fu_item(focus, "expiry test fu")
+    assert item is not None
+    # fu = today-1, exp = today+9 → 10 days runway
+    assert item["days_fu_to_expiry"] == 10
+    conn.close()
+
+
+def test_focus_item_cadence_classifies_disposition_drift(tmp_db):
+    """``cadence`` should be ``on_cadence`` / ``drifting`` / ``2x cadence``
+    based on how far past the disposition's ``default_days`` we are."""
+    conn = get_connection(tmp_db)
+    cid, pid = _seed_client_and_policy(conn)
+    # "Sent Email" disposition has default_days=7
+    # Set follow_up_date to 10 days ago → 10 days overdue → mild drift
+    ten_ago = (date.today() - timedelta(days=10)).isoformat()
+    conn.execute(
+        "INSERT INTO activity_log (activity_date, client_id, policy_id, activity_type, "
+        "subject, follow_up_date, disposition, follow_up_done, item_kind, account_exec) "
+        "VALUES (?, ?, ?, 'Email', 'drifting fu', ?, 'Sent Email', 0, 'followup', 'Grant')",
+        (date.today().isoformat(), cid, pid, ten_ago),
+    )
+    conn.commit()
+
+    focus, _waiting, _stats = build_focus_queue(conn, horizon_days=-999)
+    # Waiting external goes to waiting bucket unless promoted. Check both.
+    all_items = focus + _waiting
+    item = None
+    for i in all_items:
+        if i.get("subject") == "drifting fu":
+            item = i
+            break
+    assert item is not None
+    # days_over = 10, default_days = 7, 7 < 10 <= 14 → mild drift
+    assert item["cadence"] == "mild"
+    conn.close()
+
+
+def test_focus_item_nudge_count_accumulates(tmp_db):
+    """Multiple waiting-external activities on a policy should bump
+    ``nudge_count`` / ``escalation_tier``."""
+    conn = get_connection(tmp_db)
+    cid, pid = _seed_client_and_policy(conn)
+    today_iso = date.today().isoformat()
+    # Three prior waiting-external activities in the last 90 days
+    for subject in ("first nudge", "second nudge", "third nudge"):
+        conn.execute(
+            "INSERT INTO activity_log (activity_date, client_id, policy_id, activity_type, "
+            "subject, disposition, follow_up_done, item_kind, account_exec) "
+            "VALUES (?, ?, ?, 'Email', ?, 'Sent Email', 1, 'followup', 'Grant')",
+            (today_iso, cid, pid, subject),
+        )
+    # Current pending follow-up with waiting-external disposition
+    conn.execute(
+        "INSERT INTO activity_log (activity_date, client_id, policy_id, activity_type, "
+        "subject, follow_up_date, disposition, follow_up_done, item_kind, account_exec) "
+        "VALUES (?, ?, ?, 'Email', 'current nudge', ?, 'Sent Email', 0, 'followup', 'Grant')",
+        (today_iso, cid, pid, (date.today() - timedelta(days=1)).isoformat()),
+    )
+    conn.commit()
+
+    focus, waiting, _stats = build_focus_queue(conn, horizon_days=-999)
+    all_items = focus + waiting
+    item = None
+    for i in all_items:
+        if i.get("subject") == "current nudge":
+            item = i
+            break
+    assert item is not None
+    # 4 total waiting-disposition activities (3 historic + 1 current) → urgent
+    assert item["nudge_count"] >= 3
+    assert item["escalation_tier"] == "urgent"
+    conn.close()
     conn.close()

--- a/tests/test_followup_dedup.py
+++ b/tests/test_followup_dedup.py
@@ -1,0 +1,238 @@
+"""Tests for Focus Queue follow-up dedup invariants.
+
+Covers:
+1. ``activity_complete`` closes sibling pending follow-ups on the same policy.
+2. ``_dedup_activity_siblings`` keeps only the most recent follow-up per policy.
+3. ``activity_abandon`` marks the row done with an ``[Abandoned]`` prefix and
+   closes siblings.
+"""
+
+from datetime import date
+
+import pytest
+from fastapi.testclient import TestClient
+
+from policydb.db import get_connection, init_db
+from policydb.focus_queue import _dedup_activity_siblings
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.sqlite"
+    monkeypatch.setattr("policydb.db.DB_PATH", db_path)
+    monkeypatch.setattr("policydb.db.DB_DIR", tmp_path)
+    monkeypatch.setattr("policydb.db.EXPORTS_DIR", tmp_path / "exports")
+    monkeypatch.setattr("policydb.db.CONFIG_PATH", tmp_path / "config.yaml")
+    init_db(path=db_path)
+    return db_path
+
+
+@pytest.fixture
+def app_client(tmp_db):
+    from policydb.web.app import app
+    with TestClient(app) as client:
+        yield client
+
+
+def _seed_client_and_policy(conn):
+    conn.execute("INSERT INTO clients (name, industry_segment) VALUES ('Dedup Co', 'Test')")
+    cid = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+    conn.execute(
+        "INSERT INTO policies (policy_uid, client_id, policy_type, carrier, effective_date, expiration_date) "
+        "VALUES ('POL-001', ?, 'GL', 'Test Carrier', '2026-01-01', '2027-01-01')",
+        (cid,),
+    )
+    pid = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+    return cid, pid
+
+
+def _insert_followup(conn, client_id, policy_id, subject, follow_up_date):
+    conn.execute(
+        "INSERT INTO activity_log (activity_date, client_id, policy_id, activity_type, "
+        "subject, follow_up_date, follow_up_done, item_kind, account_exec) "
+        "VALUES (?, ?, ?, 'Call', ?, ?, 0, 'followup', 'Grant')",
+        (date.today().isoformat(), client_id, policy_id, subject, follow_up_date),
+    )
+    return conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+
+# ── _dedup_activity_siblings ──────────────────────────────────────────────────
+
+
+def test_dedup_siblings_keeps_earliest_date():
+    items = [
+        {"kind": "followup", "source": "activity", "policy_uid": "POL-001",
+         "id": 1, "follow_up_date": "2026-04-01"},
+        {"kind": "followup", "source": "activity", "policy_uid": "POL-001",
+         "id": 2, "follow_up_date": "2026-04-10"},
+        {"kind": "followup", "source": "activity", "policy_uid": "POL-001",
+         "id": 3, "follow_up_date": "2026-03-28"},
+    ]
+    kept, dropped = _dedup_activity_siblings(items)
+    assert dropped == 2
+    assert len(kept) == 1
+    assert kept[0]["id"] == 3  # earliest follow_up_date wins — most urgent
+
+
+def test_dedup_siblings_breaks_tie_on_id():
+    items = [
+        {"kind": "followup", "source": "activity", "policy_uid": "POL-001",
+         "id": 1, "follow_up_date": "2026-04-01"},
+        {"kind": "followup", "source": "activity", "policy_uid": "POL-001",
+         "id": 5, "follow_up_date": "2026-04-01"},
+    ]
+    kept, dropped = _dedup_activity_siblings(items)
+    assert dropped == 1
+    assert kept[0]["id"] == 5  # on date tie, most recently written wins
+
+
+def test_dedup_siblings_prefers_overdue_over_future():
+    """The overdue item must survive so it doesn't get nullified by horizon filter."""
+    items = [
+        {"kind": "followup", "source": "activity", "policy_uid": "POL-001",
+         "id": 1, "follow_up_date": "2026-04-01"},  # overdue
+        {"kind": "followup", "source": "activity", "policy_uid": "POL-001",
+         "id": 2, "follow_up_date": "2099-04-01"},  # far future
+    ]
+    kept, dropped = _dedup_activity_siblings(items)
+    assert dropped == 1
+    assert kept[0]["id"] == 1
+
+
+def test_dedup_siblings_leaves_other_policies_alone():
+    items = [
+        {"kind": "followup", "source": "activity", "policy_uid": "POL-001",
+         "id": 1, "follow_up_date": "2026-04-01"},
+        {"kind": "followup", "source": "activity", "policy_uid": "POL-002",
+         "id": 2, "follow_up_date": "2026-04-01"},
+    ]
+    kept, dropped = _dedup_activity_siblings(items)
+    assert dropped == 0
+    assert len(kept) == 2
+
+
+def test_dedup_siblings_ignores_non_followup_kinds():
+    items = [
+        {"kind": "issue", "source": "issue", "policy_uid": "POL-001",
+         "id": 1, "follow_up_date": "2026-04-01"},
+        {"kind": "milestone", "source": "milestone", "policy_uid": "POL-001",
+         "id": 2, "follow_up_date": "2026-04-01"},
+    ]
+    kept, dropped = _dedup_activity_siblings(items)
+    assert dropped == 0
+    assert len(kept) == 2
+
+
+def test_dedup_siblings_no_policy_uid_passthrough():
+    items = [
+        {"kind": "followup", "source": "activity", "policy_uid": None,
+         "id": 1, "follow_up_date": "2026-04-01"},
+        {"kind": "followup", "source": "activity", "policy_uid": None,
+         "id": 2, "follow_up_date": "2026-04-01"},
+    ]
+    kept, dropped = _dedup_activity_siblings(items)
+    assert dropped == 0
+    assert len(kept) == 2
+
+
+# ── /activities/{id}/complete supersede ───────────────────────────────────────
+
+
+def test_activity_complete_supersedes_siblings(tmp_db, app_client):
+    conn = get_connection(tmp_db)
+    cid, pid = _seed_client_and_policy(conn)
+    a1 = _insert_followup(conn, cid, pid, "FU #1", "2026-04-01")
+    a2 = _insert_followup(conn, cid, pid, "FU #2", "2026-04-08")
+    a3 = _insert_followup(conn, cid, pid, "FU #3", "2026-04-15")
+    conn.commit()
+    conn.close()
+
+    # Complete the middle one
+    resp = app_client.post(f"/activities/{a2}/complete", data={"duration_hours": 0})
+    assert resp.status_code == 200
+
+    conn = get_connection(tmp_db)
+    rows = conn.execute(
+        "SELECT id, follow_up_done, auto_close_reason, auto_closed_by FROM activity_log "
+        "WHERE id IN (?, ?, ?)", (a1, a2, a3)
+    ).fetchall()
+    by_id = {r["id"]: r for r in rows}
+    # a2 is the one we completed
+    assert by_id[a2]["follow_up_done"] == 1
+    # a1 and a3 got swept as siblings
+    assert by_id[a1]["follow_up_done"] == 1
+    assert by_id[a1]["auto_close_reason"] == "superseded"
+    assert by_id[a1]["auto_closed_by"] == "activity_complete"
+    assert by_id[a3]["follow_up_done"] == 1
+    assert by_id[a3]["auto_close_reason"] == "superseded"
+    conn.close()
+
+
+def test_activity_complete_doesnt_touch_other_policy_followups(tmp_db, app_client):
+    conn = get_connection(tmp_db)
+    cid, pid1 = _seed_client_and_policy(conn)
+    # Second policy for the same client
+    conn.execute(
+        "INSERT INTO policies (policy_uid, client_id, policy_type, carrier, effective_date, expiration_date) "
+        "VALUES ('POL-002', ?, 'Auto', 'Test Carrier', '2026-01-01', '2027-01-01')",
+        (cid,),
+    )
+    pid2 = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+    a1 = _insert_followup(conn, cid, pid1, "FU #1", "2026-04-01")
+    a2 = _insert_followup(conn, cid, pid2, "FU #2 (other policy)", "2026-04-01")
+    conn.commit()
+    conn.close()
+
+    app_client.post(f"/activities/{a1}/complete", data={"duration_hours": 0})
+
+    conn = get_connection(tmp_db)
+    r2 = conn.execute(
+        "SELECT follow_up_done, auto_close_reason FROM activity_log WHERE id=?", (a2,)
+    ).fetchone()
+    assert r2["follow_up_done"] == 0  # untouched
+    assert r2["auto_close_reason"] is None
+    conn.close()
+
+
+# ── /activities/{id}/abandon ──────────────────────────────────────────────────
+
+
+def test_activity_abandon_marks_done_and_prefixes_note(tmp_db, app_client):
+    conn = get_connection(tmp_db)
+    cid, pid = _seed_client_and_policy(conn)
+    a1 = _insert_followup(conn, cid, pid, "FU to clear", "2026-04-01")
+    conn.commit()
+    conn.close()
+
+    resp = app_client.post(f"/activities/{a1}/abandon", data={})
+    assert resp.status_code == 200
+    assert resp.text == ""
+
+    conn = get_connection(tmp_db)
+    row = conn.execute(
+        "SELECT follow_up_done, details FROM activity_log WHERE id=?", (a1,)
+    ).fetchone()
+    assert row["follow_up_done"] == 1
+    assert (row["details"] or "").startswith("[Abandoned]")
+    conn.close()
+
+
+def test_activity_abandon_also_supersedes_siblings(tmp_db, app_client):
+    conn = get_connection(tmp_db)
+    cid, pid = _seed_client_and_policy(conn)
+    a1 = _insert_followup(conn, cid, pid, "FU #1", "2026-04-01")
+    a2 = _insert_followup(conn, cid, pid, "FU #2", "2026-04-08")
+    conn.commit()
+    conn.close()
+
+    app_client.post(f"/activities/{a1}/abandon", data={})
+
+    conn = get_connection(tmp_db)
+    r2 = conn.execute(
+        "SELECT follow_up_done, auto_close_reason, auto_closed_by FROM activity_log WHERE id=?",
+        (a2,),
+    ).fetchone()
+    assert r2["follow_up_done"] == 1
+    assert r2["auto_close_reason"] == "superseded"
+    assert r2["auto_closed_by"] == "activity_abandon"
+    conn.close()


### PR DESCRIPTION
## Summary

Two-commit pass on the Action Center follow-up UX: first close the dedup gaps that produced duplicate rows and hidden stale items, then pack every computed-but-invisible signal onto each Focus Queue row.

Driven by the user feedback: *"Gaps in being able to complete a follow up or having multiple instances of the same. The focus queue can be unclear as to what needs to be reviewed or where things need to be directed. The system is too complicated and creates issues in showing the user what they need to know contextually and how to follow up appropriately."*

Plan file: `/root/.claude/plans/iridescent-weaving-rabbit.md`

## Commit 1 — `3328e8f` — Clarity + Cleanup

Eight diagnostic findings, six concrete fixes:

- **`/activities/{id}/complete` now supersedes sibling follow-ups** on the same policy/issue via `auto_close_followups`. "Mark Done" via the overflow menu no longer leaves duplicate pending rows behind. (`src/policydb/web/routes/activities.py`)
- **`build_focus_queue` runs `auto_close_stale_followups`** at the top so users who never touch the legacy tab still get stale auto-close. (`src/policydb/focus_queue.py`)
- **Focus Queue items are enriched with `linked_issue_uid`** via a batched join after normalization. Dedup Pass 3 (suppress issue rows whose follow-up already shows) actually works now — it was dead code before.
- **New `_dedup_activity_siblings` helper** collapses multiple pending activity follow-ups on one `policy_uid` down to the most urgent (earliest `follow_up_date`, tie-breaking on largest id). Defensive read-side fix for legacy data. Drop count is logged.
- **Suggested-action hint always visible** — the `→ suggested_action_detail` line is no longer gated behind Guide Me mode. Answers the "where should this go" question without a toggle.
- **New one-click `Clear` button** + `/activities/{id}/abandon` endpoint. Marks the row done with an `[Abandoned]` prefix and closes siblings. Issue rows also get `issue_status='Closed'` so they don't rehydrate. Non-activity kinds (suggested / inbox) route to their existing kind-specific clearers. (`_focus_item.html`)
- **Legacy Follow-ups tab retired** from the Action Center tab bar. `/action-center?tab=followups` aliases to `focus`; `/action-center/followups` HTMX partial returns `HX-Redirect: /action-center?tab=focus`. `_followups_ctx` and `_followups.html` are left in place as a one-release rollback path.

## Commit 2 — `9ff41c2` — Data-Dense Metrics Strip

Follow-up feedback: *"we can make this very data dense. I am comfortable with that approach."*

Every computed-but-hidden field the old Follow-ups bucket view knew about is now surfaced inline on Focus Queue items, plus a few new ones.

### Backend

- **`_compute_nudge_tier` promoted to `queries.compute_nudge_tier`** (public) so Focus Queue and the legacy tab share one escalation model. No drift risk.
- **New enrichment pass in `build_focus_queue`** after dedup, keyed by `policy_uid`:
  - `policy_hours_30d` — one `GROUP BY` query over all policies in the queue
  - `days_fu_to_expiry` — computed from follow-up date and policy expiration
  - `nudge_count` / `escalation_tier` — cached per policy, called at most once per unique policy
  - `cadence` — `on_cadence` / `mild` / `severe` vs. the disposition's `default_days`
- **`_normalize_followup` propagates `renewal_status`** and initializes the new fields so the shape is explicit.

### Template (`_focus_item.html`)

New metrics strip below the suggested-action hint. Each chip renders only when its signal is meaningful, so light items stay light:

| Chip | Example |
|---|---|
| Urgency | `+12d over` / `in 3d` / `today` |
| FU → expiration runway (≤14d) | `exp in 5d` / `exp 2d ago` |
| Cadence | `on cadence` / `drifting` / `2× cadence` |
| Nudge tier | `nudge #2` / `⚠ nudge #4` |
| Linked issue | `⊗ ISS-2026-001` |
| Hours logged (30d) | `⏱ 4.5h / 30d` |
| Program / project | `⌘ Acme Manufacturing Bind` |
| Renewal status | `In Progress` |

Plus:
- **`prev:` line** — `prev: Sent Email · 10d ago → now: Sent Email` — disposition transition at a glance.
- **Staleness chip** — `14d since last touch` in the footer row.

### Example rendered row

```
[OVERDUE] POL-DEN-001 Dense Test Co — General Liability (Acme Ins)
Waiting on underwriter quote
Requested terms for renewal
→ Follow up on Waiting on underwriter quote. Contact: Jane Smith
[+10d over] [drifting] [⚠ nudge #4] [⊗ ISS-...] [⏱ 4.5h / 30d] [In Progress]
prev: Sent Email · 10d ago → now: Sent Email
Last: Email  10d since last touch  ↳ Jane Smith  ⏳ Waiting
                                         [Follow Up] [Clear] [⋯]
```

## Test plan

- [x] `tests/test_followup_dedup.py` — 14 new cases covering:
  - `_dedup_activity_siblings` (earliest-date wins, overdue beats future, tie-break on id, non-followup kinds untouched, no-policy passthrough)
  - `/activities/{id}/complete` sibling supersede + cross-policy isolation
  - `/activities/{id}/abandon` round-trip (done + `[Abandoned]` prefix + sibling close)
  - Metric enrichment: `policy_hours_30d`, `days_fu_to_expiry`, cadence `mild` classification, `nudge_count → urgent` escalation
- [x] Full suite: **336 passed**, 0 new regressions. 7 pre-existing baseline failures in `test_compliance` / `test_timeline_engine` / `test_llm_schemas` / `test_tabbed_pages` confirmed unchanged from `main`.
- [x] End-to-end smoke render: seeded a realistic policy with 3 historic waiting activities, 4.5h logged, and a 10d-overdue follow-up. Verified every chip renders with the expected text and the Clear button posts to the right endpoint. POST `/activities/{id}/abandon` round-trip returns 200, sets `follow_up_done=1`, prefixes details with `[Abandoned]`, and emits the `HX-Trigger` toast.
- [ ] **QA in browser on the work Mac** before merging — confirm the new metrics strip doesn't wrap awkwardly on narrow windows and that the Clear button's confirm dialog feels right.

## Things NOT touched

- `get_all_followups` SQL query — intentionally kept stable so the legacy bucket view doesn't regress.
- `_followups_ctx` / `_followups.html` — dead code after Commit 1 but left in place for one release as a rollback path.
- `focus_score_weights` and the scoring model — the complaint was about dedup/clarity/density, not ranking.
- Any schema change — both commits are code/template only, no migration.

https://claude.ai/code/session_011WKUhWeSzMpW8Yq2VwQCCm