### PR TITLE
Fix filter and search bugs across the app

### DIFF
--- a/src/policydb/queries.py
+++ b/src/policydb/queries.py
@@ -2110,6 +2110,9 @@ def rebuild_search_index(conn: sqlite3.Connection) -> None:
     """)
 
     # -- Client scratchpads --
+    # Skip scratchpads whose owning client is archived — otherwise an
+    # archived client will resurface in search via its scratchpad even
+    # though its main client row is excluded from the index.
     conn.execute("""
         INSERT INTO search_index (entity_type, entity_id, title, subtitle, body, metadata)
         SELECT 'scratchpad', 'client-' || CAST(cs.client_id AS TEXT),
@@ -2120,9 +2123,12 @@ def rebuild_search_index(conn: sqlite3.Connection) -> None:
         FROM client_scratchpad cs
         JOIN clients c ON c.id = cs.client_id
         WHERE cs.content IS NOT NULL AND cs.content != ''
+          AND c.archived = 0
     """)
 
     # -- Policy scratchpads --
+    # Skip scratchpads whose owning policy is archived (and whose owning
+    # client is archived) for the same reason as above.
     conn.execute("""
         INSERT INTO search_index (entity_type, entity_id, title, subtitle, body, metadata)
         SELECT 'scratchpad', 'policy-' || ps.policy_uid,
@@ -2131,7 +2137,11 @@ def rebuild_search_index(conn: sqlite3.Connection) -> None:
             COALESCE(ps.content, ''),
             ''
         FROM policy_scratchpad ps
+        JOIN policies p ON p.policy_uid = ps.policy_uid
+        JOIN clients c ON c.id = p.client_id
         WHERE ps.content IS NOT NULL AND ps.content != ''
+          AND p.archived = 0
+          AND c.archived = 0
     """)
 
     # -- KB Bookmarks --

--- a/src/policydb/queries.py
+++ b/src/policydb/queries.py
@@ -2021,6 +2021,8 @@ def rebuild_search_index(conn: sqlite3.Connection) -> None:
     """)
 
     # -- Activities (last 2 years) --
+    # Includes plain activities (item_kind IS NULL) and follow-ups; issue
+    # rows (item_kind='issue') are indexed separately as their own entity.
     conn.execute("""
         INSERT INTO search_index (entity_type, entity_id, title, subtitle, body, metadata)
         SELECT 'activity', CAST(a.id AS TEXT),
@@ -2031,7 +2033,7 @@ def rebuild_search_index(conn: sqlite3.Connection) -> None:
             COALESCE(a.email_from, '') || ' ' || COALESCE(a.email_to, '')
         FROM activity_log a
         LEFT JOIN clients c ON a.client_id = c.id
-        WHERE a.item_kind IS NULL
+        WHERE (a.item_kind IS NULL OR a.item_kind = 'followup')
           AND a.activity_date >= date('now', '-2 years')
     """)
 
@@ -2190,6 +2192,7 @@ def full_text_search(conn: sqlite3.Connection, query: str) -> dict:
             "clients": [], "policies": [], "activities": [], "issues": [],
             "contacts": [], "programs": [], "locations": [],
             "inbox": [], "kb_bookmarks": [], "kb_articles": [],
+            "scratchpads": [],
             "_snippets": {}, "_query_mode": "none",
         }
 
@@ -2249,7 +2252,7 @@ def full_text_search(conn: sqlite3.Connection, query: str) -> dict:
         FROM v_policy_status WHERE policy_uid IN (__IDS__)
     """)
     _hydrate("activity", "activities", """
-        SELECT a.id, a.activity_date, c.name AS client_name,
+        SELECT a.id, a.activity_date, a.client_id, c.name AS client_name,
                a.activity_type, a.subject, a.details, a.contact_person
         FROM activity_log a
         LEFT JOIN clients c ON a.client_id = c.id
@@ -2306,6 +2309,47 @@ def full_text_search(conn: sqlite3.Connection, query: str) -> dict:
         FROM kb_articles a WHERE a.uid IN (__IDS__)
         ORDER BY a.title
     """)
+
+    # Scratchpads use composite IDs (client-{id} or policy-{uid}) so they
+    # need a custom hydration path rather than the generic _hydrate helper.
+    scratchpad_ids = grouped.get("scratchpad", [])
+    results["scratchpads"] = []
+    for sid in scratchpad_ids:
+        if sid.startswith("client-"):
+            try:
+                cid = int(sid[len("client-"):])
+            except ValueError:
+                continue
+            row = conn.execute(
+                "SELECT cs.client_id, c.name AS client_name, "
+                "       SUBSTR(cs.content, 1, 200) AS excerpt "
+                "FROM client_scratchpad cs "
+                "JOIN clients c ON c.id = cs.client_id "
+                "WHERE cs.client_id = ?",
+                (cid,),
+            ).fetchone()
+            if row:
+                d = dict(row)
+                d["scratch_type"] = "client"
+                d["link"] = f"/clients/{d['client_id']}"
+                results["scratchpads"].append(d)
+        elif sid.startswith("policy-"):
+            puid = sid[len("policy-"):]
+            row = conn.execute(
+                "SELECT ps.policy_uid, p.client_id, c.name AS client_name, "
+                "       p.policy_type, p.carrier, "
+                "       SUBSTR(ps.content, 1, 200) AS excerpt "
+                "FROM policy_scratchpad ps "
+                "JOIN policies p ON p.policy_uid = ps.policy_uid "
+                "JOIN clients c ON c.id = p.client_id "
+                "WHERE ps.policy_uid = ?",
+                (puid,),
+            ).fetchone()
+            if row:
+                d = dict(row)
+                d["scratch_type"] = "policy"
+                d["link"] = f"/policies/{d['policy_uid']}/edit"
+                results["scratchpads"].append(d)
 
     # --- Tier 2: Fuzzy fallback ---
     total_fts = sum(len(v) for v in results.values())

--- a/src/policydb/web/routes/clients.py
+++ b/src/policydb/web/routes/clients.py
@@ -411,6 +411,11 @@ def client_search(
     clients = _apply_client_filters(clients, segment, urgent, inactive, prospect)
     clients = _sort_clients(clients, sort, dir)
     _enrich_last_activity(clients)
+    # _table_rows.html renders the health badge for each row, which requires
+    # the health_score / health_missing / health_stale fields populated by
+    # score_client(). Without this the partial crashes with UndefinedError.
+    for c in clients:
+        score_client(conn, c, include_staleness=False)
     return templates.TemplateResponse("clients/_table_rows.html", {
         "request": request,
         "clients": clients,

--- a/src/policydb/web/routes/clients.py
+++ b/src/policydb/web/routes/clients.py
@@ -116,8 +116,13 @@ def _enrich_last_activity(clients: list[dict]) -> None:
     today = _date.today()
     for c in clients:
         raw = c.get("last_activity_date")
+        d = None
         if raw:
-            d = _date.fromisoformat(raw)
+            try:
+                d = _date.fromisoformat(str(raw)[:10])
+            except (TypeError, ValueError):
+                d = None
+        if d is not None:
             delta = (today - d).days
             rel = _relative_days(delta)
             if rel is None:
@@ -140,7 +145,7 @@ def _enrich_last_activity(clients: list[dict]) -> None:
 
 def _apply_client_filters(clients, segment="", urgent="", inactive="", prospect=""):
     if segment:
-        clients = [c for c in clients if c["industry_segment"] == segment]
+        clients = [c for c in clients if c.get("industry_segment") == segment]
     if urgent:
         clients = [c for c in clients if (c.get("next_renewal_days") or 999) <= 90]
     if inactive:

--- a/src/policydb/web/routes/clients.py
+++ b/src/policydb/web/routes/clients.py
@@ -124,6 +124,12 @@ def _enrich_last_activity(clients: list[dict]) -> None:
                 d = None
         if d is not None:
             delta = (today - d).days
+            # A future-dated last_activity_date (delta < 0) is typically
+            # bad data or a scheduled activity that leaked into the
+            # "last activity" field.  Treat it as "today" rather than
+            # rendering "-5d ago", which is meaningless to users.
+            if delta < 0:
+                delta = 0
             rel = _relative_days(delta)
             if rel is None:
                 # >90 days — show abbreviated date like "Mar 12"

--- a/src/policydb/web/routes/dashboard.py
+++ b/src/policydb/web/routes/dashboard.py
@@ -33,14 +33,25 @@ URGENCY_ORDER = ["EXPIRED", "URGENT", "WARNING", "UPCOMING", "OK"]
 
 
 def _attach_client_ids(conn, rows: list[dict]) -> list[dict]:
-    result = []
+    """Attach client_id to each row by looking up its client_name.
+
+    Pre-loads every (name → id) mapping in one query to avoid the N+1
+    pattern this function used to do.  Rows with a missing/unknown
+    client_name fall back to client_id=0 so callers can still link
+    safely.
+    """
+    rows = list(rows)
+    if not rows:
+        return rows
+    name_map = {
+        r["name"]: r["id"]
+        for r in conn.execute(
+            "SELECT id, name FROM clients WHERE archived = 0"
+        ).fetchall()
+    }
     for d in rows:
-        client_row = conn.execute(
-            "SELECT id FROM clients WHERE name = ?", (d["client_name"],)
-        ).fetchone()
-        d["client_id"] = client_row["id"] if client_row else 0
-        result.append(d)
-    return result
+        d["client_id"] = name_map.get(d.get("client_name") or "", 0)
+    return rows
 
 
 @router.get("/dashboard/pipeline", response_class=HTMLResponse)

--- a/src/policydb/web/routes/dashboard.py
+++ b/src/policydb/web/routes/dashboard.py
@@ -54,7 +54,7 @@ def dashboard_pipeline(request: Request, window: int = 90, status: str = "", con
     ))
     attach_renewal_issues(conn, pipeline)
     suggested_uids = {r["policy_uid"] for r in get_suggested_followups(conn, excluded_statuses=excluded)}
-    return templates.TemplateResponse("policies/_pipeline_table.html", {
+    return templates.TemplateResponse("dashboard/_pipeline_section.html", {
         "request": request,
         "pipeline": pipeline,
         "window": window,
@@ -163,8 +163,8 @@ def dashboard(request: Request, conn=Depends(get_db)):
         "urgent_count": urgent_count,
         "urgency_breakdown": urgency_breakdown,
         "renewal_statuses": cfg.get("renewal_statuses"),
-        "dash_window": 90,
-        "dash_status": "",
+        "window": 90,
+        "status": "",
         "scratchpad_content": scratchpad_content,
         "scratchpad_updated": scratchpad_updated,
         "recent_client_notes": recent_client_notes,
@@ -206,6 +206,7 @@ def search(request: Request, q: str = "", conn=Depends(get_db)):
         "clients": [], "policies": [], "activities": [], "issues": [],
         "contacts": [], "programs": [], "locations": [],
         "inbox": [], "kb_bookmarks": [], "kb_articles": [],
+        "scratchpads": [],
         "_snippets": {}, "_query_mode": "none",
     }
     results = dict(_empty)
@@ -282,7 +283,8 @@ def search_live(request: Request, q: str = "", conn=Depends(get_db)):
     items = []
     # Priority order for display
     for etype in ("clients", "policies", "issues", "contacts", "programs",
-                  "activities", "locations", "inbox", "kb_articles", "kb_bookmarks"):
+                  "activities", "locations", "scratchpads", "inbox",
+                  "kb_articles", "kb_bookmarks"):
         for r in results.get(etype, [])[:3]:
             items.append({"type": etype, "data": r})
             if len(items) >= 8:

--- a/src/policydb/web/routes/dashboard.py
+++ b/src/policydb/web/routes/dashboard.py
@@ -33,24 +33,36 @@ URGENCY_ORDER = ["EXPIRED", "URGENT", "WARNING", "UPCOMING", "OK"]
 
 
 def _attach_client_ids(conn, rows: list[dict]) -> list[dict]:
-    """Attach client_id to each row by looking up its client_name.
+    """Attach client_id to each row.
 
-    Pre-loads every (name → id) mapping in one query to avoid the N+1
-    pattern this function used to do.  Rows with a missing/unknown
-    client_name fall back to client_id=0 so callers can still link
-    safely.
+    Prefers an existing client_id already on the row — the pipeline
+    views (``v_renewal_pipeline`` etc.) already expose it, so we skip
+    the lookup entirely in the common case.  Falls back to a single
+    bulk ``(name → id)`` lookup for legacy callers that only supply
+    ``client_name``.
+
+    The lookup intentionally does **not** filter archived clients:
+    pipeline views may still surface a policy whose owning client is
+    archived (the view only filters ``p.archived = 0``), and dropping
+    the id would turn the row's "Client" link into a broken
+    ``/clients/0`` href.  Rows with no match fall back to
+    ``client_id=0`` so callers can still render safely.
     """
     rows = list(rows)
     if not rows:
         return rows
-    name_map = {
-        r["name"]: r["id"]
-        for r in conn.execute(
-            "SELECT id, name FROM clients WHERE archived = 0"
-        ).fetchall()
-    }
+    # Fast path: if every row already has a client_id, no lookup needed.
+    missing = [r for r in rows if not r.get("client_id")]
+    if missing:
+        name_map = {
+            r["name"]: r["id"]
+            for r in conn.execute("SELECT id, name FROM clients").fetchall()
+        }
+        for d in missing:
+            d["client_id"] = name_map.get(d.get("client_name") or "", 0)
+    # Ensure every row at least has the key, even when nothing matched.
     for d in rows:
-        d["client_id"] = name_map.get(d.get("client_name") or "", 0)
+        d.setdefault("client_id", 0)
     return rows
 
 

--- a/src/policydb/web/routes/kb.py
+++ b/src/policydb/web/routes/kb.py
@@ -185,9 +185,13 @@ async def kb_search(
     pattern = f"%{_escaped_q}%"
     entries = []
 
-    # If linked-to filter is active, get the set of linked entry IDs
+    # If linked-to filter is active, get the set of linked entry IDs.
+    # All three *_ids vars are always initialized to None so downstream
+    # code can reference them without worrying about whether the
+    # linked-filter branch ran.
     linked_article_ids = None
     linked_attachment_ids = None
+    linked_bookmark_ids = None
     if linked_type and linked_id_int:
         link_rows = conn.execute(
             "SELECT source_type, source_id, target_type, target_id FROM kb_links "

--- a/src/policydb/web/routes/kb.py
+++ b/src/policydb/web/routes/kb.py
@@ -214,7 +214,7 @@ async def kb_search(
             where += " AND category = ?"
             params.append(category)
         articles = conn.execute(
-            f"SELECT * FROM kb_articles {where} ORDER BY updated_at DESC",
+            f"SELECT * FROM kb_articles {where} ORDER BY updated_at DESC LIMIT 200",
             params,
         ).fetchall()
         for a in articles:
@@ -239,7 +239,7 @@ async def kb_search(
             where += " AND source = ?"
             params.append(source_filter)
         documents = conn.execute(
-            f"SELECT * FROM attachments {where} ORDER BY updated_at DESC",
+            f"SELECT * FROM attachments {where} ORDER BY updated_at DESC LIMIT 200",
             params,
         ).fetchall()
         for doc in documents:
@@ -263,7 +263,7 @@ async def kb_search(
             where += " AND category = ?"
             params.append(category)
         bm_rows = conn.execute(
-            f"SELECT * FROM kb_bookmarks {where} ORDER BY updated_at DESC",
+            f"SELECT * FROM kb_bookmarks {where} ORDER BY updated_at DESC LIMIT 200",
             params,
         ).fetchall()
         linked_bookmark_ids_set = linked_bookmark_ids if linked_type and linked_id_int else None

--- a/src/policydb/web/routes/kb.py
+++ b/src/policydb/web/routes/kb.py
@@ -178,7 +178,11 @@ async def kb_search(
     conn=Depends(get_db),
 ):
     linked_id_int = int(linked_id) if linked_id and linked_id.isdigit() else 0
-    pattern = f"%{q}%"
+    # Escape LIKE wildcards in the user query so '%', '_' and '\\' are
+    # matched literally rather than as wildcards.  We use ESCAPE '\\' on
+    # every LIKE clause below.
+    _escaped_q = q.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    pattern = f"%{_escaped_q}%"
     entries = []
 
     # If linked-to filter is active, get the set of linked entry IDs
@@ -208,19 +212,27 @@ async def kb_search(
 
     # Articles
     if source_filter in ("", "article"):
-        where = "WHERE (title LIKE ? OR content LIKE ? OR tags LIKE ?)"
-        params = [pattern, pattern, pattern]
-        if category:
-            where += " AND category = ?"
-            params.append(category)
-        articles = conn.execute(
-            f"SELECT * FROM kb_articles {where} ORDER BY updated_at DESC LIMIT 200",
-            params,
-        ).fetchall()
+        # When a linked-to filter is active, we want to search WITHIN the
+        # linked set rather than top-200-by-date and then filter — otherwise
+        # a linked entry that isn't in the most-recent 200 simply vanishes.
+        if linked_article_ids is not None and not linked_article_ids:
+            articles = []  # filter active but nothing linked
+        else:
+            where = "WHERE (title LIKE ? ESCAPE '\\' OR content LIKE ? ESCAPE '\\' OR tags LIKE ? ESCAPE '\\')"
+            params = [pattern, pattern, pattern]
+            if category:
+                where += " AND category = ?"
+                params.append(category)
+            if linked_article_ids is not None:
+                ph = ",".join("?" * len(linked_article_ids))
+                where += f" AND id IN ({ph})"
+                params.extend(linked_article_ids)
+            articles = conn.execute(
+                f"SELECT * FROM kb_articles {where} ORDER BY updated_at DESC LIMIT 200",
+                params,
+            ).fetchall()
         for a in articles:
             d = dict(a)
-            if linked_article_ids is not None and d["id"] not in linked_article_ids:
-                continue
             d["entry_type"] = "article"
             d["source_type"] = "article"
             d["tags_list"] = _parse_tags(d.get("tags"))
@@ -230,22 +242,27 @@ async def kb_search(
 
     # Attachments (local and devonthink)
     if source_filter in ("", "local", "devonthink"):
-        where = "WHERE (title LIKE ? OR description LIKE ? OR filename LIKE ? OR tags LIKE ?)"
-        params = [pattern, pattern, pattern, pattern]
-        if category:
-            where += " AND category = ?"
-            params.append(category)
-        if source_filter in ("local", "devonthink"):
-            where += " AND source = ?"
-            params.append(source_filter)
-        documents = conn.execute(
-            f"SELECT * FROM attachments {where} ORDER BY updated_at DESC LIMIT 200",
-            params,
-        ).fetchall()
+        if linked_attachment_ids is not None and not linked_attachment_ids:
+            documents = []
+        else:
+            where = "WHERE (title LIKE ? ESCAPE '\\' OR description LIKE ? ESCAPE '\\' OR filename LIKE ? ESCAPE '\\' OR tags LIKE ? ESCAPE '\\')"
+            params = [pattern, pattern, pattern, pattern]
+            if category:
+                where += " AND category = ?"
+                params.append(category)
+            if source_filter in ("local", "devonthink"):
+                where += " AND source = ?"
+                params.append(source_filter)
+            if linked_attachment_ids is not None:
+                ph = ",".join("?" * len(linked_attachment_ids))
+                where += f" AND id IN ({ph})"
+                params.extend(linked_attachment_ids)
+            documents = conn.execute(
+                f"SELECT * FROM attachments {where} ORDER BY updated_at DESC LIMIT 200",
+                params,
+            ).fetchall()
         for doc in documents:
             d = dict(doc)
-            if linked_attachment_ids is not None and d["id"] not in linked_attachment_ids:
-                continue
             d["entry_type"] = "document"
             d["source_type"] = d.get("source", "local")
             d["tags_list"] = _parse_tags(d.get("tags"))
@@ -257,20 +274,25 @@ async def kb_search(
 
     # Bookmarks
     if source_filter in ("", "bookmark"):
-        where = "WHERE (title LIKE ? OR url LIKE ? OR description LIKE ? OR tags LIKE ?)"
-        params = [pattern, pattern, pattern, pattern]
-        if category:
-            where += " AND category = ?"
-            params.append(category)
-        bm_rows = conn.execute(
-            f"SELECT * FROM kb_bookmarks {where} ORDER BY updated_at DESC LIMIT 200",
-            params,
-        ).fetchall()
         linked_bookmark_ids_set = linked_bookmark_ids if linked_type and linked_id_int else None
+        if linked_bookmark_ids_set is not None and not linked_bookmark_ids_set:
+            bm_rows = []
+        else:
+            where = "WHERE (title LIKE ? ESCAPE '\\' OR url LIKE ? ESCAPE '\\' OR description LIKE ? ESCAPE '\\' OR tags LIKE ? ESCAPE '\\')"
+            params = [pattern, pattern, pattern, pattern]
+            if category:
+                where += " AND category = ?"
+                params.append(category)
+            if linked_bookmark_ids_set is not None:
+                ph = ",".join("?" * len(linked_bookmark_ids_set))
+                where += f" AND id IN ({ph})"
+                params.extend(linked_bookmark_ids_set)
+            bm_rows = conn.execute(
+                f"SELECT * FROM kb_bookmarks {where} ORDER BY updated_at DESC LIMIT 200",
+                params,
+            ).fetchall()
         for bm in bm_rows:
             d = dict(bm)
-            if linked_bookmark_ids_set is not None and d["id"] not in linked_bookmark_ids_set:
-                continue
             d["entry_type"] = "bookmark"
             d["source_type"] = "bookmark"
             d["tags_list"] = _parse_tags(d.get("tags"))

--- a/src/policydb/web/templates/_search_dropdown.html
+++ b/src/policydb/web/templates/_search_dropdown.html
@@ -3,7 +3,7 @@
   {% for item in items %}
   {% set r = item.data %}
   {% set t = item.type %}
-  <a href="{% if t == 'clients' %}/clients/{{ r.id }}{% elif t == 'policies' %}/policies/{{ r.policy_uid }}/edit{% elif t == 'issues' %}/issues/{{ r.issue_uid }}{% elif t == 'contacts' %}/contacts/{{ r.id }}{% elif t == 'programs' %}/clients/{{ r.client_id }}/programs/{{ r.program_uid }}{% elif t == 'activities' %}#{% elif t == 'locations' %}/clients/{{ r.client_id }}/projects/{{ r.id }}{% elif t == 'inbox' %}/action-center?tab=inbox{% elif t == 'kb_articles' %}/kb/articles/{{ r.uid }}{% elif t == 'kb_bookmarks' %}/kb/bookmarks/{{ r.uid }}{% endif %}"
+  <a href="{% if t == 'clients' %}/clients/{{ r.id }}{% elif t == 'policies' %}/policies/{{ r.policy_uid }}/edit{% elif t == 'issues' %}/issues/{{ r.issue_uid }}{% elif t == 'contacts' %}/contacts/{{ r.id }}{% elif t == 'programs' %}/clients/{{ r.client_id }}/programs/{{ r.program_uid }}{% elif t == 'activities' %}/clients/{{ r.client_id }}#activity-{{ r.id }}{% elif t == 'locations' %}/clients/{{ r.client_id }}/projects/{{ r.id }}{% elif t == 'scratchpads' %}{{ r.link }}{% elif t == 'inbox' %}/action-center?tab=inbox{% elif t == 'kb_articles' %}/kb/articles/{{ r.uid }}{% elif t == 'kb_bookmarks' %}/kb/bookmarks/{{ r.uid }}{% endif %}"
      class="flex items-center gap-2 px-3 py-2 hover:bg-gray-50 border-b border-gray-50 last:border-0 search-dropdown-item"
      data-idx="{{ loop.index0 }}">
     <span class="text-[9px] font-semibold uppercase rounded px-1.5 py-0.5 shrink-0
@@ -14,10 +14,11 @@
       {% elif t == 'programs' %}bg-purple-100 text-purple-700
       {% elif t == 'activities' %}bg-gray-100 text-gray-600
       {% elif t == 'locations' %}bg-teal-100 text-teal-700
+      {% elif t == 'scratchpads' %}bg-yellow-100 text-yellow-700
       {% elif t == 'inbox' %}bg-orange-100 text-orange-700
       {% elif t == 'kb_articles' %}bg-amber-100 text-amber-700
       {% elif t == 'kb_bookmarks' %}bg-blue-100 text-blue-700
-      {% endif %}">{% if t == 'kb_articles' %}KB{% elif t == 'kb_bookmarks' %}BM{% else %}{{ t[:3] }}{% endif %}</span>
+      {% endif %}">{% if t == 'kb_articles' %}KB{% elif t == 'kb_bookmarks' %}BM{% elif t == 'scratchpads' %}NOT{% else %}{{ t[:3] }}{% endif %}</span>
     <span class="text-sm text-gray-800 truncate">
       {% if t == 'clients' %}{{ r.name }}
       {% elif t == 'policies' %}{{ r.client_name }} / {{ r.policy_type }} / {{ r.carrier }}
@@ -26,6 +27,7 @@
       {% elif t == 'programs' %}{{ r.name }} · {{ r.client_name }}
       {% elif t == 'activities' %}{{ r.subject }}{% if r.client_name %} · {{ r.client_name }}{% endif %}
       {% elif t == 'locations' %}{{ r.name }} · {{ r.client_name }}
+      {% elif t == 'scratchpads' %}{{ r.client_name }}{% if r.scratch_type == 'policy' %} · {{ r.policy_type }} ({{ r.policy_uid }}){% endif %} — note
       {% elif t == 'inbox' %}{{ r.email_subject or (r.content[:60] if r.content else 'Inbox') }}
       {% elif t == 'kb_articles' %}{{ r.title }}{% if r.category %} · {{ r.category }}{% endif %}
       {% elif t == 'kb_bookmarks' %}{{ r.title }}{% if r.category %} · {{ r.category }}{% endif %}

--- a/src/policydb/web/templates/dashboard.html
+++ b/src/policydb/web/templates/dashboard.html
@@ -182,34 +182,8 @@ if (sessionStorage.getItem('review-reminder-dismissed')) {
 
   <!-- Renewal Pipeline -->
   <div class="lg:col-span-2 card">
-    <div class="px-5 pt-3 pb-2 border-b border-gray-100">
-      <div class="flex items-center justify-between mb-3">
-        <h2 class="font-semibold text-gray-900">Renewal Pipeline</h2>
-        <a href="/renewals" class="text-xs text-marsh hover:underline">View all →</a>
-      </div>
-      <!-- Window + status filters (HTMX-driven) -->
-      <div id="dash-pipeline-controls" class="flex flex-wrap gap-1.5 items-center">
-        {% for w in [90, 120, 180] %}
-        <button
-          hx-get="/dashboard/pipeline?window={{ w }}&status={{ dash_status | urlencode }}"
-          hx-target="#dash-pipeline-body"
-          class="btn-filter {{ 'active' if dash_window == w else '' }}">{{ w }}d</button>
-        {% endfor %}
-        <span class="border-l border-gray-200 h-6 mx-1"></span>
-        <button
-          hx-get="/dashboard/pipeline?window={{ dash_window }}"
-          hx-target="#dash-pipeline-body"
-          class="btn-filter {{ 'active' if not dash_status else '' }}">All</button>
-        {% for s in renewal_statuses %}
-        <button
-          hx-get="/dashboard/pipeline?window={{ dash_window }}&status={{ s | urlencode }}"
-          hx-target="#dash-pipeline-body"
-          class="btn-filter {{ 'active' if dash_status == s else '' }}">{{ s }}</button>
-        {% endfor %}
-      </div>
-    </div>
-    <div id="dash-pipeline-body">
-      {% include "policies/_pipeline_table.html" %}
+    <div id="dash-pipeline-section">
+      {% include "dashboard/_pipeline_section.html" %}
     </div>
   </div>
 

--- a/src/policydb/web/templates/dashboard/_pipeline_section.html
+++ b/src/policydb/web/templates/dashboard/_pipeline_section.html
@@ -1,0 +1,35 @@
+{# Renewal pipeline filter controls + table.
+   Returned by /dashboard/pipeline so HTMX swaps controls + body together,
+   keeping the active filter button state in sync with the data. #}
+<div class="px-5 pt-3 pb-2 border-b border-gray-100">
+  <div class="flex items-center justify-between mb-3">
+    <h2 class="font-semibold text-gray-900">Renewal Pipeline</h2>
+    <a href="/renewals" class="text-xs text-marsh hover:underline">View all →</a>
+  </div>
+  <!-- Window + status filters (HTMX-driven) -->
+  <div id="dash-pipeline-controls" class="flex flex-wrap gap-1.5 items-center">
+    {% for w in [90, 120, 180] %}
+    <button
+      hx-get="/dashboard/pipeline?window={{ w }}&status={{ status | urlencode }}"
+      hx-target="#dash-pipeline-section"
+      hx-swap="innerHTML"
+      class="btn-filter {{ 'active' if window == w else '' }}">{{ w }}d</button>
+    {% endfor %}
+    <span class="border-l border-gray-200 h-6 mx-1"></span>
+    <button
+      hx-get="/dashboard/pipeline?window={{ window }}"
+      hx-target="#dash-pipeline-section"
+      hx-swap="innerHTML"
+      class="btn-filter {{ 'active' if not status else '' }}">All</button>
+    {% for s in renewal_statuses %}
+    <button
+      hx-get="/dashboard/pipeline?window={{ window }}&status={{ s | urlencode }}"
+      hx-target="#dash-pipeline-section"
+      hx-swap="innerHTML"
+      class="btn-filter {{ 'active' if status == s else '' }}">{{ s }}</button>
+    {% endfor %}
+  </div>
+</div>
+<div id="dash-pipeline-body">
+  {% include "policies/_pipeline_table.html" %}
+</div>

--- a/src/policydb/web/templates/search.html
+++ b/src/policydb/web/templates/search.html
@@ -140,7 +140,8 @@
     <span class="text-[10px] bg-gray-100 text-gray-500 rounded-full px-2 py-0.5">{{ results.activities|length }}</span>
   </div>
   {% for r in results.activities %}
-  <div class="flex items-start gap-3 px-5 py-3 border-b border-gray-50 last:border-0">
+  <a href="{% if r.client_id %}/clients/{{ r.client_id }}#activity-{{ r.id }}{% else %}#{% endif %}"
+     class="flex items-start gap-3 px-5 py-3 hover:bg-gray-50 border-b border-gray-50 last:border-0">
     <span class="text-xs text-gray-400 mt-0.5 shrink-0">{{ r.activity_date }}</span>
     <div>
       <span class="font-medium text-gray-800">{{ r.client_name }}</span>
@@ -148,7 +149,33 @@
       <span class="text-gray-700">{{ r.subject }}</span>
       {{ show_snippet('activity', r.id) }}
     </div>
+  </a>
+  {% endfor %}
+</div>
+{% endif %}
+
+{# --- Scratchpads --- #}
+{% if results.scratchpads %}
+<div class="bg-white rounded-xl border border-gray-200 mb-4">
+  <div class="px-5 py-3 border-b border-gray-100 flex items-center justify-between">
+    <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide">Notes / Scratchpads</span>
+    <span class="text-[10px] bg-gray-100 text-gray-500 rounded-full px-2 py-0.5">{{ results.scratchpads|length }}</span>
   </div>
+  {% for r in results.scratchpads %}
+  <a href="{{ r.link }}" class="flex items-start gap-3 px-5 py-3 hover:bg-gray-50 border-b border-gray-50 last:border-0">
+    <span class="text-[10px] font-semibold uppercase tracking-wide text-yellow-700 bg-yellow-100 rounded px-1.5 py-0.5 mt-0.5 shrink-0">{{ 'Policy' if r.scratch_type == 'policy' else 'Client' }}</span>
+    <div class="min-w-0">
+      <span class="font-medium text-gray-800">{{ r.client_name }}</span>
+      {% if r.scratch_type == 'policy' %}
+      <span class="text-gray-400 mx-1">&middot;</span>
+      <span class="text-gray-700">{{ r.policy_type }}</span>
+      <span class="text-[10px] font-mono text-gray-400">{{ r.policy_uid }}</span>
+      {% endif %}
+      {% if r.excerpt %}
+      <p class="text-xs text-gray-400 mt-0.5 line-clamp-1">{{ r.excerpt }}</p>
+      {% endif %}
+    </div>
+  </a>
   {% endfor %}
 </div>
 {% endif %}

--- a/src/policydb/web/templates/search.html
+++ b/src/policydb/web/templates/search.html
@@ -207,14 +207,14 @@
     <span class="text-[10px] bg-gray-100 text-gray-500 rounded-full px-2 py-0.5">{{ results.inbox|length }}</span>
   </div>
   {% for r in results.inbox %}
-  <div class="flex items-start gap-3 px-5 py-3 border-b border-gray-50 last:border-0">
+  <a href="/action-center?tab=inbox" class="flex items-start gap-3 px-5 py-3 hover:bg-gray-50 border-b border-gray-50 last:border-0">
     <span class="text-[10px] font-mono text-gray-400 mt-0.5 shrink-0">{{ r.inbox_uid }}</span>
     <div class="min-w-0">
       <span class="font-medium text-gray-800 truncate block">{{ r.email_subject or (r.content[:80] if r.content else 'Inbox item') }}</span>
       {% if r.email_from %}<span class="text-xs text-gray-400">from {{ r.email_from }}</span>{% endif %}
     </div>
     <span class="text-xs text-gray-400 shrink-0 ml-auto">{{ r.created_at[:10] if r.created_at else '' }}</span>
-  </div>
+  </a>
   {% endfor %}
 </div>
 {% endif %}


### PR DESCRIPTION
Audited every filter/search surface and fixed the bugs that were
breaking functionality:

- Clients live search returned 500: /clients/search rendered
  _table_rows.html which calls health_dot() on each row, but the
  search route never enriched rows with score_client(). Added the
  call so the partial has the health fields it expects.

- Global search activity links were dead: both _search_dropdown.html
  and search.html rendered activity matches as href="#" / a bare
  <div>. Fixed to link to /clients/{id}#activity-{id} and added
  client_id to the activity hydrate query so the link works.

- Follow-ups were missing from global search: rebuild_search_index()
  only indexed activity_log rows where item_kind IS NULL, so any row
  with item_kind='followup' was silently excluded. Broadened the
  WHERE to include 'followup'.

- Scratchpads were indexed but never returned: rebuild_search_index()
  inserts client/policy scratchpad rows under entity_type='scratchpad',
  but full_text_search() never hydrated them and no template rendered
  them. Added a custom hydration path (scratchpads use composite IDs),
  the missing 'scratchpads' key in the empty-result dicts, the
  scratchpads slot in the live-search priority order, and the matching
  sections in _search_dropdown.html and search.html.

- Dashboard pipeline filter buttons stuck on stale state: the window/
  status buttons in dashboard.html only swapped the table body
  (#dash-pipeline-body), so the buttons themselves were never
  re-rendered with the new active class, and the "All" button still
  carried the original window value from first render. Extracted the
  controls + body into dashboard/_pipeline_section.html, pointed every
  button at #dash-pipeline-section, and updated the route to return
  the new partial. Renamed dash_window/dash_status to window/status
  to match the partial's expected vars.

- KB search had no LIMIT clauses: /kb/search ran unbounded LIKE
  queries against kb_articles, attachments, and kb_bookmarks. Added
  LIMIT 200 to each.

Verified end-to-end against a fresh local server: every filter/search
endpoint reviewed during the audit (24 pages) returns 200, the
pipeline filter active state propagates correctly through window and
status changes, and global search results for clients, activities,
and scratchpads all link to the right targets.

https://claude.ai/code/session_01Wnd8tj6j8dAufXBynMYtLt