### PR TITLE
RFI attachments: item-level support, re-parent on delete, download all as zip

### DIFF
--- a/src/policydb/web/routes/attachments.py
+++ b/src/policydb/web/routes/attachments.py
@@ -429,9 +429,8 @@ def download_attachments_zip(
     with zipfile.ZipFile(buf, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
         # Header
         if record_type == "rfi_bundle" and bundle_meta:
-            manifest_lines.append(
-                f"RFI: {bundle_meta['rfi_uid'] or ''} — {bundle_meta['title'] or ''}".strip(" —")
-            )
+            parts = [p for p in (bundle_meta["rfi_uid"], bundle_meta["title"]) if p]
+            manifest_lines.append("RFI: " + (" — ".join(parts) if parts else f"Bundle #{record_id}"))
         else:
             manifest_lines.append(f"{record_type.upper()} #{record_id}")
         manifest_lines.append("=" * 60)

--- a/src/policydb/web/routes/attachments.py
+++ b/src/policydb/web/routes/attachments.py
@@ -1,19 +1,24 @@
 """Universal Attachments routes — DevonThink links + local file uploads.
 
 Supports attaching files to any record type: policy, client, activity,
-rfi_bundle, kb_article, meeting, project.
+rfi_bundle, rfi_item, kb_article, meeting, project, issue. Also exposes
+a zip-all endpoint that packages every file attached to a record (and,
+for rfi_bundle, every file attached to its items) as a downloadable
+archive ready to send to a client.
 """
 
 from __future__ import annotations
 
+import io
 import json
 import logging
 import os
 import re
+import zipfile
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, File, Form, Query, Request, UploadFile
-from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse, StreamingResponse
 
 import policydb.config as cfg
 from policydb.db import next_attachment_uid
@@ -49,7 +54,7 @@ _MIME_MAP = {
     ".csv": "text/csv",
 }
 
-_VALID_RECORD_TYPES = {"policy", "client", "activity", "rfi_bundle", "kb_article", "project", "issue"}
+_VALID_RECORD_TYPES = {"policy", "client", "activity", "rfi_bundle", "rfi_item", "kb_article", "project", "issue"}
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
@@ -271,6 +276,219 @@ async def attachment_panel_partial(
         "categories": categories,
         "dt_available": dt_available,
     })
+
+
+# ── Download all attachments as a single zip ────────────────────────────────
+# NOTE: this route must be defined BEFORE the /api/attachments/{uid} routes
+# below, otherwise FastAPI matches the {uid} pattern first with uid="zip".
+
+
+def _slugify_folder(name: str, max_len: int = 40) -> str:
+    """Make a filesystem-safe, short folder name from free text."""
+    n = re.sub(r"[^\w\s-]", "", name or "").strip()
+    n = re.sub(r"\s+", "_", n)
+    return n[:max_len] or "Untitled"
+
+
+@router.get("/api/attachments/zip")
+def download_attachments_zip(
+    record_type: str = Query(...),
+    record_id: int = Query(...),
+    conn=Depends(get_db),
+):
+    """Download all attachments linked to a record as a single zip.
+
+    For record_type='rfi_bundle', also includes attachments from every
+    item in the bundle — bundle-level files go under ``Bundle/`` and
+    each item with attachments gets its own ``Item_NNN_<slug>/`` folder.
+    DevonThink files are resolved via ``fetch_item_metadata`` and pulled
+    from their on-disk path; files that can't be resolved are listed in
+    ``MANIFEST.txt`` as UNAVAILABLE so the user can retrieve them by hand.
+    """
+    if record_type not in _VALID_RECORD_TYPES:
+        return JSONResponse({"ok": False, "error": "Invalid record type"}, status_code=400)
+
+    # Direct attachments on this record
+    direct_rows = conn.execute(
+        """SELECT a.*, ra.sort_order AS link_sort
+           FROM attachments a
+           JOIN record_attachments ra ON ra.attachment_id = a.id
+           WHERE ra.record_type = ? AND ra.record_id = ?
+           ORDER BY ra.sort_order, a.created_at""",
+        (record_type, record_id),
+    ).fetchall()
+
+    # For rfi_bundle, also pull item-level attachments keyed by item
+    item_groups: list[tuple[dict, list]] = []
+    bundle_meta = None
+    if record_type == "rfi_bundle":
+        bundle_meta = conn.execute(
+            "SELECT rfi_uid, title FROM client_request_bundles WHERE id = ?",
+            (record_id,),
+        ).fetchone()
+        items = conn.execute(
+            """SELECT id, description, sort_order
+               FROM client_request_items
+               WHERE bundle_id = ?
+               ORDER BY sort_order, id""",
+            (record_id,),
+        ).fetchall()
+        for item in items:
+            att_rows = conn.execute(
+                """SELECT a.*, ra.sort_order AS link_sort
+                   FROM attachments a
+                   JOIN record_attachments ra ON ra.attachment_id = a.id
+                   WHERE ra.record_type = 'rfi_item' AND ra.record_id = ?
+                   ORDER BY ra.sort_order, a.created_at""",
+                (item["id"],),
+            ).fetchall()
+            if att_rows:
+                item_groups.append((dict(item), att_rows))
+
+    if not direct_rows and not item_groups:
+        return JSONResponse({"ok": False, "error": "No attachments to download"}, status_code=404)
+
+    # Build zip in memory
+    buf = io.BytesIO()
+    manifest_lines: list[str] = []
+    used_names_by_folder: dict[str, set[str]] = {}
+
+    def _uniq_name(folder: str, fname: str) -> str:
+        used = used_names_by_folder.setdefault(folder, set())
+        if fname not in used:
+            used.add(fname)
+            return fname
+        base, ext = os.path.splitext(fname)
+        i = 2
+        while True:
+            candidate = f"{base}_{i}{ext}"
+            if candidate not in used:
+                used.add(candidate)
+                return candidate
+            i += 1
+
+    def _add_attachment(zf: zipfile.ZipFile, folder: str, att: dict) -> None:
+        """Add one attachment to the zip and append a manifest line."""
+        raw_name = att.get("filename") or att.get("title") or "file"
+        fname = _sanitize_filename(str(raw_name).strip() or "file")
+
+        if att.get("source") == "local":
+            fp = Path(att.get("file_path") or "")
+            try:
+                resolved = fp.resolve()
+                if not str(resolved).startswith(str(_ATTACHMENTS_DIR.resolve())):
+                    manifest_lines.append(f"  SKIPPED (invalid path): {fname}")
+                    return
+                if not resolved.exists() or not resolved.is_file():
+                    manifest_lines.append(f"  SKIPPED (missing on disk): {fname}")
+                    return
+                uniq = _uniq_name(folder, fname)
+                arcname = f"{folder}{uniq}" if folder else uniq
+                zf.write(str(resolved), arcname=arcname)
+                sz = att.get("file_size") or resolved.stat().st_size
+                manifest_lines.append(f"  {arcname}  [Local, {_format_file_size(sz)}]")
+            except Exception as exc:
+                logger.warning("Zip: failed to add local attachment %s: %s", att.get("uid"), exc)
+                manifest_lines.append(f"  SKIPPED (error): {fname}")
+            return
+
+        if att.get("source") == "devonthink":
+            dt_uuid = att.get("dt_uuid")
+            dt_url = att.get("dt_url") or ""
+            meta = fetch_item_metadata(dt_uuid) if dt_uuid else None
+            dt_path = (meta or {}).get("path") if meta else None
+            display_title = att.get("title") or fname
+            if not dt_path:
+                manifest_lines.append(
+                    f"  UNAVAILABLE: {display_title}  [DevonThink link: {dt_url}]"
+                )
+                return
+            try:
+                src = Path(dt_path)
+                if not src.exists() or not src.is_file():
+                    manifest_lines.append(
+                        f"  UNAVAILABLE: {display_title}  [DevonThink path missing, link: {dt_url}]"
+                    )
+                    return
+                dt_filename = _sanitize_filename((meta or {}).get("filename") or src.name or fname)
+                uniq = _uniq_name(folder, dt_filename)
+                arcname = f"{folder}{uniq}" if folder else uniq
+                zf.write(str(src), arcname=arcname)
+                sz = src.stat().st_size
+                manifest_lines.append(f"  {arcname}  [DevonThink, {_format_file_size(sz)}]")
+            except Exception as exc:
+                logger.warning("Zip: failed to add DT attachment %s: %s", att.get("uid"), exc)
+                manifest_lines.append(
+                    f"  UNAVAILABLE: {display_title}  [Error: {exc}, link: {dt_url}]"
+                )
+            return
+
+        # Unknown source — skip
+        manifest_lines.append(f"  SKIPPED (unknown source): {fname}")
+
+    with zipfile.ZipFile(buf, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        # Header
+        if record_type == "rfi_bundle" and bundle_meta:
+            manifest_lines.append(
+                f"RFI: {bundle_meta['rfi_uid'] or ''} — {bundle_meta['title'] or ''}".strip(" —")
+            )
+        else:
+            manifest_lines.append(f"{record_type.upper()} #{record_id}")
+        manifest_lines.append("=" * 60)
+        manifest_lines.append("")
+
+        # Direct / bundle-level files
+        if direct_rows:
+            if record_type == "rfi_bundle":
+                manifest_lines.append("Bundle-level files:")
+                folder = "Bundle/"
+            else:
+                manifest_lines.append("Files:")
+                folder = ""
+            for r in direct_rows:
+                _add_attachment(zf, folder, dict(r))
+            manifest_lines.append("")
+
+        # Item-level files (rfi_bundle only)
+        for item_info, att_rows in item_groups:
+            slug = _slugify_folder(item_info.get("description") or "Item")
+            so = item_info.get("sort_order") or 0
+            folder = f"Item_{so:03d}_{slug}/"
+            manifest_lines.append(
+                f"Item: {item_info.get('description') or '(no description)'}"
+            )
+            for r in att_rows:
+                _add_attachment(zf, folder, dict(r))
+            manifest_lines.append("")
+
+        zf.writestr("MANIFEST.txt", "\n".join(manifest_lines).encode("utf-8"))
+
+    buf.seek(0)
+    data = buf.getvalue()
+
+    # Download filename
+    if record_type == "rfi_bundle" and bundle_meta:
+        base_name = bundle_meta["rfi_uid"] or f"RFI_{record_id}"
+        if bundle_meta["title"]:
+            base_name = f"{base_name}_{_slugify_folder(bundle_meta['title'])}"
+    else:
+        base_name = f"{record_type}_{record_id}"
+    download_name = f"{_sanitize_filename(base_name)}_files.zip"
+
+    logger.info(
+        "Zip download: %s/%s → %d bytes (%d direct, %d item groups)",
+        record_type,
+        record_id,
+        len(data),
+        len(direct_rows),
+        len(item_groups),
+    )
+
+    return StreamingResponse(
+        iter([data]),
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{download_name}"'},
+    )
 
 
 # ── Get / Update / Delete attachment ─────────────────────────────────────────

--- a/src/policydb/web/routes/clients.py
+++ b/src/policydb/web/routes/clients.py
@@ -1550,8 +1550,14 @@ def client_tab_files(
             WHEN 'policy' THEN (SELECT policy_uid || ' — ' || COALESCE(policy_type, '') FROM policies WHERE id = ra.record_id)
             WHEN 'activity' THEN (SELECT COALESCE(activity_type, '') || ': ' || COALESCE(subject, '') FROM activity_log WHERE id = ra.record_id)
             WHEN 'project' THEN (SELECT name FROM projects WHERE id = ra.record_id)
-            WHEN 'rfi_bundle' THEN (SELECT COALESCE(title, 'RFI Bundle') FROM client_request_bundles WHERE id = ra.record_id)
-          END AS source_label
+            WHEN 'rfi_bundle' THEN (SELECT COALESCE(rfi_uid, '') || CASE WHEN rfi_uid IS NOT NULL AND rfi_uid <> '' THEN ' — ' ELSE '' END || COALESCE(title, 'RFI Bundle') FROM client_request_bundles WHERE id = ra.record_id)
+            WHEN 'rfi_item' THEN (SELECT COALESCE(cri.description, 'RFI Item') FROM client_request_items cri WHERE cri.id = ra.record_id)
+          END AS source_label,
+          CASE ra.record_type
+            WHEN 'rfi_bundle' THEN ra.record_id
+            WHEN 'rfi_item' THEN (SELECT cri.bundle_id FROM client_request_items cri WHERE cri.id = ra.record_id)
+            ELSE NULL
+          END AS rfi_bundle_id
         FROM attachments a
         JOIN record_attachments ra ON ra.attachment_id = a.id
         WHERE (ra.record_type = 'client' AND ra.record_id = :cid)
@@ -1559,6 +1565,11 @@ def client_tab_files(
            OR (ra.record_type = 'activity' AND ra.record_id IN (SELECT id FROM activity_log WHERE client_id = :cid))
            OR (ra.record_type = 'project' AND ra.record_id IN (SELECT id FROM projects WHERE client_id = :cid))
            OR (ra.record_type = 'rfi_bundle' AND ra.record_id IN (SELECT id FROM client_request_bundles WHERE client_id = :cid))
+           OR (ra.record_type = 'rfi_item' AND ra.record_id IN (
+               SELECT cri.id FROM client_request_items cri
+               JOIN client_request_bundles crb ON crb.id = cri.bundle_id
+               WHERE crb.client_id = :cid
+           ))
         ORDER BY ra.record_type, source_label, ra.sort_order
         LIMIT 500
     """, {"cid": client_id}).fetchall()
@@ -1586,7 +1597,7 @@ def client_tab_files(
         a["size_display"] = _size_display(a.get("file_size"))
 
     # Build link URLs for source records
-    def _link_url(record_type, record_id, source_label):
+    def _link_url(record_type, record_id, source_label, rfi_bundle_id):
         if record_type == "policy" and source_label:
             uid = source_label.split(" — ")[0].strip()
             return f"/policies/{uid}/edit"
@@ -1594,10 +1605,16 @@ def client_tab_files(
             return f"/clients/{client_id}/projects/{record_id}"
         if record_type == "client":
             return f"/clients/{client_id}"
+        if record_type == "rfi_bundle":
+            return f"/clients/{client_id}/requests/{record_id}"
+        if record_type == "rfi_item" and rfi_bundle_id:
+            return f"/clients/{client_id}/requests/{rfi_bundle_id}#req-item-{record_id}"
         return ""
 
     for a in all_atts:
-        a["link_url"] = _link_url(a["record_type"], a["record_id"], a.get("source_label", ""))
+        a["link_url"] = _link_url(
+            a["record_type"], a["record_id"], a.get("source_label", ""), a.get("rfi_bundle_id")
+        )
 
     total_count = len(all_atts)
     record_types = sorted({a["record_type"] for a in all_atts})
@@ -2172,6 +2189,11 @@ def client_detail(request: Request, client_id: int, add_contact: str = "", conn=
            OR (ra.record_type = 'activity' AND ra.record_id IN (SELECT id FROM activity_log WHERE client_id = :cid))
            OR (ra.record_type = 'project' AND ra.record_id IN (SELECT id FROM projects WHERE client_id = :cid))
            OR (ra.record_type = 'rfi_bundle' AND ra.record_id IN (SELECT id FROM client_request_bundles WHERE client_id = :cid))
+           OR (ra.record_type = 'rfi_item' AND ra.record_id IN (
+               SELECT cri.id FROM client_request_items cri
+               JOIN client_request_bundles crb ON crb.id = cri.bundle_id
+               WHERE crb.client_id = :cid
+           ))
     """, {"cid": client_id}).fetchone()[0]
 
     from policydb.queries import REVIEW_CYCLE_LABELS as _REVIEW_CYCLE_LABELS
@@ -4981,6 +5003,24 @@ def _enrich_request_items(conn, items: list[dict]) -> list[dict]:
     return items
 
 
+def _attach_item_attachment_counts(conn, items: list[dict]) -> None:
+    """Populate item['attachment_count'] for a list of RFI items via one batched query."""
+    if not items:
+        return
+    item_ids = [i["id"] for i in items]
+    placeholders = ",".join("?" * len(item_ids))
+    rows = conn.execute(
+        f"""SELECT record_id AS item_id, COUNT(*) AS n
+            FROM record_attachments
+            WHERE record_type='rfi_item' AND record_id IN ({placeholders})
+            GROUP BY record_id""",
+        item_ids,
+    ).fetchall()
+    counts = {r["item_id"]: r["n"] for r in rows}
+    for item in items:
+        item["attachment_count"] = counts.get(item["id"], 0)
+
+
 def _bundle_response(request, conn, client_id: int, bundle_id: int):
     bundle = conn.execute(
         "SELECT * FROM client_request_bundles WHERE id=? AND client_id=?",
@@ -4992,6 +5032,15 @@ def _bundle_response(request, conn, client_id: int, bundle_id: int):
         "SELECT * FROM client_request_items WHERE bundle_id=? ORDER BY received ASC, sort_order ASC, id ASC",
         (bundle_id,),
     ).fetchall()])
+    _attach_item_attachment_counts(conn, items)
+    # Total attachment count for the Download ZIP button — bundle-level + sum of item counts
+    bundle_att_count = conn.execute(
+        "SELECT COUNT(*) FROM record_attachments WHERE record_type='rfi_bundle' AND record_id=?",
+        (bundle_id,),
+    ).fetchone()[0]
+    item_att_total = sum(i.get("attachment_count", 0) for i in items)
+    bundle_dict = dict(bundle)
+    bundle_dict["total_attachment_count"] = bundle_att_count + item_att_total
     client = conn.execute("SELECT id, name FROM clients WHERE id=?", (client_id,)).fetchone()
     # Get policies for this client (for linking items to policies)
     policies = [dict(r) for r in conn.execute(
@@ -5001,7 +5050,7 @@ def _bundle_response(request, conn, client_id: int, bundle_id: int):
     return templates.TemplateResponse("clients/_request_bundle.html", {
         "request": request,
         "client": dict(client) if client else {"id": client_id, "name": ""},
-        "bundle": dict(bundle),
+        "bundle": bundle_dict,
         "items": items,
         "policies": policies,
         "request_categories": cfg.get("request_categories", []),
@@ -5192,6 +5241,7 @@ def toggle_request_item(
         "SELECT * FROM client_request_items WHERE id=?", (item_id,)
     ).fetchone())
     _enrich_request_items(conn, [updated_item])
+    _attach_item_attachment_counts(conn, [updated_item])
     bundle = conn.execute(
         "SELECT * FROM client_request_bundles WHERE id=? AND client_id=?",
         (bundle_id, client_id),
@@ -5239,12 +5289,30 @@ def delete_request_item(
     item_id: int,
     conn=Depends(get_db),
 ):
+    # Re-parent any item-level attachments up to the bundle so history is
+    # preserved ("we sent this type of application for this RFI before").
+    # INSERT OR IGNORE protects the UNIQUE(attachment_id, record_type, record_id)
+    # constraint in the case where the same file is already linked at the bundle
+    # level — the existing bundle link wins, the item link is dropped.
+    conn.execute(
+        """INSERT OR IGNORE INTO record_attachments (attachment_id, record_type, record_id, sort_order, created_at)
+           SELECT attachment_id, 'rfi_bundle', ?, sort_order, created_at
+           FROM record_attachments
+           WHERE record_type='rfi_item' AND record_id=?""",
+        (bundle_id, item_id),
+    )
+    conn.execute(
+        "DELETE FROM record_attachments WHERE record_type='rfi_item' AND record_id=?",
+        (item_id,),
+    )
     conn.execute(
         "DELETE FROM client_request_items WHERE id=? AND bundle_id=?",
         (item_id, bundle_id),
     )
     conn.commit()
-    return HTMLResponse("")
+    # Trigger a refresh of the bundle-level attachment panel so any promoted
+    # files appear immediately. The listener lives in _request_bundle.html.
+    return HTMLResponse("", headers={"HX-Trigger": "refreshBundleAttachments"})
 
 
 @router.post(

--- a/src/policydb/web/templates/clients/_request_bundle.html
+++ b/src/policydb/web/templates/clients/_request_bundle.html
@@ -142,24 +142,44 @@
 
 <script>
 /* Global: toggle the lazy-loaded attachment panel under an RFI item.
-   First click fetches the panel via HTMX; subsequent clicks just show/hide it. */
+   Always re-fetches on open so the panel stays fresh after detaches made
+   elsewhere, and so a failed first-load naturally retries on the next click. */
 if (typeof window.toggleItemAttachments !== 'function') {
   window.toggleItemAttachments = function(itemId) {
     var host = document.getElementById('item-att-' + itemId);
     if (!host) return;
-    var isHidden = host.classList.contains('hidden');
+    var willShow = host.classList.contains('hidden');
     host.classList.toggle('hidden');
-    if (isHidden && host.dataset.loaded !== 'true') {
-      if (window.htmx) {
-        window.htmx.ajax(
-          'GET',
-          '/api/attachments/panel?record_type=rfi_item&record_id=' + itemId,
-          {target: '#item-att-' + itemId, swap: 'innerHTML'}
-        );
-        host.dataset.loaded = 'true';
-      }
+    if (willShow && window.htmx) {
+      window.htmx.ajax(
+        'GET',
+        '/api/attachments/panel?record_type=rfi_item&record_id=' + itemId,
+        {target: '#item-att-' + itemId, swap: 'innerHTML'}
+      );
     }
   };
+}
+
+/* Keep each item's paperclip count badge in sync with its panel after any
+   HTMX swap inside that item's attachment container. Handles both first
+   load (target = #item-att-N) and subsequent panel refreshes after
+   attach/detach (target = #attachments-panel-rfi_item-N). Installed once. */
+if (!window.__rfiItemBadgeListenerInstalled) {
+  window.__rfiItemBadgeListenerInstalled = true;
+  document.body.addEventListener('htmx:afterSwap', function(evt) {
+    var target = evt.detail && evt.detail.target;
+    if (!target) return;
+    var container = (target.id && target.id.indexOf('item-att-') === 0)
+      ? target
+      : (target.closest && target.closest('[id^="item-att-"]'));
+    if (!container || !container.id) return;
+    var itemId = container.id.replace('item-att-', '');
+    var count = container.querySelectorAll('[id^="att-card-"]').length;
+    var badge = document.getElementById('item-att-count-' + itemId);
+    if (badge) {
+      badge.textContent = count > 0 ? count : 'Attach';
+    }
+  });
 }
 
 (function() {

--- a/src/policydb/web/templates/clients/_request_bundle.html
+++ b/src/policydb/web/templates/clients/_request_bundle.html
@@ -58,6 +58,14 @@
        class="text-xs text-marsh hover:text-blue-800 border border-blue-200 hover:border-blue-300 rounded px-2 py-1 transition-colors no-print">Copy Table</button>
     <a href="/clients/{{ client.id }}/requests/{{ bundle.id }}/export"
        class="text-xs text-green-600 hover:text-green-700 border border-green-200 hover:border-green-300 rounded px-2 py-1 transition-colors no-print">Export XLSX</a>
+    {% if bundle.total_attachment_count and bundle.total_attachment_count > 0 %}
+    <a href="/api/attachments/zip?record_type=rfi_bundle&record_id={{ bundle.id }}"
+       class="text-xs text-marsh hover:text-marsh-light border border-marsh/30 hover:border-marsh rounded px-2 py-1 transition-colors no-print inline-flex items-center gap-1"
+       title="Download all attached files (bundle + items) as a zip archive">
+       <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M7 10l5 5 5-5M12 15V3"/></svg>
+       Download ZIP ({{ bundle.total_attachment_count }})
+    </a>
+    {% endif %}
     <span class="flex-1"></span>
     {% if bundle.status != 'complete' %}
     <form hx-post="/clients/{{ client.id }}/requests/{{ bundle.id }}/status"
@@ -119,16 +127,41 @@
   <p class="text-[10px] text-gray-400 mt-2">Sent {{ bundle.sent_at[:16] }}</p>
   {% endif %}
 
-  {# ── Files & Attachments ── #}
+  {# ── Files & Attachments ──
+     Also listens for refreshBundleAttachments (fired after an RFI item is
+     deleted) so any attachments that were re-parented from the deleted item
+     up to the bundle appear immediately without a full page reload. #}
   <div class="mt-4 pt-3 border-t border-gray-200"
     hx-get="/api/attachments/panel?record_type=rfi_bundle&record_id={{ bundle.id }}"
-    hx-trigger="load" hx-swap="innerHTML">
+    hx-trigger="load, refreshBundleAttachments from:body"
+    hx-swap="innerHTML">
     <p class="text-xs text-gray-400 italic">Loading attachments...</p>
   </div>
 
 </div>
 
 <script>
+/* Global: toggle the lazy-loaded attachment panel under an RFI item.
+   First click fetches the panel via HTMX; subsequent clicks just show/hide it. */
+if (typeof window.toggleItemAttachments !== 'function') {
+  window.toggleItemAttachments = function(itemId) {
+    var host = document.getElementById('item-att-' + itemId);
+    if (!host) return;
+    var isHidden = host.classList.contains('hidden');
+    host.classList.toggle('hidden');
+    if (isHidden && host.dataset.loaded !== 'true') {
+      if (window.htmx) {
+        window.htmx.ajax(
+          'GET',
+          '/api/attachments/panel?record_type=rfi_item&record_id=' + itemId,
+          {target: '#item-att-' + itemId, swap: 'innerHTML'}
+        );
+        host.dataset.loaded = 'true';
+      }
+    }
+  };
+}
+
 (function() {
   var BID = "{{ bundle.id }}";
   var CID = "{{ client.id }}";

--- a/src/policydb/web/templates/clients/_request_item.html
+++ b/src/policydb/web/templates/clients/_request_item.html
@@ -38,7 +38,7 @@
           class="text-[10px] text-gray-400 hover:text-marsh inline-flex items-center gap-0.5 no-print"
           title="{% if item.attachment_count and item.attachment_count > 0 %}Show/hide attached files{% else %}Attach a file{% endif %}">
           <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"/></svg>
-          {% if item.attachment_count and item.attachment_count > 0 %}{{ item.attachment_count }}{% else %}Attach{% endif %}
+          <span id="item-att-count-{{ item.id }}">{% if item.attachment_count and item.attachment_count > 0 %}{{ item.attachment_count }}{% else %}Attach{% endif %}</span>
         </button>
       </div>
     </div>
@@ -57,6 +57,5 @@
          style="min-height: 1.5rem; white-space: pre-line; word-break: break-word;">{{ item.notes or '' }}</div>
   </div>
   {# Row 3: Lazy-loaded attachment panel — hidden until the paperclip is clicked #}
-  <div id="item-att-{{ item.id }}" class="hidden ml-8 mt-2 no-print"
-       data-loaded="false"></div>
+  <div id="item-att-{{ item.id }}" class="hidden ml-8 mt-2 no-print"></div>
 </div>

--- a/src/policydb/web/templates/clients/_request_item.html
+++ b/src/policydb/web/templates/clients/_request_item.html
@@ -33,6 +33,13 @@
         {% if item.received and item.received_at %}
         <span class="text-[10px] text-green-600">received {{ item.received_at[:10] }}</span>
         {% endif %}
+        <button type="button"
+          onclick="toggleItemAttachments({{ item.id }})"
+          class="text-[10px] text-gray-400 hover:text-marsh inline-flex items-center gap-0.5 no-print"
+          title="{% if item.attachment_count and item.attachment_count > 0 %}Show/hide attached files{% else %}Attach a file{% endif %}">
+          <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"/></svg>
+          {% if item.attachment_count and item.attachment_count > 0 %}{{ item.attachment_count }}{% else %}Attach{% endif %}
+        </button>
       </div>
     </div>
     <button
@@ -49,4 +56,7 @@
          data-placeholder="Response or notes..."
          style="min-height: 1.5rem; white-space: pre-line; word-break: break-word;">{{ item.notes or '' }}</div>
   </div>
+  {# Row 3: Lazy-loaded attachment panel — hidden until the paperclip is clicked #}
+  <div id="item-att-{{ item.id }}" class="hidden ml-8 mt-2 no-print"
+       data-loaded="false"></div>
 </div>


### PR DESCRIPTION
Close the last gaps in RFI file attachments. Bundle-level attachments already
worked via the universal attachments panel; this adds:

- Item-level attachments via a new rfi_item record_type. Each RFI item card
  carries a compact paperclip trigger that lazy-loads the existing attachment
  panel on first click — no per-item query N+1, counts are batched.
- Re-parent on item delete: when an RFI item with attachments is removed,
  its links are promoted up to the bundle (INSERT OR IGNORE handles the
  case where the same file was already attached at the bundle level).
  Historical context is preserved without leaving orphan rows.
- Download ZIP endpoint at /api/attachments/zip that bundles every file
  linked to a record into a single archive ready to send to a client. For
  rfi_bundle, also pulls all item-level files, organizing them into
  Bundle/ and Item_NNN_<slug>/ folders with a MANIFEST.txt. DevonThink
  items are resolved via fetch_item_metadata and read from disk; any that
  can't be resolved are listed in the manifest with their x-devonthink-item
  URL for manual retrieval.
- Client Files tab rollup now surfaces rfi_item attachments with a
  clickable anchor back to the bundle detail page at the item anchor.

Route order fix: the new /api/attachments/zip had to be registered before
/api/attachments/{uid} to avoid being swallowed by the uid catch-all.

https://claude.ai/code/session_01CHCxsH75S6jWUghjoVxU3S