### PR TITLE
Email sync hardening: 9 fixes, bulk dismiss, email_direction column

### DIFF
--- a/.claude/skills/policydb-activity-review/SKILL.md
+++ b/.claude/skills/policydb-activity-review/SKILL.md
@@ -13,16 +13,21 @@ The Activity Review Engine detects work sessions that happened (audit trail evid
 
 ## System vs User Activity — Critical Filtering Rule
 
-Every query that counts or checks activities for review/anomaly purposes MUST exclude system-generated activities. Three filter conditions:
+Every query that counts or checks activities for review/anomaly purposes MUST exclude system-generated activities. The canonical filter:
 
 ```sql
 AND activity_type NOT IN ('Milestone')
-AND source = 'manual'
+AND (source IN ('manual', 'outlook_sync', 'thread_inherit') OR source IS NULL)
 ```
 
 **System-generated activity types to exclude:**
 - `activity_type = 'Milestone'` — auto-logged when policy status changes to Bound
-- `source = 'outlook_sync'` — auto-imported from Outlook email sweep
+
+**Activity sources that DO count as user work:**
+- `source = 'manual'` — user logged it themselves
+- `source = 'outlook_sync'` — synced email from Outlook (real client contact)
+- `source = 'thread_inherit'` — promoted from inbox via post-sync thread inheritance (still real correspondence)
+- `source IS NULL` — pre-migration-122 rows (predate the column)
 
 **System-generated audit operations to exclude:**
 - `(policy_milestones, INSERT)` — renewal checklist items auto-populated by system
@@ -31,16 +36,15 @@ AND source = 'manual'
 **User operations to KEEP:**
 - `(policy_milestones, UPDATE)` — user checking off a milestone = real work
 - All `clients`, `policies`, `contacts` operations — user is editing data
-- `source = 'manual'` activities — user logged it themselves
 
 ### Where Filtering Applies
 
 | Location | Function | What to filter |
 |----------|----------|----------------|
 | `activity_review.py` | Entry list building | Exclude `_SYSTEM_OPS` from audit entries |
-| `activity_review.py` | `_has_covering_activity()` | Only count `source='manual'` and non-Milestone |
-| `anomaly_engine.py` | Review gate "Recent Activity" | Only count user activities |
-| `anomaly_engine.py` | `_rule_no_activity()` | Only count user activities for staleness |
+| `activity_review.py` | `_has_covering_activity()` | Only count `source IN ('manual', 'outlook_sync', 'thread_inherit')` and non-Milestone |
+| `anomaly_engine.py` | Review gate "Recent Activity" | Only count user activities (manual / outlook_sync / thread_inherit / NULL) |
+| `anomaly_engine.py` | `_rule_no_activity()` | Same filter |
 
 ## Architecture
 

--- a/.claude/skills/policydb-outlook/SKILL.md
+++ b/.claude/skills/policydb-outlook/SKILL.md
@@ -56,6 +56,18 @@ class ComposeRequest(BaseModel):
 | **All other folders** | Only if has `outlook_capture_category` (default: "PDB") OR `[PDB:]` ref tag in content | Opt-in via category |
 | **Flagged (all folders)** | Always captured | N/A |
 
+> **Empty capture category is a hard error.** If `outlook_capture_category` is
+> blank, `sync_outlook` refuses to invoke `search_all_folders` (which would
+> otherwise ingest *every* message in *every* folder) and adds a warning to
+> the sync results banner. Sent + Flagged scans still proceed.
+
+### Resume window
+
+`last_outlook_sync` is captured **at the moment the sweep starts** (minus a 60s
+safety overlap), then written to config when the sweep completes. Storing the
+end-of-sweep timestamp would silently drop any email that arrived during the
+scan window. The 60s overlap is absorbed by the `outlook_message_id` dedup.
+
 ### Matching: Ref Tag + Thread Inheritance
 
 **Tier 1 — Ref tag matching:**
@@ -67,14 +79,24 @@ class ComposeRequest(BaseModel):
 **Tier 2 — Domain matching:**
 5. If no ref tag, match sender/recipient email domains against client websites and contact emails
 6. Skip domains in `freemail_domains` and `internal_email_domains` config (marsh.com, etc.)
-7. Requires unique client match — ambiguous (multiple clients) returns None
+7. **Archived clients are excluded** from the domain index — `_build_domain_index` filters `archived = 0`
+8. Requires unique client match — ambiguous (multiple clients) returns None
 
 **Tier 3 — Thread inheritance (post-sync pass):**
-8. After all emails processed, `_run_thread_inheritance()` propagates Tier 1 matches to unmatched inbox items in the same thread
-9. Thread = exact normalized subject match + same client via domain matching
-10. Only Tier 1 matches propagate (must have policy_id, issue_id, or program_id)
-11. Promoted items get `source='thread_inherit'`, `follow_up_done=1`
-12. Unmatched emails with no ref tag or thread match go to Inbox for manual triage
+9. After all emails processed, `_run_thread_inheritance()` propagates Tier 1 matches to unmatched inbox items in the same thread
+10. Thread = exact normalized subject match + same client via domain matching
+11. Only Tier 1 matches propagate (must have policy_id, issue_id, or program_id)
+12. Promoted items get `source='thread_inherit'`, `follow_up_done=1`
+13. Unmatched emails with no ref tag or thread match go to Inbox for manual triage
+14. **Historical scan is bounded to 90 days** (matches the matched-rows window) so the inbox doesn't slow every sync as items pile up
+
+### Performance: domain index
+
+`_build_domain_index(conn)` is called **once** at the top of `sync_outlook` and
+returns `{domain: {client_id, ...}}` covering both client websites and contact
+email domains for non-archived clients. The map is threaded into every
+`_match_by_domain` and `_run_thread_inheritance` call so a 500-email sweep does
+exactly one client/contact scan instead of N+1 queries per email.
 
 ### Resolution Priority (Most Specific Wins)
 
@@ -88,21 +110,50 @@ Each more-specific record's `client_id`/`policy_id` overwrites less-specific val
 
 | Scenario | Action |
 |----------|--------|
-| Ref tag match + existing same-day Email activity on same policy | Enrich: add `outlook_message_id`, `email_snippet` |
-| Ref tag match + no existing activity | Create: `activity_type='Email'`, `source='outlook_sync'` |
+| Ref tag match + existing same-day Email activity on same policy | Enrich: add `outlook_message_id`, `email_snippet`, `email_direction` |
+| Ref tag match + no existing activity | Create: `activity_type='Email'`, `source='outlook_sync'`, `email_direction` set |
 | Thread inheritance match (post-sync) | Create: `activity_type='Email'`, `source='thread_inherit'`, delete from inbox |
-| Sent, no match | Route to Inbox as `[Outlook Sent]` item |
+| Sent, no match | Route to Inbox as `[Outlook Sent]` item, `email_direction='sent'` |
 | Received/flagged, no match | Route to Inbox as `[Outlook Flagged]` / `[Outlook Received]` item |
+
+### Direction tracking (`email_direction` column)
+
+Migration **144** added `email_direction` (`'sent' | 'received' | 'flagged'`)
+to both `activity_log` and `inbox`. The pre-migration "Received: " subject
+prefix munging is gone — direction is read from the column. The migration
+backfills existing rows from the legacy prefix and the inbox `[Outlook Sent|
+Received|Flagged]` brackets, then strips the legacy prefix from
+`activity_log.subject`. `_normalize_subject` still tolerates a stray
+"Received: " for safety.
 
 ### Dedup
 
 Every imported email stores `outlook_message_id` on both `activity_log` and `inbox` tables. Checked before any creation — duplicates are counted as "skipped".
 
+When the user dismisses an Outlook-sourced activity OR an Outlook-sourced
+inbox row (single or bulk), the message_id is recorded in
+`dismissed_outlook_messages` so the next sync sweep won't re-import it.
+
+### Bulk dismiss (Inbox tab)
+
+The Action Center inbox tab exposes a "Bulk dismiss ▾" menu when there are
+pending Outlook items. Three scopes:
+
+| Scope | Behavior |
+|-------|----------|
+| `outlook_unmatched` | Dismiss every pending Outlook row with no `client_id` (i.e. true triage queue) |
+| `outlook_all` | Dismiss every pending Outlook row, matched or not |
+| `all_pending` | Dismiss every pending row including manual notes (red, confirm twice) |
+
+Endpoint: `POST /inbox/bulk-dismiss` with JSON body `{"scope": "outlook_unmatched"}`
+or `{"inbox_ids": [1,2,3]}`. All paths populate `dismissed_outlook_messages`
+for any rows that have an `outlook_message_id`.
+
 ## Subject Normalization (`_normalize_subject`)
 
 Used by thread inheritance to determine if two emails are in the same thread. Strips in order:
 
-1. `"Received: "` prefix (added by `_create_or_enrich_activity` for non-sent emails)
+1. Legacy `"Received: "` prefix from rows imported before migration 144 (modern rows store direction in `email_direction` column, no prefix)
 2. External sender warnings: `[EXTERNAL]`, `[EXT]`, `*External*`, `EXTERNAL:`, `[External Sender]` and variants
 3. Reply/forward prefixes: `Re:`, `RE:`, `Fwd:`, `FW:`, `Fw:` (repeated/nested)
 4. Collapse whitespace, strip, lowercase
@@ -111,17 +162,36 @@ Result: `"[EXTERNAL] RE: FW: Re: GL Renewal Discussion"` → `"gl renewal discus
 
 **Adding new prefix patterns:** If you encounter new corporate email prefixes (e.g., `[CAUTION]`, `[SPAM?]`), add them to `_EXTERNAL_RE` in `email_sync.py`.
 
+## Suggested contact capture
+
+`_capture_unknown_contacts` upserts unknown sender/recipient addresses into
+`suggested_contacts`. The filter cascade:
+
+1. Skip freemail domains (`gmail.com`, `outlook.com`, ...)
+2. Skip internal email domains (`marsh.com`, ...)
+3. Skip automated/noreply prefixes via `_is_automated_sender` — local part
+   matched against `automated_email_prefixes` config (default: `noreply`,
+   `no-reply`, `donotreply`, `mailer-daemon`, `postmaster`, `bounce`,
+   `bounces`, `notification`, `notifications`, `alert`, `alerts`,
+   `automated`, `system`). Also strips `+suffix` so
+   `bounces+abc123@list.com` → `bounces`.
+4. Skip if the resolved client is archived (whole capture is bypassed).
+5. Skip if already a known contact.
+
+`automated_email_prefixes` is editable in **Settings → Email & Contacts**.
+
 ## Config Keys
 
 | Key | Default | Purpose |
 |-----|---------|---------|
-| `last_outlook_sync` | null | ISO timestamp, cleared by Reset button in Settings |
+| `last_outlook_sync` | null | ISO timestamp **of the moment the sweep started** (minus 60s overlap), cleared by Reset button in Settings |
 | `outlook_sync_lookback_days` | 7 | First-sync lookback window |
-| `outlook_capture_category` | "PDB" | Outlook category for opt-in on received emails |
+| `outlook_capture_category` | "PDB" | Outlook category for opt-in on received emails. **Empty value triggers a sync error — refusing to scan all folders** |
 | `outlook_skip_category` | "Personal" | Outlook category to exclude sent emails |
 | `outlook_email_shell_header` | true | Navy header bar in formal HTML emails |
 | `freemail_domains` | gmail.com, etc. | Domains skipped during client matching (freemail providers) |
 | `internal_email_domains` | marsh.com, marshpm.com, mmc.com | Company domains skipped during client matching |
+| `automated_email_prefixes` | noreply, no-reply, donotreply, mailer-daemon, postmaster, bounce, bounces, notification, notifications, alert, alerts, automated, system | Local-part prefixes treated as automated senders and excluded from `_capture_unknown_contacts` |
 
 All editable in Settings > Email & Contacts tab. "Reset" button clears `last_outlook_sync` so next sync uses lookback window (safe — dedup prevents duplicates).
 
@@ -133,7 +203,7 @@ Emails almost always include multiple Marsh colleague addresses in CC/TO. Withou
 
 1. **`sender` property fails on sent messages** — wrap in `try/end try`, fall back to empty string
 2. **`content` returns HTML** — use `plain text content of msg` for ref tag matching, fall back to `content` if plain text fails
-3. **Body snippet truncation** — fetch 2000 chars from Outlook for matching, store only 500 chars (stripped of HTML) in `email_snippet`
+3. **Body snippet truncation** — AppleScript truncates at 100 000 chars per email (cap on subprocess stdout volume); `_create_or_enrich_activity` then runs `_clean_email_text(...)[:5000]` so only the first 5 000 cleaned chars land in `activity_log.email_snippet` / `inbox.content`
 4. **Flagged emails** — `todo flag of it is not not flagged` is the correct AppleScript syntax; `is flagged` does NOT work
 5. **Categories** — `categories of msg` returns a list of category objects; iterate and get `name of c`
 6. **Folder scanning** — `messages of inbox` only gets Inbox; use `every mail folder of default account` and iterate for cross-folder scans. Skip "Deleted Items", "Junk Email", "Drafts", "Trash", "Clutter", "Sent Items" (sent scanned separately)
@@ -155,13 +225,19 @@ Activities from sync show a "synced" badge (`source='outlook_sync'`). Thread-inh
 
 If an email auto-links to the wrong client/policy, the expandable detail row in the Activities table has Client and Policy dropdowns for reassignment. Changing client reloads the policy dropdown. Uses `PATCH /activities/{id}/field` with `client_id` or `policy_id`.
 
-## Migration 122
+## Migrations relevant to email sync
 
-```sql
-ALTER TABLE activity_log ADD COLUMN outlook_message_id TEXT;
-ALTER TABLE activity_log ADD COLUMN source TEXT NOT NULL DEFAULT 'manual';
-ALTER TABLE activity_log ADD COLUMN email_snippet TEXT;
-CREATE INDEX idx_activity_outlook_msgid ON activity_log(outlook_message_id) WHERE outlook_message_id IS NOT NULL;
-```
+- **122** `outlook_message_id`, `source`, `email_snippet` on `activity_log` + index
+- **123** `email_subject`, `email_date`, `outlook_message_id` on `inbox`
+- **125** `dismissed_outlook_messages` table — message_ids whose activities were intentionally deleted, so sync won't re-import
+- **129** `suggested_contacts` table — populated by `_capture_unknown_contacts`
+- **132** `email_from` / `email_to` on `activity_log` and `inbox`
+- **144** `email_direction` on `activity_log` and `inbox` (`'sent' | 'received' | 'flagged'`); backfills from legacy `Received: ` prefix and `[Outlook Sent|Received|Flagged]` brackets, then strips the legacy prefix from existing subjects
 
-Inbox table also has `outlook_message_id`, `email_subject`, `email_date` columns (added in same session).
+## Activity filter rule (anomaly engine + activity review)
+
+`anomaly_engine.py` and `activity_review.py` count **`source IN ('manual',
+'outlook_sync', 'thread_inherit') OR source IS NULL`** as user activity.
+Including `thread_inherit` is required so renewals where most correspondence
+was promoted via thread inheritance still register as "active" — leaving it
+out causes silent false-positive `no_activity` anomaly findings.

--- a/src/policydb/activity_review.py
+++ b/src/policydb/activity_review.py
@@ -216,14 +216,14 @@ def _has_covering_activity(
 
     # Check if any user-created activity was created within the session window
     # (±30 min).  Exclude system-generated activities (Milestone auto-logs).
-    # outlook_sync emails count as real work — synced emails represent genuine
-    # client contact and should satisfy the covering-activity check.
+    # outlook_sync and thread_inherit emails count as real work — they
+    # represent genuine client contact and satisfy the covering-activity check.
     count = conn.execute(
         """SELECT COUNT(*) FROM activity_log
            WHERE client_id = ?
            AND created_at >= ? AND created_at <= ?
            AND activity_type NOT IN ('Milestone')
-           AND source IN ('manual', 'outlook_sync')""",
+           AND source IN ('manual', 'outlook_sync', 'thread_inherit')""",
         (client_id, window_start, window_end),
     ).fetchone()[0]
 

--- a/src/policydb/activity_review.py
+++ b/src/policydb/activity_review.py
@@ -218,12 +218,14 @@ def _has_covering_activity(
     # (±30 min).  Exclude system-generated activities (Milestone auto-logs).
     # outlook_sync and thread_inherit emails count as real work — they
     # represent genuine client contact and satisfy the covering-activity check.
+    # Include `source IS NULL` for parity with anomaly_engine (pre-migration-122
+    # rows legitimately have no source).
     count = conn.execute(
         """SELECT COUNT(*) FROM activity_log
            WHERE client_id = ?
            AND created_at >= ? AND created_at <= ?
            AND activity_type NOT IN ('Milestone')
-           AND source IN ('manual', 'outlook_sync', 'thread_inherit')""",
+           AND (source IN ('manual', 'outlook_sync', 'thread_inherit') OR source IS NULL)""",
         (client_id, window_start, window_end),
     ).fetchone()[0]
 

--- a/src/policydb/anomaly_engine.py
+++ b/src/policydb/anomaly_engine.py
@@ -290,13 +290,13 @@ def _rule_no_activity(conn, thresholds: dict) -> list[tuple]:
     findings = []
     for c in clients:
         # Any recent user-created activity? (exclude system-generated Milestones;
-        # outlook_sync emails count as real client contact)
+        # outlook_sync and thread_inherit emails count as real client contact)
         act_row = conn.execute(
             """SELECT MAX(DATE(activity_date)) AS last_act
                FROM activity_log
                WHERE client_id = ? AND DATE(activity_date) >= DATE(?)
                AND activity_type NOT IN ('Milestone')
-               AND (source IN ('manual', 'outlook_sync') OR source IS NULL)""",
+               AND (source IN ('manual', 'outlook_sync', 'thread_inherit') OR source IS NULL)""",
             (c["id"], cutoff),
         ).fetchone()
         if act_row and act_row["last_act"]:
@@ -313,12 +313,12 @@ def _rule_no_activity(conn, thresholds: dict) -> list[tuple]:
         if rev_row and rev_row["last_rev"]:
             continue
 
-        # How long since last user-created activity? (outlook_sync emails count)
+        # How long since last user-created activity? (outlook_sync + thread_inherit count)
         last_any = conn.execute(
             """SELECT MAX(DATE(activity_date)) AS last_act
                FROM activity_log WHERE client_id = ?
                AND activity_type NOT IN ('Milestone')
-               AND (source IN ('manual', 'outlook_sync') OR source IS NULL)""",
+               AND (source IN ('manual', 'outlook_sync', 'thread_inherit') OR source IS NULL)""",
             (c["id"],),
         ).fetchone()
         if last_any and last_any["last_act"]:
@@ -726,9 +726,9 @@ def get_review_gate_status(conn, record_type: str, record_id: int) -> dict:
         })
 
     # 2. Recent activity
-    # Count manual activities and outlook_sync emails (synced emails represent
-    # genuine client contact). Exclude system-generated Milestone auto-logs.
-    _user_act_filter = "AND activity_type NOT IN ('Milestone') AND (source IN ('manual', 'outlook_sync') OR source IS NULL)"
+    # Count manual activities, outlook_sync, and thread_inherit emails — all
+    # represent genuine client contact. Exclude system-generated Milestone auto-logs.
+    _user_act_filter = "AND activity_type NOT IN ('Milestone') AND (source IN ('manual', 'outlook_sync', 'thread_inherit') OR source IS NULL)"
     if record_type == "client":
         act_row = conn.execute(
             f"""SELECT COUNT(*) AS cnt FROM activity_log

--- a/src/policydb/config.py
+++ b/src/policydb/config.py
@@ -843,6 +843,15 @@ _DEFAULTS: dict[str, Any] = {
     "internal_email_domains": [
         "marsh.com", "marshpm.com", "mmc.com",
     ],
+    "automated_email_prefixes": [
+        "noreply", "no-reply", "no_reply",
+        "donotreply", "do-not-reply", "do_not_reply",
+        "mailer-daemon", "postmaster",
+        "bounce", "bounces",
+        "notification", "notifications",
+        "alert", "alerts",
+        "automated", "system",
+    ],
 }
 
 _config: dict[str, Any] | None = None

--- a/src/policydb/db.py
+++ b/src/policydb/db.py
@@ -1886,6 +1886,15 @@ def _init_db_inner(conn: sqlite3.Connection, db_path: Path) -> None:
         conn.commit()
         logger.info("Migration 143: added project_scratchpad table")
 
+    if 144 not in applied:
+        conn.executescript((_MIGRATIONS_DIR / "144_email_direction.sql").read_text())
+        conn.execute(
+            "INSERT INTO schema_version (version, description) VALUES (?, ?)",
+            (144, "Add email_direction column to activity_log and inbox"),
+        )
+        conn.commit()
+        logger.info("Migration 144: added email_direction column")
+
     # Data hygiene: fix 'None' string corruption in text fields (runs every startup, fast no-op if clean)
     conn.execute("UPDATE clients SET cn_number = NULL WHERE cn_number = 'None'")
 

--- a/src/policydb/db.py
+++ b/src/policydb/db.py
@@ -364,7 +364,7 @@ def _init_db_inner(conn: sqlite3.Connection, db_path: Path) -> None:
     # Back up the database once before running any pending migrations.
     # This gives a clean restore point regardless of which migration fails.
 
-    _KNOWN_MIGRATIONS = set(range(1, 142))  # update upper bound when adding new migrations
+    _KNOWN_MIGRATIONS = set(range(1, 145))  # update upper bound when adding new migrations
 
     if _KNOWN_MIGRATIONS - applied:
         _backup_db(conn, db_path)

--- a/src/policydb/email_sync.py
+++ b/src/policydb/email_sync.py
@@ -520,13 +520,16 @@ def _create_or_enrich_activity(
     # Can't create activity without a client
     if not client_id:
         return {"action": "skipped", "activity_id": 0, "reason": "no_client"}
-    folder = email.get("folder", "")
-    subject = email.get("subject", "")
-    sender = email.get("sender", "")
-    recipients = ", ".join(email.get("recipients", [])[:5])
+    # Defensive `or ""` on every field that goes through string ops — the
+    # AppleScript bridge always emits strings in practice, but a malformed
+    # JSON parse fallback or future change could surface None and crash.
+    folder = email.get("folder") or ""
+    subject = email.get("subject") or ""
+    sender = email.get("sender") or ""
+    recipients = ", ".join((email.get("recipients") or [])[:5])
     # Clean and store readable text snippet
-    snippet = _clean_email_text(email.get("body_snippet", ""))[:5000]
-    email_date = email.get("date", "")[:10]  # ISO date portion
+    snippet = _clean_email_text(email.get("body_snippet") or "")[:5000]
+    email_date = (email.get("date") or "")[:10]  # ISO date portion
     flag_due = email.get("flag_due_date")
 
     is_sent = folder.lower() in ("sent items", "sent")
@@ -941,8 +944,8 @@ def _process_email(
 ) -> None:
     """Process a single email: extract ref tags, match, create/enrich activity."""
     # Strip HTML tags from body before searching for ref tags
-    body = _HTML_TAG_RE.sub('', email.get("body_snippet", ""))
-    combined_text = email.get("subject", "") + " " + body
+    body = _HTML_TAG_RE.sub('', email.get("body_snippet") or "")
+    combined_text = (email.get("subject") or "") + " " + body
     # Dedup tags so we don't resolve the same tag twice when it appears in both
     # subject and body.
     tags = list(dict.fromkeys(_extract_ref_tags(combined_text)))
@@ -995,14 +998,14 @@ def _process_email(
             if existing_inbox:
                 results["skipped"] += 1
                 return
-        subject = email.get("subject", "")
-        sender = email.get("sender", "")
-        folder = email.get("folder", "")
-        date_str = (email.get("date", "") or "")[:10]
-        snippet = _clean_email_text(email.get("body_snippet", ""))[:5000]
+        subject = email.get("subject") or ""
+        sender = email.get("sender") or ""
+        folder = email.get("folder") or ""
+        date_str = (email.get("date") or "")[:10]
+        snippet = _clean_email_text(email.get("body_snippet") or "")[:5000]
         label_map = {"flagged": "[Outlook Flagged]", "sent": "[Outlook Sent]", "received": "[Outlook Received]"}
         label = label_map.get(category, "[Outlook]")
-        recipients = ", ".join(email.get("recipients", [])[:3])
+        recipients = ", ".join((email.get("recipients") or [])[:3])
         content = f"{label} {subject}\nFrom: {sender}\nTo: {recipients}\nFolder: {folder}\nDate: {date_str}"
         if snippet:
             content += f"\n\n{snippet}"

--- a/src/policydb/email_sync.py
+++ b/src/policydb/email_sync.py
@@ -21,6 +21,35 @@ logger = logging.getLogger(__name__)
 _REF_TAG_RE = re.compile(r'\[PDB:([^\]]+)\]')
 _HTML_TAG_RE = re.compile(r'<[^>]+>')
 
+# Default automated/noreply local-part prefixes — overridable via
+# cfg.get("automated_email_prefixes"). Match is anchored on local part.
+_DEFAULT_AUTOMATED_PREFIXES = (
+    "noreply", "no-reply", "no_reply", "donotreply", "do-not-reply", "do_not_reply",
+    "mailer-daemon", "postmaster", "bounce", "bounces", "notification", "notifications",
+    "alert", "alerts", "automated", "system", "info", "support", "newsletter",
+)
+
+
+def _is_automated_sender(address: str) -> bool:
+    """Return True if the email address looks like an automated/noreply sender.
+
+    Matches the local part (before @) against a list of common automated prefixes,
+    plus any '+' suffix conventions (e.g. 'bounces+abc123@example.com').
+    """
+    if not address or "@" not in address:
+        return False
+    local = address.strip().lower().rsplit("@", 1)[0]
+    # Strip '+suffix' so 'bounces+abc123' → 'bounces'
+    base = local.split("+", 1)[0]
+    prefixes = cfg.get("automated_email_prefixes", list(_DEFAULT_AUTOMATED_PREFIXES))
+    for p in prefixes:
+        p_norm = (p or "").strip().lower()
+        if not p_norm:
+            continue
+        if base == p_norm or base.startswith(p_norm + "."):
+            return True
+    return False
+
 
 def _extract_ref_tags(text: str) -> list[str]:
     """Extract all [PDB:...] ref tags from text."""
@@ -38,11 +67,12 @@ _EXTERNAL_RE = re.compile(
 def _normalize_subject(subject: str) -> str:
     """Normalize an email subject for thread comparison.
 
-    Strips Re:/Fwd:/FW: prefixes (repeated/nested), external sender warnings,
-    the "Received: " prefix added by sync, collapses whitespace, lowercases.
+    Strips Re:/Fwd:/FW: prefixes (repeated/nested) and external sender warnings,
+    collapses whitespace, lowercases. Also tolerates legacy "Received: " prefixes
+    from rows imported before email_direction column existed (migration 144).
     """
     s = subject or ""
-    # Strip "Received: " prefix added by _create_or_enrich_activity
+    # Strip legacy "Received: " prefix (pre-migration-144 data)
     if s.startswith("Received: "):
         s = s[10:]
     # Strip external sender warnings
@@ -128,11 +158,55 @@ def _extract_domain(email_or_url: str) -> str:
     return s
 
 
-def _match_by_domain(conn: sqlite3.Connection, email_addresses: list[str]) -> dict | None:
+def _build_domain_index(conn: sqlite3.Connection) -> dict[str, set[int]]:
+    """Build a {domain: {client_id, ...}} map once per sync.
+
+    Indexes both client website domains and contact email domains, restricted to
+    non-archived clients. Used by `_match_by_domain` to avoid an N+1 query
+    pattern across hundreds of emails.
+    """
+    index: dict[str, set[int]] = {}
+
+    # Client website domains
+    for row in conn.execute(
+        """SELECT id, website FROM clients
+           WHERE archived = 0 AND website IS NOT NULL AND website != ''"""
+    ).fetchall():
+        d = _extract_domain(row["website"])
+        if d:
+            index.setdefault(d, set()).add(row["id"])
+
+    # Contact email domains via assignments — only for active clients
+    for row in conn.execute(
+        """SELECT DISTINCT LOWER(TRIM(co.email)) AS email, cca.client_id
+           FROM contacts co
+           JOIN contact_client_assignments cca ON co.id = cca.contact_id
+           JOIN clients c ON cca.client_id = c.id
+           WHERE c.archived = 0
+             AND co.email IS NOT NULL AND co.email != ''"""
+    ).fetchall():
+        email = row["email"] or ""
+        if "@" in email:
+            d = email.rsplit("@", 1)[1]
+            if d:
+                index.setdefault(d, set()).add(row["client_id"])
+
+    return index
+
+
+def _match_by_domain(
+    conn: sqlite3.Connection,
+    email_addresses: list[str],
+    domain_index: dict[str, set[int]] | None = None,
+) -> dict | None:
     """Tier 2: match email addresses to a client by domain.
 
-    Checks client website fields and contact email domains.
-    Returns match dict with tier=2 or None if no unique match.
+    Uses a pre-built domain index when available (built once per sync via
+    `_build_domain_index`). Falls back to building one on-demand when called
+    outside a sync context (e.g. ad-hoc inbox routing). Skips freemail and
+    internal domains. Excludes archived clients.
+
+    Returns a match dict with tier=2 or None if no unique match.
     """
     skip_domains = set(cfg.get("freemail_domains", []))
     skip_domains.update(cfg.get("internal_email_domains", []))
@@ -145,29 +219,12 @@ def _match_by_domain(conn: sqlite3.Connection, email_addresses: list[str]) -> di
     if not domains:
         return None
 
-    matched_clients: dict[int, str] = {}  # client_id -> match source
+    if domain_index is None:
+        domain_index = _build_domain_index(conn)
 
+    matched_clients: set[int] = set()
     for domain in domains:
-        # 1. Match against client website field
-        rows = conn.execute(
-            "SELECT id, website FROM clients WHERE website IS NOT NULL AND website != ''",
-        ).fetchall()
-        for row in rows:
-            client_domain = _extract_domain(row["website"])
-            if client_domain == domain:
-                matched_clients[row["id"]] = "website"
-
-        # 2. Match against contact email domains via assignments
-        contact_rows = conn.execute(
-            """SELECT DISTINCT cca.client_id
-               FROM contacts co
-               JOIN contact_client_assignments cca ON co.id = cca.contact_id
-               WHERE LOWER(TRIM(co.email)) LIKE ?""",
-            (f"%@{domain}",),
-        ).fetchall()
-        for cr in contact_rows:
-            if cr["client_id"] not in matched_clients:
-                matched_clients[cr["client_id"]] = "contact_domain"
+        matched_clients.update(domain_index.get(domain, set()))
 
     if len(matched_clients) == 1:
         client_id = next(iter(matched_clients))
@@ -175,7 +232,10 @@ def _match_by_domain(conn: sqlite3.Connection, email_addresses: list[str]) -> di
 
     if len(matched_clients) > 1:
         # Ambiguous — return None, caller will route to inbox
-        logger.debug("Domain match ambiguous: %d clients matched for domains %s", len(matched_clients), domains)
+        logger.debug(
+            "Domain match ambiguous: %d clients matched for domains %s",
+            len(matched_clients), domains,
+        )
         return None
 
     return None
@@ -204,6 +264,14 @@ def _capture_unknown_contacts(
     # (Internal domains ARE filtered in _match_by_domain() for client matching.)
     subject = email.get("subject", "")
 
+    # Skip capture entirely if the resolved client is archived
+    if client_id:
+        archived_row = conn.execute(
+            "SELECT archived FROM clients WHERE id = ?", (client_id,),
+        ).fetchone()
+        if archived_row and archived_row["archived"]:
+            return
+
     for addr, display in addresses:
         addr_lower = addr.lower().strip()
         if not addr_lower or "@" not in addr_lower:
@@ -211,6 +279,10 @@ def _capture_unknown_contacts(
 
         domain = addr_lower.rsplit("@", 1)[1]
         if domain in skip_domains:
+            continue
+
+        # Skip noreply / bounce / mailer-daemon / notifications / etc.
+        if _is_automated_sender(addr_lower):
             continue
 
         # Skip if already a known contact
@@ -458,6 +530,15 @@ def _create_or_enrich_activity(
     flag_due = email.get("flag_due_date")
 
     is_sent = folder.lower() in ("sent items", "sent")
+    # Flagged items (from get_flagged_emails) are action items — leave follow_up_done=0.
+    # Regular sent/received imports are records, not action items.
+    is_flagged = "flag_due_date" in email  # Only flagged emails have this key
+    if is_flagged:
+        email_direction = "flagged"
+    elif is_sent:
+        email_direction = "sent"
+    else:
+        email_direction = "received"
 
     # Check if there's an existing same-day email activity for this policy
     if is_sent and policy_id:
@@ -473,16 +554,16 @@ def _create_or_enrich_activity(
             conn.execute(
                 """UPDATE activity_log
                    SET outlook_message_id=?, email_snippet=?, source='outlook_sync',
-                       email_from=?, email_to=?
+                       email_from=?, email_to=?, email_direction=?
                    WHERE id=?""",
-                (message_id, snippet, sender, recipients, existing_activity["id"]),
+                (message_id, snippet, sender, recipients, email_direction,
+                 existing_activity["id"]),
             )
             conn.commit()
             return {"action": "enriched", "activity_id": existing_activity["id"]}
 
     # Create new activity
     disposition = "Sent Email" if is_sent else ""
-    subj_prefix = "" if is_sent else "Received: "
 
     # Resolve contact from sender email
     contact_id = None
@@ -496,24 +577,19 @@ def _create_or_enrich_activity(
             contact_id = contact["id"]
             contact_person = contact["name"] or sender
 
-    # Flagged items (from get_flagged_emails) are action items — leave follow_up_done=0.
-    # Regular sent/received imports are records, not action items — mark follow_up_done=1
-    # so they don't clutter the Action Center.
-    is_flagged = "flag_due_date" in email  # Only flagged emails have this key
-
     cursor = conn.execute(
         """INSERT INTO activity_log
            (activity_date, client_id, policy_id, program_id, activity_type, subject, details,
             contact_person, contact_id, disposition, source, outlook_message_id,
             email_snippet, issue_id, follow_up_date, follow_up_done,
-            email_from, email_to, duration_hours)
-           VALUES (?, ?, ?, ?, 'Email', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            email_from, email_to, email_direction, duration_hours)
+           VALUES (?, ?, ?, ?, 'Email', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             email_date,
             client_id,
             policy_id,
             program_id,
-            f"{subj_prefix}{subject}",
+            subject,
             f"Imported from Outlook ({folder})",
             contact_person,
             contact_id,
@@ -526,6 +602,7 @@ def _create_or_enrich_activity(
             0 if is_flagged else 1,  # Only open follow-up for flagged items
             sender,
             recipients,
+            email_direction,
             0.1,
         ),
     )
@@ -538,6 +615,7 @@ def _run_thread_inheritance(
     conn: sqlite3.Connection,
     current_batch_inbox: list[dict],
     results: dict,
+    domain_index: dict[str, set[int]] | None = None,
 ) -> None:
     """Propagate ref tag matches to unmatched emails in the same thread.
 
@@ -592,12 +670,16 @@ def _run_thread_inheritance(
         if inbox_row:
             inbox_candidates.append(dict(inbox_row))
 
+    # Bound the historical scan to the last 90 days so the inbox doesn't make
+    # every sync slower as items pile up. Same window as the matched_rows query
+    # above — anything older won't have a thread map entry anyway.
     historical = conn.execute("""
         SELECT id, content, outlook_message_id, email_subject, email_date,
                email_from, email_to
         FROM inbox
         WHERE outlook_message_id IS NOT NULL
           AND status = 'pending'
+          AND created_at >= datetime('now', '-90 days')
     """).fetchall()
     seen_ids = {c["id"] for c in inbox_candidates}
     for row in historical:
@@ -620,7 +702,7 @@ def _run_thread_inheritance(
         content = candidate.get("content", "")
         addresses = re.findall(r'[\w.+-]+@[\w-]+\.[\w.-]+', content)
 
-        domain_match = _match_by_domain(conn, addresses)
+        domain_match = _match_by_domain(conn, addresses, domain_index=domain_index)
         if not domain_match:
             continue
         candidate_client_id = domain_match.get("client_id")
@@ -687,8 +769,8 @@ def _run_thread_inheritance(
                (activity_date, client_id, policy_id, program_id, activity_type, subject,
                 details, contact_person, contact_id, source, outlook_message_id,
                 email_snippet, issue_id, follow_up_done,
-                email_from, email_to, duration_hours)
-               VALUES (?, ?, ?, ?, 'Email', ?, ?, ?, ?, 'thread_inherit', ?, ?, ?, 1, ?, ?, 0.1)""",
+                email_from, email_to, email_direction, duration_hours)
+               VALUES (?, ?, ?, ?, 'Email', ?, ?, ?, ?, 'thread_inherit', ?, ?, ?, 1, ?, ?, ?, 0.1)""",
             (
                 email_date,
                 inherited_match["client_id"],
@@ -703,6 +785,7 @@ def _run_thread_inheritance(
                 inherited_match.get("issue_id"),
                 sender,
                 email_to,
+                "received",
             ),
         )
 
@@ -733,6 +816,13 @@ def sync_outlook(conn: sqlite3.Connection) -> dict:
     else:
         since = datetime.now() - timedelta(days=cfg.get("outlook_sync_lookback_days", 7))
 
+    # Capture the start-of-sweep timestamp BEFORE invoking AppleScript so the
+    # next sync resumes from this instant. Storing datetime.now() at the END
+    # (legacy behavior) silently dropped any email that arrived during the
+    # scan. We subtract a 60s overlap as a safety margin — dedup on
+    # outlook_message_id will absorb the rescan.
+    sweep_start = datetime.now() - timedelta(seconds=60)
+
     results = {
         "auto_linked": {"sent": 0, "received": 0, "flagged": 0},
         "suggestions": [],
@@ -745,7 +835,10 @@ def sync_outlook(conn: sqlite3.Connection) -> dict:
     }
 
     skip_category = cfg.get("outlook_skip_category", "Personal")
-    capture_category = cfg.get("outlook_capture_category", "PDB")
+    capture_category = (cfg.get("outlook_capture_category", "PDB") or "").strip()
+
+    # ── Build domain index once for the whole sweep (perf) ───────────
+    domain_index = _build_domain_index(conn)
 
     # ── Scan Sent Items (default-in, skip "Personal" category) ───────
     sent_result = search_emails("Sent Items", since)
@@ -759,16 +852,25 @@ def sync_outlook(conn: sqlite3.Connection) -> dict:
             if skip_category and skip_category in cats:
                 results["skipped"] += 1
                 continue
-            _process_email(conn, email, results, "sent")
+            _process_email(conn, email, results, "sent", domain_index=domain_index)
 
     # ── Scan all folders for "PDB" category or [PDB:] ref tag ────────
-    received_result = search_all_folders(since, category_filter=capture_category)
-    if not received_result.get("ok"):
-        results["errors"].append(received_result.get("error", "Failed to scan received emails"))
+    # Refuse to scan when the capture category is empty: AppleScript would
+    # treat that as "no filter" and ingest every message in every folder.
+    if not capture_category:
+        results["errors"].append(
+            "Outlook capture category is empty — refusing to scan all folders. "
+            "Set 'outlook_capture_category' in Settings (default: PDB)."
+        )
+        logger.warning("Skipping all-folder scan: outlook_capture_category is empty")
     else:
-        for email in received_result.get("emails", []):
-            results["total_scanned"] += 1
-            _process_email(conn, email, results, "received")
+        received_result = search_all_folders(since, category_filter=capture_category)
+        if not received_result.get("ok"):
+            results["errors"].append(received_result.get("error", "Failed to scan received emails"))
+        else:
+            for email in received_result.get("emails", []):
+                results["total_scanned"] += 1
+                _process_email(conn, email, results, "received", domain_index=domain_index)
 
     # ── Scan Flagged across all folders → inbox ──────────────────────
     flagged_result = get_flagged_emails(since)
@@ -777,11 +879,13 @@ def sync_outlook(conn: sqlite3.Connection) -> dict:
     else:
         for email in flagged_result.get("emails", []):
             results["total_scanned"] += 1
-            _process_email(conn, email, results, "flagged")
+            _process_email(conn, email, results, "flagged", domain_index=domain_index)
 
     # ── Thread inheritance pass ─────────────────────────────────────
     try:
-        _run_thread_inheritance(conn, list(results["suggestions"]), results)
+        _run_thread_inheritance(
+            conn, list(results["suggestions"]), results, domain_index=domain_index,
+        )
     except Exception as e:
         logger.exception("Thread inheritance pass failed: %s", e)
         results["errors"].append(f"Thread inheritance error: {e}")
@@ -791,9 +895,11 @@ def sync_outlook(conn: sqlite3.Connection) -> dict:
         "SELECT COUNT(*) FROM suggested_contacts WHERE status='pending' AND blocked=0"
     ).fetchone()[0]
 
-    # ── Update last sync timestamp ───────────────────────────────────
+    # ── Update last sync timestamp (use sweep_start, NOT datetime.now()) ──
+    # Storing the moment the sweep BEGAN ensures emails that arrived during
+    # the sweep get picked up next time. Dedup absorbs the small overlap.
     config_data = dict(cfg.load_config())
-    config_data["last_outlook_sync"] = datetime.now().isoformat()
+    config_data["last_outlook_sync"] = sweep_start.isoformat()
     cfg.save_config(config_data)
     cfg.reload_config()
 
@@ -831,12 +937,15 @@ def _process_email(
     email: dict,
     results: dict,
     category: str,  # "sent", "received", "flagged"
+    domain_index: dict[str, set[int]] | None = None,
 ) -> None:
     """Process a single email: extract ref tags, match, create/enrich activity."""
     # Strip HTML tags from body before searching for ref tags
     body = _HTML_TAG_RE.sub('', email.get("body_snippet", ""))
     combined_text = email.get("subject", "") + " " + body
-    tags = _extract_ref_tags(combined_text)
+    # Dedup tags so we don't resolve the same tag twice when it appears in both
+    # subject and body.
+    tags = list(dict.fromkeys(_extract_ref_tags(combined_text)))
 
     # Resolve ALL tags — one activity per unique (client_id, policy_id) pair
     matches: list[dict] = []
@@ -849,6 +958,8 @@ def _process_email(
                 if pair not in seen_pairs:
                     seen_pairs.add(pair)
                     matches.append(match)
+            else:
+                logger.debug("Ref tag did not resolve: %s", tag)
 
     if not matches:
         # Tier 2: try domain-based matching
@@ -856,7 +967,7 @@ def _process_email(
         if email.get("sender"):
             all_addresses.append(email["sender"])
         all_addresses.extend(email.get("recipients", []))
-        domain_match = _match_by_domain(conn, all_addresses)
+        domain_match = _match_by_domain(conn, all_addresses, domain_index=domain_index)
         if domain_match:
             matches.append(domain_match)
 
@@ -898,9 +1009,9 @@ def _process_email(
         conn.execute(
             """INSERT INTO inbox (content, client_id, contact_id, inbox_uid,
                                   email_subject, email_date, outlook_message_id,
-                                  email_from, email_to)
-               VALUES (?, NULL, NULL, '', ?, ?, ?, ?, ?)""",
-            (content, subject, date_str, message_id, sender, recipients),
+                                  email_from, email_to, email_direction)
+               VALUES (?, NULL, NULL, '', ?, ?, ?, ?, ?, ?)""",
+            (content, subject, date_str, message_id, sender, recipients, category),
         )
         row_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
         conn.execute("UPDATE inbox SET inbox_uid = ? WHERE id = ?", (f"INB-{row_id}", row_id))

--- a/src/policydb/migrations/144_email_direction.sql
+++ b/src/policydb/migrations/144_email_direction.sql
@@ -1,0 +1,40 @@
+-- Track email direction as a first-class column instead of munging the subject
+-- with a "Received: " prefix. Values: 'sent', 'received', 'flagged', or NULL.
+ALTER TABLE activity_log ADD COLUMN email_direction TEXT;
+ALTER TABLE inbox ADD COLUMN email_direction TEXT;
+
+-- Backfill from the legacy "Received: " subject prefix so existing rows survive.
+UPDATE activity_log
+   SET email_direction = 'received'
+ WHERE email_direction IS NULL
+   AND activity_type = 'Email'
+   AND subject LIKE 'Received: %';
+
+UPDATE activity_log
+   SET email_direction = 'sent'
+ WHERE email_direction IS NULL
+   AND activity_type = 'Email'
+   AND outlook_message_id IS NOT NULL
+   AND (subject NOT LIKE 'Received: %');
+
+-- Strip the legacy prefix from existing subjects now that direction is tracked
+-- as a column (display layer reads the column, not the prefix).
+UPDATE activity_log
+   SET subject = SUBSTR(subject, 11)
+ WHERE subject LIKE 'Received: %';
+
+-- Backfill inbox direction from the bracket label embedded in content
+UPDATE inbox
+   SET email_direction = 'sent'
+ WHERE email_direction IS NULL
+   AND content LIKE '[Outlook Sent]%';
+
+UPDATE inbox
+   SET email_direction = 'received'
+ WHERE email_direction IS NULL
+   AND content LIKE '[Outlook Received]%';
+
+UPDATE inbox
+   SET email_direction = 'flagged'
+ WHERE email_direction IS NULL
+   AND content LIKE '[Outlook Flagged]%';

--- a/src/policydb/migrations/144_email_direction.sql
+++ b/src/policydb/migrations/144_email_direction.sql
@@ -3,27 +3,55 @@
 ALTER TABLE activity_log ADD COLUMN email_direction TEXT;
 ALTER TABLE inbox ADD COLUMN email_direction TEXT;
 
--- Backfill from the legacy "Received: " subject prefix so existing rows survive.
+-- ── Backfill activity_log.email_direction ────────────────────────────────
+--
+-- Order matters: the more authoritative signals run first so the catch-all
+-- never overwrites a confident classification.
+
+-- 1) Received — rows with the legacy "Received: " subject prefix
 UPDATE activity_log
    SET email_direction = 'received'
  WHERE email_direction IS NULL
    AND activity_type = 'Email'
    AND subject LIKE 'Received: %';
 
+-- 2) Received — thread-inherited rows. The legacy _run_thread_inheritance()
+--    code did NOT add the "Received: " prefix to these, so they need an
+--    explicit pass; without this they'd be misclassified as 'sent' by the
+--    catch-all below (since they have outlook_message_id but no prefix).
+UPDATE activity_log
+   SET email_direction = 'received'
+ WHERE email_direction IS NULL
+   AND activity_type = 'Email'
+   AND source = 'thread_inherit';
+
+-- 3) Sent — outlook-sourced rows whose disposition is the legacy "Sent Email"
+--    tag. This is the only authoritative outbound-direction signal in the
+--    legacy data: _create_or_enrich_activity wrote disposition='Sent Email'
+--    on sent imports only.
 UPDATE activity_log
    SET email_direction = 'sent'
  WHERE email_direction IS NULL
    AND activity_type = 'Email'
    AND outlook_message_id IS NOT NULL
-   AND (subject NOT LIKE 'Received: %');
+   AND disposition = 'Sent Email';
 
--- Strip the legacy prefix from existing subjects now that direction is tracked
--- as a column (display layer reads the column, not the prefix).
+-- 4) Received — catch-all for any remaining outlook-sourced row. Anything
+--    that has an outlook_message_id and isn't sent is, by elimination,
+--    received (unflagged) imported correspondence.
+UPDATE activity_log
+   SET email_direction = 'received'
+ WHERE email_direction IS NULL
+   AND activity_type = 'Email'
+   AND outlook_message_id IS NOT NULL;
+
+-- Strip the legacy prefix from existing subjects now that direction is
+-- tracked as a column. Display layer reads the column, not the prefix.
 UPDATE activity_log
    SET subject = SUBSTR(subject, 11)
  WHERE subject LIKE 'Received: %';
 
--- Backfill inbox direction from the bracket label embedded in content
+-- ── Backfill inbox.email_direction from the [Outlook ...] bracket label ──
 UPDATE inbox
    SET email_direction = 'sent'
  WHERE email_direction IS NULL

--- a/src/policydb/web/routes/inbox.py
+++ b/src/policydb/web/routes/inbox.py
@@ -498,6 +498,11 @@ def inbox_dismiss(inbox_id: int, conn=Depends(get_db)):
     })
 
 
+# SQLite default SQLITE_MAX_VARIABLE_NUMBER is 999 on older builds, 32766 on
+# newer. Stay well below the lower bound to be safe with parameterized IN clauses.
+_BULK_CHUNK = 500
+
+
 @router.post("/inbox/bulk-dismiss")
 async def inbox_bulk_dismiss(request: Request, conn=Depends(get_db)):
     """Bulk dismiss inbox items.
@@ -513,9 +518,33 @@ async def inbox_bulk_dismiss(request: Request, conn=Depends(get_db)):
     For any Outlook-sourced rows, message_ids are also written to
     `dismissed_outlook_messages` so the next sync doesn't re-import them.
     """
-    body = await request.json()
-    inbox_ids = body.get("inbox_ids") or []
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"ok": False, "error": "Invalid JSON body"}, status_code=400)
+
+    if not isinstance(body, dict):
+        return JSONResponse({"ok": False, "error": "Body must be a JSON object"}, status_code=400)
+
+    raw_ids = body.get("inbox_ids") or []
     scope = (body.get("scope") or "").strip()
+
+    # Validate inbox_ids shape — must be a list of integers (or coercible)
+    inbox_ids: list[int] = []
+    if raw_ids:
+        if not isinstance(raw_ids, list):
+            return JSONResponse(
+                {"ok": False, "error": "inbox_ids must be a list of integers"},
+                status_code=400,
+            )
+        for x in raw_ids:
+            try:
+                inbox_ids.append(int(x))
+            except (TypeError, ValueError):
+                return JSONResponse(
+                    {"ok": False, "error": "inbox_ids must contain only integers"},
+                    status_code=400,
+                )
 
     if not inbox_ids and not scope:
         return JSONResponse({"ok": False, "error": "Provide inbox_ids or scope"}, status_code=400)
@@ -539,13 +568,18 @@ async def inbox_bulk_dismiss(request: Request, conn=Depends(get_db)):
                WHERE status = 'pending'"""
         ).fetchall()
     elif inbox_ids:
-        # Use parameterized IN with a generated placeholder list
-        placeholders = ",".join("?" * len(inbox_ids))
-        rows = conn.execute(
-            f"""SELECT id, outlook_message_id FROM inbox
-                WHERE status = 'pending' AND id IN ({placeholders})""",
-            list(inbox_ids),
-        ).fetchall()
+        # Chunk the IN-clause to avoid hitting SQLITE_MAX_VARIABLE_NUMBER on
+        # large lists. SELECT-then-aggregate so the bulk-dismiss numbers below
+        # operate on a single combined row set.
+        rows = []
+        for i in range(0, len(inbox_ids), _BULK_CHUNK):
+            chunk = inbox_ids[i:i + _BULK_CHUNK]
+            placeholders = ",".join("?" * len(chunk))
+            rows.extend(conn.execute(
+                f"""SELECT id, outlook_message_id FROM inbox
+                    WHERE status = 'pending' AND id IN ({placeholders})""",
+                chunk,
+            ).fetchall())
     else:
         return JSONResponse({"ok": False, "error": "Unknown scope"}, status_code=400)
 
@@ -555,20 +589,24 @@ async def inbox_bulk_dismiss(request: Request, conn=Depends(get_db)):
     target_ids = [r["id"] for r in rows]
     msg_ids = [r["outlook_message_id"] for r in rows if r["outlook_message_id"]]
 
-    # Block re-import on next sync
-    for mid in msg_ids:
-        conn.execute(
+    # Block re-import on next sync (executemany batches the inserts)
+    if msg_ids:
+        conn.executemany(
             "INSERT OR IGNORE INTO dismissed_outlook_messages (message_id) VALUES (?)",
-            (mid,),
+            [(m,) for m in msg_ids],
         )
 
-    placeholders = ",".join("?" * len(target_ids))
-    conn.execute(
-        f"""UPDATE inbox
-            SET status='processed', processed_at=CURRENT_TIMESTAMP
-            WHERE id IN ({placeholders})""",
-        target_ids,
-    )
+    # Chunk the UPDATE the same way as the SELECT to stay under the parameter
+    # limit on huge dismiss operations.
+    for i in range(0, len(target_ids), _BULK_CHUNK):
+        chunk = target_ids[i:i + _BULK_CHUNK]
+        placeholders = ",".join("?" * len(chunk))
+        conn.execute(
+            f"""UPDATE inbox
+                SET status='processed', processed_at=CURRENT_TIMESTAMP
+                WHERE id IN ({placeholders})""",
+            chunk,
+        )
     conn.commit()
     logger.info("Bulk-dismissed %d inbox items (scope=%s)", len(target_ids), scope or "explicit_ids")
     return JSONResponse({"ok": True, "dismissed": len(target_ids)})

--- a/src/policydb/web/routes/inbox.py
+++ b/src/policydb/web/routes/inbox.py
@@ -325,7 +325,9 @@ def inbox_process(
     act_date = activity_date or date.today().isoformat()
     # Carry over contact_id and email metadata from inbox item
     inbox_row = conn.execute(
-        "SELECT contact_id, outlook_message_id, content, email_from, email_to FROM inbox WHERE id=?", (inbox_id,),
+        """SELECT contact_id, outlook_message_id, content, email_from, email_to,
+                  email_direction
+           FROM inbox WHERE id=?""", (inbox_id,),
     ).fetchone()
     if not contact_id and inbox_row and inbox_row["contact_id"]:
         contact_id = inbox_row["contact_id"]
@@ -334,10 +336,12 @@ def inbox_process(
     outlook_msg_id = None
     email_from = None
     email_to = None
+    email_direction = None
     if inbox_row:
         outlook_msg_id = inbox_row["outlook_message_id"]
         email_from = inbox_row["email_from"]
         email_to = inbox_row["email_to"]
+        email_direction = inbox_row["email_direction"]
         if outlook_msg_id or (inbox_row["content"] or "").startswith("[Outlook"):
             email_snippet = inbox_row["content"]
     # Mark follow-up as done if no follow-up date (log-only)
@@ -347,15 +351,16 @@ def inbox_process(
            (activity_date, client_id, policy_id, activity_type, subject, details,
             follow_up_date, follow_up_done, disposition, account_exec,
             duration_hours, contact_id, issue_id,
-            email_snippet, outlook_message_id, source, email_from, email_to)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            email_snippet, outlook_message_id, source, email_from, email_to,
+            email_direction)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (act_date, client_id, policy_id or None, activity_type,
          subject or "Inbox item", details or None,
          follow_up_date or None, follow_up_done, disposition or None,
          account_exec, dur, contact_id or None,
          issue_id or None, email_snippet, outlook_msg_id,
          "outlook_sync" if outlook_msg_id else "manual",
-         email_from, email_to),
+         email_from, email_to, email_direction),
     )
     activity_id = cursor.lastrowid
     # Supersede follow-ups if needed
@@ -428,7 +433,7 @@ async def inbox_batch_process(request: Request, conn=Depends(get_db)):
     for iid in inbox_ids:
         inbox_row = conn.execute(
             """SELECT id, content, email_subject, email_date, contact_id,
-                      outlook_message_id, email_from, email_to
+                      outlook_message_id, email_from, email_to, email_direction
                FROM inbox WHERE id = ? AND status = 'pending'""",
             (iid,),
         ).fetchone()
@@ -447,13 +452,13 @@ async def inbox_batch_process(request: Request, conn=Depends(get_db)):
             """INSERT INTO activity_log
                (activity_date, client_id, policy_id, activity_type, subject, details,
                 account_exec, contact_id, issue_id, email_snippet, outlook_message_id,
-                source, email_from, email_to, follow_up_done, duration_hours)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 0.1)""",
+                source, email_from, email_to, email_direction, follow_up_done, duration_hours)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 0.1)""",
             (act_date, client_id, policy_id, activity_type, item_subject,
              f"Batch processed from inbox thread",
              account_exec, item_contact, issue_id, email_snippet,
              outlook_msg_id, "outlook_sync" if outlook_msg_id else "manual",
-             inbox_row["email_from"], inbox_row["email_to"]),
+             inbox_row["email_from"], inbox_row["email_to"], inbox_row["email_direction"]),
         )
         conn.execute(
             "UPDATE inbox SET status='processed', activity_id=?, processed_at=CURRENT_TIMESTAMP WHERE id=?",
@@ -468,7 +473,19 @@ async def inbox_batch_process(request: Request, conn=Depends(get_db)):
 
 @router.post("/inbox/{inbox_id}/dismiss")
 def inbox_dismiss(inbox_id: int, conn=Depends(get_db)):
-    """Dismiss inbox item without creating activity."""
+    """Dismiss inbox item without creating activity.
+
+    For Outlook-sourced items, also record the message_id in
+    `dismissed_outlook_messages` so the next sync sweep doesn't re-import it.
+    """
+    row = conn.execute(
+        "SELECT outlook_message_id FROM inbox WHERE id=?", (inbox_id,),
+    ).fetchone()
+    if row and row["outlook_message_id"]:
+        conn.execute(
+            "INSERT OR IGNORE INTO dismissed_outlook_messages (message_id) VALUES (?)",
+            (row["outlook_message_id"],),
+        )
     conn.execute(
         "UPDATE inbox SET status='processed', processed_at=CURRENT_TIMESTAMP WHERE id=?",
         (inbox_id,),
@@ -479,6 +496,82 @@ def inbox_dismiss(inbox_id: int, conn=Depends(get_db)):
     return HTMLResponse("", headers={
         "HX-Trigger": '{"activityLogged": "' + uid_str + ' dismissed"}'
     })
+
+
+@router.post("/inbox/bulk-dismiss")
+async def inbox_bulk_dismiss(request: Request, conn=Depends(get_db)):
+    """Bulk dismiss inbox items.
+
+    Body JSON:
+        {"inbox_ids": [1,2,3]}                  — dismiss exact ids
+        {"scope": "outlook_unmatched"}          — dismiss every pending Outlook
+                                                  item that has no client_id yet
+        {"scope": "outlook_all"}                — dismiss every pending Outlook
+                                                  item (matched or not)
+        {"scope": "all_pending"}                — dismiss every pending item
+
+    For any Outlook-sourced rows, message_ids are also written to
+    `dismissed_outlook_messages` so the next sync doesn't re-import them.
+    """
+    body = await request.json()
+    inbox_ids = body.get("inbox_ids") or []
+    scope = (body.get("scope") or "").strip()
+
+    if not inbox_ids and not scope:
+        return JSONResponse({"ok": False, "error": "Provide inbox_ids or scope"}, status_code=400)
+
+    if scope == "outlook_unmatched":
+        rows = conn.execute(
+            """SELECT id, outlook_message_id FROM inbox
+               WHERE status = 'pending'
+                 AND outlook_message_id IS NOT NULL
+                 AND (client_id IS NULL OR client_id = 0)"""
+        ).fetchall()
+    elif scope == "outlook_all":
+        rows = conn.execute(
+            """SELECT id, outlook_message_id FROM inbox
+               WHERE status = 'pending'
+                 AND outlook_message_id IS NOT NULL"""
+        ).fetchall()
+    elif scope == "all_pending":
+        rows = conn.execute(
+            """SELECT id, outlook_message_id FROM inbox
+               WHERE status = 'pending'"""
+        ).fetchall()
+    elif inbox_ids:
+        # Use parameterized IN with a generated placeholder list
+        placeholders = ",".join("?" * len(inbox_ids))
+        rows = conn.execute(
+            f"""SELECT id, outlook_message_id FROM inbox
+                WHERE status = 'pending' AND id IN ({placeholders})""",
+            list(inbox_ids),
+        ).fetchall()
+    else:
+        return JSONResponse({"ok": False, "error": "Unknown scope"}, status_code=400)
+
+    if not rows:
+        return JSONResponse({"ok": True, "dismissed": 0})
+
+    target_ids = [r["id"] for r in rows]
+    msg_ids = [r["outlook_message_id"] for r in rows if r["outlook_message_id"]]
+
+    # Block re-import on next sync
+    for mid in msg_ids:
+        conn.execute(
+            "INSERT OR IGNORE INTO dismissed_outlook_messages (message_id) VALUES (?)",
+            (mid,),
+        )
+
+    placeholders = ",".join("?" * len(target_ids))
+    conn.execute(
+        f"""UPDATE inbox
+            SET status='processed', processed_at=CURRENT_TIMESTAMP
+            WHERE id IN ({placeholders})""",
+        target_ids,
+    )
+    conn.commit()
+    logger.info("Bulk-dismissed %d inbox items (scope=%s)", len(target_ids), scope or "explicit_ids")
+    return JSONResponse({"ok": True, "dismissed": len(target_ids)})
 
 
 @router.post("/inbox/{inbox_id}/schedule", response_class=HTMLResponse)

--- a/src/policydb/web/routes/outlook_routes.py
+++ b/src/policydb/web/routes/outlook_routes.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import threading
+
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse, HTMLResponse
 from pydantic import BaseModel
@@ -21,6 +23,12 @@ from policydb.email_templates import (
 from policydb.outlook import is_outlook_available, create_draft
 
 router = APIRouter(prefix="/outlook", tags=["outlook"])
+
+# Module-level mutex so two browser tabs / two parallel POSTs to /outlook/sync
+# can't both spawn osascript subprocesses and race on last_outlook_sync.
+# `acquire(blocking=False)` lets us reject a second sync immediately with a
+# 409 instead of queuing it up.
+_sync_lock = threading.Lock()
 
 
 class ComposeRequest(BaseModel):
@@ -157,11 +165,36 @@ def outlook_compose(req: ComposeRequest, conn=Depends(get_db)):
 def outlook_sync(request: Request, conn=Depends(get_db)):
     """Run Outlook email sweep — scan Sent/Received/Flagged and create activities.
 
-    Returns an HTML partial with sync results.
+    Returns an HTML partial with sync results. If another sync is already in
+    progress (e.g. user clicked Sync in two tabs), returns a 409 with an
+    error banner instead of running a second sweep in parallel — parallel
+    runs would race on `last_outlook_sync`, spawn duplicate osascript
+    subprocesses, and contend for SQLite write locks.
     """
     from policydb.email_sync import sync_outlook
 
-    results = sync_outlook(conn)
+    # Non-blocking: reject the second caller immediately rather than queueing
+    if not _sync_lock.acquire(blocking=False):
+        return jinja_templates.TemplateResponse(
+            "outlook/_sync_results.html",
+            {
+                "request": request,
+                "auto_linked": {"sent": 0, "received": 0, "flagged": 0},
+                "suggestions": [],
+                "skipped": 0,
+                "errors": ["Another Outlook sync is already running. Please wait for it to finish."],
+                "total_scanned": 0,
+                "since": "",
+                "new_contacts_found": 0,
+                "thread_inherited": 0,
+            },
+            status_code=409,
+        )
+
+    try:
+        results = sync_outlook(conn)
+    finally:
+        _sync_lock.release()
 
     return jinja_templates.TemplateResponse("outlook/_sync_results.html", {
         "request": request,

--- a/src/policydb/web/routes/settings.py
+++ b/src/policydb/web/routes/settings.py
@@ -62,6 +62,7 @@ EDITABLE_LISTS: dict[str, str] = {
     "attachment_categories": "Attachment Categories",
     "freemail_domains": "Freemail Domains (Skip for Client Matching)",
     "internal_email_domains": "Internal Email Domains (Skip for Client Matching)",
+    "automated_email_prefixes": "Automated Email Prefixes (Skip for Contact Capture)",
     "relationship_risk_levels": "Relationship Risk Levels",
     "risk_review_prompt_categories": "Risk Review Prompt Categories",
     "import_source_names": "Import Source Names",
@@ -118,6 +119,7 @@ TAB_LISTS: dict[str, dict[str, str]] = {
         "service_model_options": "Service Model Options",
         "freemail_domains": "Freemail Domains (Skip for Client Matching)",
         "internal_email_domains": "Internal Email Domains (Skip for Client Matching)",
+        "automated_email_prefixes": "Automated Email Prefixes (Skip for Contact Capture)",
     },
     "issues": {
         "issue_lifecycle_states": "Issue Lifecycle States",

--- a/src/policydb/web/templates/action_center/_inbox.html
+++ b/src/policydb/web/templates/action_center/_inbox.html
@@ -18,21 +18,54 @@
 </div>
 
 {# ── Pending Header ── #}
+{% set pending_outlook = pending | selectattr('outlook_message_id') | list %}
+{% set pending_outlook_unmatched = pending_outlook | rejectattr('client_id') | list %}
 <div class="flex items-center justify-between mb-3 px-1">
   <div class="flex items-center gap-2">
     <h3 class="text-sm font-bold text-gray-700">Pending</h3>
     {% if pending %}
     <span class="bg-teal-100 text-teal-700 text-xs font-semibold px-2 py-0.5 rounded-full">{{ pending | length }} item{{ 's' if pending | length != 1 else '' }}</span>
     {% endif %}
+    {% if pending_outlook %}
+    <span class="text-[10px] text-gray-400">({{ pending_outlook | length }} from Outlook)</span>
+    {% endif %}
   </div>
-  <label class="flex items-center gap-1.5 cursor-pointer no-print">
-    <input type="checkbox" {% if show_processed %}checked{% endif %}
-      hx-get="/action-center/inbox?show_processed={{ '0' if show_processed else '1' }}"
-      hx-target="#ac-tab-content"
-      hx-swap="innerHTML"
-      class="rounded border-gray-300 text-marsh focus:ring-marsh">
-    <span class="text-xs text-gray-500">Show processed</span>
-  </label>
+  <div class="flex items-center gap-3 no-print">
+    {% if pending_outlook %}
+    <details class="relative" id="ac-bulk-dismiss-menu">
+      <summary class="text-xs text-gray-500 hover:text-gray-700 cursor-pointer select-none list-none">
+        Bulk dismiss &#9662;
+      </summary>
+      <div class="absolute right-0 mt-1 w-72 bg-white border border-gray-200 rounded-lg shadow-lg z-20 py-1 text-xs">
+        {% if pending_outlook_unmatched %}
+        <button type="button" onclick="acBulkDismiss('outlook_unmatched', {{ pending_outlook_unmatched | length }})"
+          class="w-full text-left px-3 py-2 hover:bg-gray-50 text-gray-700">
+          Dismiss <span class="font-semibold">{{ pending_outlook_unmatched | length }}</span> unmatched Outlook item{{ 's' if pending_outlook_unmatched | length != 1 else '' }}
+          <div class="text-[10px] text-gray-400 mt-0.5">Outlook items with no client assigned</div>
+        </button>
+        {% endif %}
+        <button type="button" onclick="acBulkDismiss('outlook_all', {{ pending_outlook | length }})"
+          class="w-full text-left px-3 py-2 hover:bg-gray-50 text-gray-700">
+          Dismiss all <span class="font-semibold">{{ pending_outlook | length }}</span> Outlook item{{ 's' if pending_outlook | length != 1 else '' }}
+          <div class="text-[10px] text-gray-400 mt-0.5">Includes matched + unmatched. Won't be re-imported.</div>
+        </button>
+        <button type="button" onclick="acBulkDismiss('all_pending', {{ pending | length }})"
+          class="w-full text-left px-3 py-2 hover:bg-gray-50 text-red-600 border-t border-gray-100">
+          Dismiss all <span class="font-semibold">{{ pending | length }}</span> pending item{{ 's' if pending | length != 1 else '' }}
+          <div class="text-[10px] text-gray-400 mt-0.5">Manual notes + Outlook items</div>
+        </button>
+      </div>
+    </details>
+    {% endif %}
+    <label class="flex items-center gap-1.5 cursor-pointer">
+      <input type="checkbox" {% if show_processed %}checked{% endif %}
+        hx-get="/action-center/inbox?show_processed={{ '0' if show_processed else '1' }}"
+        hx-target="#ac-tab-content"
+        hx-swap="innerHTML"
+        class="rounded border-gray-300 text-marsh focus:ring-marsh">
+      <span class="text-xs text-gray-500">Show processed</span>
+    </label>
+  </div>
 </div>
 
 {# ── Empty State ── #}
@@ -164,6 +197,36 @@ function acCancelDismiss(id) {
     '<button type="button" onclick="acShowDismissConfirm(' + id + ')" ' +
       'class="text-xs bg-gray-100 text-gray-500 px-3 py-1 rounded hover:bg-gray-200 transition-colors">' +
       'Dismiss</button>';
+}
+
+/* Bulk dismiss inbox items by scope. Re-import is blocked via dismissed_outlook_messages. */
+function acBulkDismiss(scope, count) {
+  var label = {
+    'outlook_unmatched': 'unmatched Outlook item',
+    'outlook_all': 'Outlook item',
+    'all_pending': 'pending item'
+  }[scope] || 'item';
+  var msg = 'Dismiss ' + count + ' ' + label + (count !== 1 ? 's' : '') + '?';
+  if (scope === 'all_pending') msg += '\n\nThis includes manual notes you\'ve captured.';
+  if (!confirm(msg)) return;
+  var menu = document.getElementById('ac-bulk-dismiss-menu');
+  if (menu) menu.removeAttribute('open');
+  fetch('/inbox/bulk-dismiss', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({scope: scope})
+  }).then(function(r) { return r.json(); }).then(function(result) {
+    if (result.ok) {
+      if (typeof showToast === 'function') {
+        showToast(result.dismissed + ' item' + (result.dismissed !== 1 ? 's' : '') + ' dismissed', true);
+      }
+      // Reload the inbox tab — preserve the show_processed toggle state
+      var reloadUrl = '/action-center/inbox{% if show_processed %}?show_processed=1{% endif %}';
+      htmx.ajax('GET', reloadUrl, {target: '#ac-tab-content', swap: 'innerHTML'});
+    } else if (typeof showToast === 'function') {
+      showToast('Bulk dismiss failed: ' + (result.error || 'unknown'), false);
+    }
+  });
 }
 
 /* Wire up @ contact autocomplete on the inbox tab capture input */

--- a/src/policydb/web/templates/action_center/_inbox.html
+++ b/src/policydb/web/templates/action_center/_inbox.html
@@ -199,23 +199,66 @@ function acCancelDismiss(id) {
       'Dismiss</button>';
 }
 
-/* Bulk dismiss inbox items by scope. Re-import is blocked via dismissed_outlook_messages. */
+/* Bulk dismiss inbox items by scope. Re-import is blocked via dismissed_outlook_messages.
+ *
+ * Two-step inline confirm to match the single-row dismiss pattern (no native
+ * confirm() — see CLAUDE.md design rules), single-flight guard so a double-click
+ * can't fire the request twice, and a .catch() that surfaces network errors as
+ * a toast instead of silently doing nothing.
+ */
+window._acBulkDismissInFlight = window._acBulkDismissInFlight || false;
+
 function acBulkDismiss(scope, count) {
-  var label = {
+  if (window._acBulkDismissInFlight) return;
+  var menu = document.getElementById('ac-bulk-dismiss-menu');
+  var labels = {
     'outlook_unmatched': 'unmatched Outlook item',
     'outlook_all': 'Outlook item',
     'all_pending': 'pending item'
-  }[scope] || 'item';
-  var msg = 'Dismiss ' + count + ' ' + label + (count !== 1 ? 's' : '') + '?';
-  if (scope === 'all_pending') msg += '\n\nThis includes manual notes you\'ve captured.';
-  if (!confirm(msg)) return;
+  };
+  var label = labels[scope] || 'item';
+  var noun = label + (count !== 1 ? 's' : '');
+
+  // Show inline confirm row inside the dropdown menu
+  if (!menu) return;
+  var existing = menu.querySelector('.ac-bulk-confirm');
+  if (existing) existing.remove();
+  var row = document.createElement('div');
+  row.className = 'ac-bulk-confirm px-3 py-2 border-t border-gray-100 text-xs text-gray-700 flex items-center gap-2';
+  var warn = (scope === 'all_pending') ? ' (incl. manual notes)' : '';
+  var safeLabel = noun.replace(/[<>&"]/g, '');
+  row.appendChild(document.createTextNode('Dismiss ' + count + ' ' + safeLabel + warn + '?'));
+  var yes = document.createElement('button');
+  yes.type = 'button';
+  yes.className = 'text-red-600 hover:text-red-800 font-medium px-1';
+  yes.textContent = 'Yes';
+  yes.addEventListener('click', function() { _acBulkDismissExecute(scope); });
+  row.appendChild(yes);
+  var no = document.createElement('button');
+  no.type = 'button';
+  no.className = 'text-gray-400 hover:text-gray-600 px-1';
+  no.textContent = 'No';
+  no.addEventListener('click', function() { row.remove(); });
+  row.appendChild(no);
+  menu.appendChild(row);
+}
+
+function _acBulkDismissExecute(scope) {
+  if (window._acBulkDismissInFlight) return;
+  window._acBulkDismissInFlight = true;
   var menu = document.getElementById('ac-bulk-dismiss-menu');
   if (menu) menu.removeAttribute('open');
+
   fetch('/inbox/bulk-dismiss', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({scope: scope})
-  }).then(function(r) { return r.json(); }).then(function(result) {
+  })
+  .then(function(r) {
+    // Tolerate non-JSON 4xx/5xx bodies — fall back to status text
+    return r.json().catch(function() { return {ok: false, error: 'HTTP ' + r.status}; });
+  })
+  .then(function(result) {
     if (result.ok) {
       if (typeof showToast === 'function') {
         showToast(result.dismissed + ' item' + (result.dismissed !== 1 ? 's' : '') + ' dismissed', true);
@@ -226,6 +269,14 @@ function acBulkDismiss(scope, count) {
     } else if (typeof showToast === 'function') {
       showToast('Bulk dismiss failed: ' + (result.error || 'unknown'), false);
     }
+  })
+  .catch(function(err) {
+    if (typeof showToast === 'function') {
+      showToast('Bulk dismiss failed: ' + (err && err.message ? err.message : 'network error'), false);
+    }
+  })
+  .finally(function() {
+    window._acBulkDismissInFlight = false;
   });
 }
 

--- a/tests/test_email_sync.py
+++ b/tests/test_email_sync.py
@@ -1,0 +1,507 @@
+"""Tests for the Outlook email sync engine.
+
+Covers pure helpers (no Outlook needed) plus DB-backed resolution and
+the create / enrich / inbox-routing paths in `email_sync.py`.
+
+The tests reuse the same `tmp_db` pattern as `test_db.py`: a fresh sqlite
+database under tmp_path, with `policydb.db.DB_PATH` monkeypatched.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from policydb.db import get_connection, init_db
+from policydb import config as cfg
+from policydb.email_sync import (
+    _build_domain_index,
+    _capture_unknown_contacts,
+    _create_or_enrich_activity,
+    _extract_ref_tags,
+    _is_automated_sender,
+    _match_by_domain,
+    _normalize_subject,
+    _parse_ref_tag,
+    _process_email,
+    _resolve_ref_tag,
+    _run_thread_inheritance,
+    sync_outlook,
+)
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    """Fresh sqlite DB on disk with all migrations applied."""
+    db_path = tmp_path / "test.sqlite"
+    monkeypatch.setattr("policydb.db.DB_PATH", db_path)
+    monkeypatch.setattr("policydb.db.DB_DIR", tmp_path)
+    monkeypatch.setattr("policydb.db.EXPORTS_DIR", tmp_path / "exports")
+    monkeypatch.setattr("policydb.db.CONFIG_PATH", tmp_path / "config.yaml")
+    init_db(path=db_path)
+    return db_path
+
+
+@pytest.fixture
+def conn(tmp_db):
+    c = get_connection(tmp_db)
+    yield c
+    c.close()
+
+
+def _insert_client(conn, name, cn, website, archived=0):
+    """Helper: insert a client filling NOT NULL columns."""
+    cur = conn.execute(
+        """INSERT INTO clients (name, cn_number, website, archived, industry_segment)
+           VALUES (?, ?, ?, ?, '')""",
+        (name, cn, website, archived),
+    )
+    return cur.lastrowid
+
+
+@pytest.fixture
+def seed_client(conn):
+    """Insert a basic client with website + contact for matching tests."""
+    client_id = _insert_client(conn, "Acme Corp", "999000111", "https://www.acme.com")
+    conn.execute(
+        """INSERT INTO contacts (name, email)
+           VALUES ('Jane Doe', 'jane@acme.com')"""
+    )
+    contact_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+    conn.execute(
+        """INSERT INTO contact_client_assignments (contact_id, client_id, role)
+           VALUES (?, ?, 'Risk Manager')""",
+        (contact_id, client_id),
+    )
+    conn.commit()
+    return client_id
+
+
+@pytest.fixture
+def seed_archived_client(conn):
+    """Archived client with the same domain as a real concern — should be ignored."""
+    return _insert_client(
+        conn, "Old Acme", "111222333", "https://www.archived-acme.com", archived=1,
+    )
+
+
+@pytest.fixture
+def seed_policy(conn, seed_client):
+    cur = conn.execute(
+        """INSERT INTO policies
+              (policy_uid, client_id, policy_type, carrier, archived)
+           VALUES ('POL-042', ?, 'GL', 'Travelers', 0)""",
+        (seed_client,),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+# ── _parse_ref_tag ──────────────────────────────────────────────────────────
+
+
+def test_parse_ref_tag_cn_only():
+    assert _parse_ref_tag("CN999000111") == {"cn_number": "999000111"}
+
+
+def test_parse_ref_tag_cn_with_policy():
+    parsed = _parse_ref_tag("CN999000111-POL042")
+    assert parsed["cn_number"] == "999000111"
+    assert parsed["policy_uid"] == "POL-042"
+
+
+def test_parse_ref_tag_full_compound():
+    parsed = _parse_ref_tag("CN999000111-L5-POL042")
+    assert parsed["cn_number"] == "999000111"
+    assert parsed["project_id"] == 5
+    assert parsed["policy_uid"] == "POL-042"
+
+
+def test_parse_ref_tag_with_issue_uid():
+    parsed = _parse_ref_tag("CN999000111-A7F2C3B1")
+    assert parsed["cn_number"] == "999000111"
+    assert parsed["issue_uid"] == "A7F2C3B1"
+
+
+def test_parse_ref_tag_program_uid():
+    parsed = _parse_ref_tag("CN999000111-PGM7")
+    assert parsed["cn_number"] == "999000111"
+    assert parsed["program_uid"] == "PGM-7"
+
+
+def test_parse_ref_tag_garbage_returns_empty_dict():
+    assert _parse_ref_tag("not-a-real-tag") == {}
+
+
+# ── _normalize_subject ──────────────────────────────────────────────────────
+
+
+def test_normalize_subject_strips_re_fwd():
+    assert _normalize_subject("Re: Fwd: GL Renewal") == "gl renewal"
+
+
+def test_normalize_subject_strips_external_warning():
+    assert _normalize_subject("[EXTERNAL] Re: Quote") == "quote"
+
+
+def test_normalize_subject_strips_legacy_received_prefix():
+    # Backward-compat for rows imported before migration 144 added email_direction
+    assert _normalize_subject("Received: GL Renewal") == "gl renewal"
+
+
+def test_normalize_subject_collapses_whitespace_and_lowercases():
+    assert _normalize_subject("   GL    Renewal\tDiscussion  ") == "gl renewal discussion"
+
+
+def test_normalize_subject_handles_nested_re():
+    assert _normalize_subject("RE: Re: re: Re: Quote") == "quote"
+
+
+def test_normalize_subject_empty_string():
+    assert _normalize_subject("") == ""
+    assert _normalize_subject(None) == ""
+
+
+# ── _extract_ref_tags ───────────────────────────────────────────────────────
+
+
+def test_extract_ref_tags_single():
+    assert _extract_ref_tags("Hello [PDB:CN12345-POL042] world") == ["CN12345-POL042"]
+
+
+def test_extract_ref_tags_multiple():
+    text = "[PDB:CN1] body [PDB:CN2-POL5] footer"
+    assert _extract_ref_tags(text) == ["CN1", "CN2-POL5"]
+
+
+def test_extract_ref_tags_none_in_empty():
+    assert _extract_ref_tags("") == []
+    assert _extract_ref_tags(None) == []
+
+
+# ── _is_automated_sender ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("addr,expected", [
+    ("noreply@carrier.com", True),
+    ("no-reply@example.com", True),
+    ("donotreply@portal.com", True),
+    ("mailer-daemon@host.com", True),
+    ("bounces+abc123@list.com", True),
+    ("notifications@app.io", True),
+    ("postmaster@x.com", True),
+    ("alerts@status.io", True),
+    ("jane.doe@acme.com", False),
+    ("john@acme.com", False),
+    ("", False),
+    ("not-an-email", False),
+])
+def test_is_automated_sender(addr, expected):
+    assert _is_automated_sender(addr) is expected
+
+
+# ── _build_domain_index + _match_by_domain ──────────────────────────────────
+
+
+def test_domain_index_includes_active_clients(conn, seed_client):
+    idx = _build_domain_index(conn)
+    assert "acme.com" in idx
+    assert seed_client in idx["acme.com"]
+
+
+def test_domain_index_excludes_archived_clients(conn, seed_client, seed_archived_client):
+    idx = _build_domain_index(conn)
+    # Active client present
+    assert seed_client in idx.get("acme.com", set())
+    # Archived client's domain is not indexed
+    assert seed_archived_client not in idx.get("archived-acme.com", set())
+
+
+def test_match_by_domain_unique_match(conn, seed_client):
+    match = _match_by_domain(conn, ["jane@acme.com"])
+    assert match is not None
+    assert match["tier"] == 2
+    assert match["client_id"] == seed_client
+
+
+def test_match_by_domain_skips_freemail(conn, seed_client, monkeypatch):
+    # Pre-populate freemail
+    monkeypatch.setattr(cfg, "get", lambda k, default=None: {
+        "freemail_domains": ["gmail.com"],
+        "internal_email_domains": ["marsh.com"],
+    }.get(k, default if default is not None else []))
+    assert _match_by_domain(conn, ["someone@gmail.com"]) is None
+
+
+def test_match_by_domain_ambiguous_returns_none(conn, seed_client):
+    # Create a second client also using acme.com → ambiguous
+    _insert_client(conn, "Acme East", "888777666", "https://www.acme.com")
+    conn.commit()
+    match = _match_by_domain(conn, ["jane@acme.com"])
+    assert match is None
+
+
+# ── _resolve_ref_tag ────────────────────────────────────────────────────────
+
+
+def test_resolve_ref_tag_by_cn(conn, seed_client):
+    match = _resolve_ref_tag(conn, "CN999000111")
+    assert match is not None
+    assert match["client_id"] == seed_client
+    assert match["tier"] == 1
+
+
+def test_resolve_ref_tag_by_policy(conn, seed_policy, seed_client):
+    match = _resolve_ref_tag(conn, "CN999000111-POL042")
+    assert match is not None
+    assert match["client_id"] == seed_client
+    assert match["policy_id"] == seed_policy
+
+
+def test_resolve_ref_tag_garbage_returns_none(conn):
+    assert _resolve_ref_tag(conn, "TOTAL-GARBAGE") is None
+
+
+def test_resolve_ref_tag_direct_policy_lookup(conn, seed_policy):
+    match = _resolve_ref_tag(conn, "POL042")
+    assert match is not None
+    assert match["policy_id"] == seed_policy
+
+
+# ── _create_or_enrich_activity ──────────────────────────────────────────────
+
+
+def _email_fixture(**overrides):
+    base = {
+        "message_id": "MSG-1",
+        "subject": "Quote",
+        "sender": "jane@acme.com",
+        "recipients": ["me@marsh.com"],
+        "date": "2026-04-13T10:30:00",
+        "body_snippet": "Body text",
+        "folder": "Inbox",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_create_activity_received_uses_email_direction_column(conn, seed_client):
+    match = {"tier": 1, "client_id": seed_client}
+    result = _create_or_enrich_activity(conn, _email_fixture(), match)
+    assert result["action"] == "created"
+    row = conn.execute(
+        "SELECT subject, email_direction FROM activity_log WHERE id = ?",
+        (result["activity_id"],),
+    ).fetchone()
+    # No more "Received: " subject prefix munging (#10)
+    assert row["subject"] == "Quote"
+    assert row["email_direction"] == "received"
+
+
+def test_create_activity_sent_marked_as_sent(conn, seed_client):
+    match = {"tier": 1, "client_id": seed_client}
+    email = _email_fixture(folder="Sent Items", message_id="MSG-2")
+    result = _create_or_enrich_activity(conn, email, match)
+    row = conn.execute(
+        "SELECT email_direction, disposition FROM activity_log WHERE id = ?",
+        (result["activity_id"],),
+    ).fetchone()
+    assert row["email_direction"] == "sent"
+    assert row["disposition"] == "Sent Email"
+
+
+def test_create_activity_flagged_marked_and_open(conn, seed_client):
+    match = {"tier": 1, "client_id": seed_client}
+    email = _email_fixture(message_id="MSG-3", flag_due_date="2026-04-20")
+    result = _create_or_enrich_activity(conn, email, match)
+    row = conn.execute(
+        "SELECT email_direction, follow_up_done, follow_up_date FROM activity_log WHERE id = ?",
+        (result["activity_id"],),
+    ).fetchone()
+    assert row["email_direction"] == "flagged"
+    assert row["follow_up_done"] == 0
+    assert row["follow_up_date"] == "2026-04-20"
+
+
+def test_create_activity_dedups_on_message_id(conn, seed_client):
+    match = {"tier": 1, "client_id": seed_client}
+    _create_or_enrich_activity(conn, _email_fixture(message_id="MSG-DUP"), match)
+    second = _create_or_enrich_activity(conn, _email_fixture(message_id="MSG-DUP"), match)
+    assert second["action"] == "skipped"
+
+
+def test_create_activity_skips_dismissed_message(conn, seed_client):
+    conn.execute(
+        "INSERT INTO dismissed_outlook_messages (message_id) VALUES ('MSG-DISMISSED')"
+    )
+    conn.commit()
+    match = {"tier": 1, "client_id": seed_client}
+    result = _create_or_enrich_activity(
+        conn, _email_fixture(message_id="MSG-DISMISSED"), match,
+    )
+    assert result["action"] == "skipped"
+    assert result["reason"] == "dismissed"
+
+
+def test_create_activity_no_client_returns_skipped(conn):
+    match = {"tier": 1}  # no client_id
+    result = _create_or_enrich_activity(conn, _email_fixture(message_id="MSG-X"), match)
+    assert result["action"] == "skipped"
+    assert result["reason"] == "no_client"
+
+
+def test_enrichment_path_updates_existing_same_day_email(conn, seed_client, seed_policy):
+    # Pre-existing manually logged email on same day + policy
+    conn.execute(
+        """INSERT INTO activity_log
+              (activity_date, client_id, policy_id, activity_type, subject, source)
+           VALUES ('2026-04-13', ?, ?, 'Email', 'Quote', 'manual')""",
+        (seed_client, seed_policy),
+    )
+    existing_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+    conn.commit()
+
+    match = {"tier": 1, "client_id": seed_client, "policy_id": seed_policy}
+    email = _email_fixture(folder="Sent Items", message_id="MSG-ENRICH")
+    result = _create_or_enrich_activity(conn, email, match)
+    assert result["action"] == "enriched"
+    assert result["activity_id"] == existing_id
+
+    row = conn.execute(
+        "SELECT outlook_message_id, source, email_direction FROM activity_log WHERE id = ?",
+        (existing_id,),
+    ).fetchone()
+    assert row["outlook_message_id"] == "MSG-ENRICH"
+    assert row["source"] == "outlook_sync"
+    assert row["email_direction"] == "sent"
+
+
+# ── _capture_unknown_contacts ───────────────────────────────────────────────
+
+
+def test_capture_unknown_contacts_skips_noreply(conn):
+    email = {
+        "sender": "noreply@carrier.com",
+        "recipients": ["me@marsh.com"],
+        "subject": "Quote",
+    }
+    _capture_unknown_contacts(conn, email, client_id=None)
+    count = conn.execute(
+        "SELECT COUNT(*) FROM suggested_contacts WHERE email = 'noreply@carrier.com'"
+    ).fetchone()[0]
+    assert count == 0
+
+
+def test_capture_unknown_contacts_skips_archived_client(conn, seed_archived_client):
+    email = {
+        "sender": "real.person@vendor.com",
+        "recipients": [],
+        "subject": "Hi",
+    }
+    _capture_unknown_contacts(conn, email, client_id=seed_archived_client)
+    count = conn.execute(
+        "SELECT COUNT(*) FROM suggested_contacts WHERE email = 'real.person@vendor.com'"
+    ).fetchone()[0]
+    assert count == 0
+
+
+def test_capture_unknown_contacts_inserts_new(conn, seed_client):
+    email = {
+        "sender": "new.person@vendor.com",
+        "recipients": [],
+        "subject": "Hi there",
+    }
+    _capture_unknown_contacts(conn, email, client_id=seed_client)
+    row = conn.execute(
+        "SELECT email, parsed_name FROM suggested_contacts WHERE email = ?",
+        ("new.person@vendor.com",),
+    ).fetchone()
+    assert row is not None
+    assert row["parsed_name"] == "New Person"
+
+
+# ── _process_email routing ──────────────────────────────────────────────────
+
+
+def test_process_email_unmatched_routed_to_inbox_with_direction(conn):
+    """An email with no ref tag and no domain match goes to the inbox."""
+    results = {
+        "auto_linked": {"sent": 0, "received": 0, "flagged": 0},
+        "suggestions": [],
+        "skipped": 0,
+        "errors": [],
+    }
+    email = _email_fixture(
+        message_id="MSG-INBOX-1",
+        sender="stranger@unknownco.example",
+        recipients=["me@marsh.com"],
+        subject="Cold pitch",
+    )
+    _process_email(conn, email, results, "received")
+    row = conn.execute(
+        "SELECT email_direction, content FROM inbox WHERE outlook_message_id = ?",
+        ("MSG-INBOX-1",),
+    ).fetchone()
+    assert row is not None
+    assert row["email_direction"] == "received"
+
+
+def test_process_email_with_ref_tag_creates_activity(conn, seed_client, seed_policy):
+    results = {
+        "auto_linked": {"sent": 0, "received": 0, "flagged": 0},
+        "suggestions": [],
+        "skipped": 0,
+        "errors": [],
+    }
+    email = _email_fixture(
+        message_id="MSG-TAG-1",
+        subject="Update [PDB:CN999000111-POL042]",
+    )
+    _process_email(conn, email, results, "received")
+    row = conn.execute(
+        "SELECT client_id, policy_id, email_direction FROM activity_log WHERE outlook_message_id = ?",
+        ("MSG-TAG-1",),
+    ).fetchone()
+    assert row is not None
+    assert row["client_id"] == seed_client
+    assert row["policy_id"] == seed_policy
+    assert row["email_direction"] == "received"
+
+
+# ── sync_outlook empty-category guard ───────────────────────────────────────
+
+
+def test_sync_outlook_refuses_empty_capture_category(conn, monkeypatch):
+    """Migration 144 + #5 — empty category must not silently scan everything."""
+    # Stub the AppleScript bridges so we don't need Outlook
+    monkeypatch.setattr("policydb.email_sync.search_emails",
+                        lambda *a, **k: {"ok": True, "emails": []})
+    monkeypatch.setattr("policydb.email_sync.get_flagged_emails",
+                        lambda *a, **k: {"ok": True, "emails": []})
+
+    called = {"count": 0}
+
+    def _fail_if_called(*args, **kwargs):
+        called["count"] += 1
+        return {"ok": True, "emails": []}
+
+    monkeypatch.setattr("policydb.email_sync.search_all_folders", _fail_if_called)
+
+    # Force capture category to empty via cfg.get monkeypatch
+    real_get = cfg.get
+    def _get(k, default=None):
+        if k == "outlook_capture_category":
+            return ""
+        return real_get(k, default)
+    monkeypatch.setattr(cfg, "get", _get)
+    monkeypatch.setattr(cfg, "save_config", lambda *a, **k: None)
+    monkeypatch.setattr(cfg, "reload_config", lambda *a, **k: None)
+    monkeypatch.setattr(cfg, "load_config", lambda: {})
+
+    results = sync_outlook(conn)
+    assert called["count"] == 0
+    assert any("capture category is empty" in e.lower() for e in results["errors"])


### PR DESCRIPTION
Implements 9 of the 10 email sync review recommendations plus a Bulk
Dismiss workflow for the inbox. Adds 49 unit tests for email_sync.py
(previously zero coverage).

Sync engine fixes (email_sync.py):
- #1  last_outlook_sync now captures sweep START time minus a 60s
      overlap, not end time. Eliminates the missed-email window where
      mail arriving during the scan was dropped on the next sync.
- #2  _build_domain_index() builds a single {domain: {client_id}} map
      per sweep. _match_by_domain reads it in O(1) instead of running
      N+1 client/contact queries per email.
- #3  Thread inheritance historical scan bounded to last 90 days
      (matches the matched_rows window). Prevents inbox bloat from
      degrading every subsequent sync.
- #4  _is_automated_sender() filters noreply / donotreply / bounces /
      mailer-daemon / postmaster / notifications / alerts / etc. from
      _capture_unknown_contacts. New automated_email_prefixes config
      list, editable in Settings -> Email & Contacts.
- #5  sync_outlook refuses to invoke search_all_folders when
      outlook_capture_category is empty (which previously silently
      ingested every message in every folder). Surfaces an error in
      the sync results banner instead.
- #7  _build_domain_index excludes archived clients from both website
      and contact-domain lookups. _capture_unknown_contacts skips
      capture entirely if the resolved client is archived.

Activity-filter correctness (anomaly_engine.py + activity_review.py):
- #6  source filter expanded from ('manual', 'outlook_sync') to
      ('manual', 'outlook_sync', 'thread_inherit'). Renewals where
      most correspondence was promoted via thread inheritance now
      register as active and no longer trip false-positive
      no_activity anomalies / unlogged-session findings.

Schema + direction column (#10, migration 144):
- New email_direction column on activity_log and inbox
  ('sent' | 'received' | 'flagged'). Backfills from the legacy
  "Received: " subject prefix and the [Outlook Sent|Received|Flagged]
  inbox brackets, then strips the legacy prefix from existing
  activity_log subjects.
- _create_or_enrich_activity sets email_direction directly instead of
  munging the subject. _normalize_subject still tolerates a stray
  "Received: " for safety / pre-migration rows.
- Inbox process / batch-process routes carry email_direction through
  to the new activity_log row.

Bulk Dismiss (Action Center inbox tab):
- POST /inbox/bulk-dismiss accepts {"scope": ...} or
  {"inbox_ids": [...]}. Three scopes: outlook_unmatched (Outlook rows
  with no client), outlook_all, all_pending. Single-row
  POST /inbox/{id}/dismiss now also writes outlook_message_id to
  dismissed_outlook_messages so the next sync won't re-import.
- New "Bulk dismiss ▾" menu in _inbox.html, surfaces unmatched and
  all-Outlook counts at a glance.

Tests (#8, tests/test_email_sync.py — 49 new tests):
- _parse_ref_tag (CN, compound, issue, program, garbage)
- _normalize_subject (Re/Fwd, [EXTERNAL], legacy Received: prefix,
  whitespace, nested)
- _extract_ref_tags
- _is_automated_sender (parametrized)
- _build_domain_index (active vs archived)
- _match_by_domain (unique, freemail skip, ambiguous)
- _resolve_ref_tag (CN, policy, garbage, direct lookup)
- _create_or_enrich_activity (received / sent / flagged, dedup,
  dismissed message, no_client, enrichment path)
- _capture_unknown_contacts (noreply skip, archived skip, insert)
- _process_email (inbox routing with direction, ref tag → activity)
- sync_outlook (refuses empty capture category)

Skill doc updates:
- policydb-outlook: scan rules, resume window, domain index perf,
  email_direction column, bulk dismiss, automated_email_prefixes,
  100k/5k snippet truncation reality, migration 144
- policydb-activity-review: canonical user-activity filter now
  includes thread_inherit

https://claude.ai/code/session_01XaZZjvo6L2XyyQAvpKuizM