### PR TITLE
Add recurring events system for scheduled repeating touchpoints

### DIFF
--- a/src/policydb/config.py
+++ b/src/policydb/config.py
@@ -639,6 +639,31 @@ _DEFAULTS: dict[str, Any] = {
             "subject": "Confirm final policy document received",
         },
     ],
+    # ── Recurring Events ─────────────────────────────────────────────
+    # Cadence labels used by recurring_events.cadence. _advance() in
+    # recurring_events.py hard-codes how each label steps forward; adding a
+    # new label here requires a corresponding case there.
+    "recurring_event_cadences": [
+        "Daily",
+        "Weekly",
+        "Biweekly",
+        "Monthly",
+        "Quarterly",
+        "Semi-Annual",
+        "Annual",
+    ],
+    # Classification labels for recurring_events.event_type (UI filtering only)
+    "recurring_event_types": [
+        "Call",
+        "Deliverable",
+        "Meeting",
+        "Review",
+        "Report",
+    ],
+    # How far ahead the generator looks when materializing issue instances
+    "recurring_event_generation_horizon_days": 14,
+    # Safety cap on instances materialized per template per generation pass
+    "recurring_event_max_catchup": 12,
     "email_subject_request": "{{client_name}} \u2014 {{rfi_uid}} {{request_title}}",
     "email_subject_request_all": "{{client_name}} \u2014 Outstanding Information Requests",
     "email_subject_rfi_notify": "FYI: {{client_name}} \u2014 {{rfi_uid}} Items Received",

--- a/src/policydb/db.py
+++ b/src/policydb/db.py
@@ -364,7 +364,7 @@ def _init_db_inner(conn: sqlite3.Connection, db_path: Path) -> None:
     # Back up the database once before running any pending migrations.
     # This gives a clean restore point regardless of which migration fails.
 
-    _KNOWN_MIGRATIONS = set(range(1, 142))  # update upper bound when adding new migrations
+    _KNOWN_MIGRATIONS = set(range(1, 145))  # update upper bound when adding new migrations
 
     if _KNOWN_MIGRATIONS - applied:
         _backup_db(conn, db_path)
@@ -1886,6 +1886,15 @@ def _init_db_inner(conn: sqlite3.Connection, db_path: Path) -> None:
         conn.commit()
         logger.info("Migration 143: added project_scratchpad table")
 
+    if 144 not in applied:
+        conn.executescript((_MIGRATIONS_DIR / "144_recurring_events.sql").read_text())
+        conn.execute(
+            "INSERT INTO schema_version (version, description) VALUES (?, ?)",
+            (144, "Add recurring_events table for scheduled repeating issue instances"),
+        )
+        conn.commit()
+        logger.info("Migration 144: added recurring_events table + activity_log link columns")
+
     # Data hygiene: fix 'None' string corruption in text fields (runs every startup, fast no-op if clean)
     conn.execute("UPDATE clients SET cn_number = NULL WHERE cn_number = 'None'")
 
@@ -2006,6 +2015,13 @@ def _init_db_inner(conn: sqlite3.Connection, db_path: Path) -> None:
     # Generate policy timelines for all active policies with milestone profiles
     from policydb.timeline_engine import generate_policy_timelines
     generate_policy_timelines(conn)
+
+    # Materialize any due recurring event instances as issue rows
+    try:
+        from policydb.recurring_events import generate_due_recurring_instances
+        generate_due_recurring_instances(conn)
+    except Exception:
+        logger.exception("generate_due_recurring_instances failed during init_db")
 
     # Create/update renewal issues for policies/programs in the renewal window
     from policydb.renewal_issues import ensure_renewal_issues

--- a/src/policydb/focus_queue.py
+++ b/src/policydb/focus_queue.py
@@ -431,6 +431,8 @@ def _normalize_issue(item: dict, today: date) -> dict:
         "escalation_tier": None,
         "nudge_count": 0,
         "cadence": None,
+        "days_fu_to_expiry": None,
+        "policy_hours_30d": 0.0,
         "is_milestone": False,
         "milestone_name": None,
         "project_id": None,
@@ -997,6 +999,14 @@ def build_focus_queue(
         auto_close_stale_followups(conn)
     except Exception:
         logger.debug("auto_close_stale_followups failed", exc_info=True)
+
+    # Materialize any due recurring event instances as issue rows so they show
+    # up in this build pass. Idempotent and cheap.
+    try:
+        from policydb.recurring_events import generate_due_recurring_instances
+        generate_due_recurring_instances(conn)
+    except Exception:
+        logger.debug("generate_due_recurring_instances failed", exc_info=True)
 
     client_ids = [client_id] if client_id else None
 

--- a/src/policydb/migrations/144_recurring_events.sql
+++ b/src/policydb/migrations/144_recurring_events.sql
@@ -1,0 +1,75 @@
+-- 144: Recurring events — scheduled repeating touchpoints per client.
+--
+-- Stores cadence templates for repeating work (weekly open-items calls,
+-- monthly loss-run deliverables, quarterly stewardship reports, etc.).
+-- Each pending occurrence is materialized as an activity_log issue row
+-- (item_kind='issue') by generate_due_recurring_instances(), inheriting
+-- the full issue lifecycle (severity, SLA, resolve flow, Focus Queue).
+--
+-- Instances are linked back via activity_log.recurring_event_id so that
+-- resolving an instance can advance the template's next_occurrence.
+
+CREATE TABLE IF NOT EXISTS recurring_events (
+    id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+    recurring_uid         TEXT UNIQUE,                       -- "REC-001" via uid_sequence
+
+    -- Scope: client required, policy optional
+    client_id             INTEGER NOT NULL REFERENCES clients(id) ON DELETE CASCADE,
+    policy_id             INTEGER REFERENCES policies(id) ON DELETE SET NULL,
+
+    -- Classification + content
+    event_type            TEXT,                              -- from recurring_event_types config (Call/Deliverable/Meeting/Review/Report)
+    name                  TEXT NOT NULL,                     -- "Weekly open items call"
+    subject_template      TEXT,                              -- copied verbatim to issue.subject
+    details_template      TEXT,                              -- copied verbatim to issue.details
+
+    -- Issue defaults applied to every materialized instance
+    default_severity      TEXT NOT NULL DEFAULT 'Normal',    -- resolves to issue_severity + issue_sla_days
+    root_cause_default    TEXT,                              -- optional default for resolve form
+
+    -- Recurrence rule (config-list driven; _advance() hard-codes each label)
+    cadence               TEXT NOT NULL,                     -- Daily|Weekly|Biweekly|Monthly|Quarterly|Semi-Annual|Annual
+    interval_n            INTEGER NOT NULL DEFAULT 1,        -- step multiplier
+    day_of_week           INTEGER,                           -- 0=Mon..6=Sun (Weekly/Biweekly)
+    day_of_month          INTEGER,                           -- 1-31 (Monthly/Quarterly/Semi-Annual/Annual)
+    lead_days             INTEGER NOT NULL DEFAULT 0,        -- materialize N days before recurring_instance_date
+
+    -- Window
+    start_date            DATE NOT NULL,
+    end_date              DATE,                              -- NULL = indefinite
+    next_occurrence       DATE NOT NULL,                     -- high-water mark for generation
+    last_generated_date   DATE,                              -- audit trail
+
+    -- Defaults copied onto each instance
+    account_exec          TEXT,
+
+    -- State
+    active                INTEGER NOT NULL DEFAULT 1,
+    catch_up_mode         TEXT NOT NULL DEFAULT 'collapse',  -- 'collapse' | 'materialize_all'
+    notes                 TEXT,
+
+    created_at            TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_by            TEXT,
+    updated_at            TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_recurring_events_client ON recurring_events(client_id);
+CREATE INDEX IF NOT EXISTS idx_recurring_events_policy ON recurring_events(policy_id);
+CREATE INDEX IF NOT EXISTS idx_recurring_events_next   ON recurring_events(next_occurrence) WHERE active = 1;
+
+CREATE TRIGGER IF NOT EXISTS recurring_events_updated_at
+AFTER UPDATE ON recurring_events BEGIN
+    UPDATE recurring_events SET updated_at = CURRENT_TIMESTAMP WHERE id = NEW.id;
+END;
+
+-- Link materialized issue instances back to their template
+ALTER TABLE activity_log ADD COLUMN recurring_event_id INTEGER REFERENCES recurring_events(id) ON DELETE SET NULL;
+ALTER TABLE activity_log ADD COLUMN recurring_instance_date DATE;
+
+CREATE INDEX IF NOT EXISTS idx_activity_log_recurring
+    ON activity_log(recurring_event_id, recurring_instance_date)
+    WHERE recurring_event_id IS NOT NULL;
+
+-- Seed uid_sequence with REC prefix so next_recurring_uid() can use the atomic path
+INSERT INTO uid_sequence (prefix, next_val) VALUES ('REC', 0)
+ON CONFLICT(prefix) DO NOTHING;

--- a/src/policydb/recurring_events.py
+++ b/src/policydb/recurring_events.py
@@ -1,0 +1,348 @@
+"""Recurring events: lazy generation of repeating issue instances.
+
+A recurring_events row is a schedule template. For each active template
+whose next_occurrence is within the generation horizon,
+generate_due_recurring_instances materializes an activity_log row
+(item_kind='issue', issue_status='Open') and advances the template's
+next_occurrence by one cadence step.
+
+Completion/resolution goes through the standard /issues/{id}/resolve
+endpoint; a hook (advance_template_for_completion) re-runs the generator
+so the next occurrence appears immediately after the user resolves an
+instance.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from calendar import monthrange
+from datetime import date, datetime, timedelta
+
+import policydb.config as cfg
+from policydb.db import generate_issue_uid
+
+logger = logging.getLogger("policydb.recurring_events")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# UID generation — mirrors next_policy_uid() in db.py:2517
+# ─────────────────────────────────────────────────────────────────────────
+
+def next_recurring_uid(conn: sqlite3.Connection) -> str:
+    """Generate next REC-NNN uid using the atomic uid_sequence table.
+
+    Falls back to SELECT MAX for databases that haven't run migration 144.
+    """
+    try:
+        conn.execute(
+            """
+            UPDATE uid_sequence
+            SET next_val = CASE
+                WHEN (
+                    SELECT COALESCE(MAX(CAST(SUBSTR(recurring_uid, 5) AS INTEGER)), 0)
+                    FROM recurring_events WHERE recurring_uid LIKE 'REC-%'
+                ) > next_val
+                THEN (
+                    SELECT COALESCE(MAX(CAST(SUBSTR(recurring_uid, 5) AS INTEGER)), 0)
+                    FROM recurring_events WHERE recurring_uid LIKE 'REC-%'
+                )
+                ELSE next_val
+            END
+            WHERE prefix = 'REC'
+            """
+        )
+        conn.execute(
+            "UPDATE uid_sequence SET next_val = next_val + 1 WHERE prefix = 'REC'"
+        )
+        row = conn.execute(
+            "SELECT next_val FROM uid_sequence WHERE prefix = 'REC'"
+        ).fetchone()
+        if row is not None:
+            return f"REC-{row[0]:03d}"
+    except Exception:
+        pass
+    # Fallback
+    row = conn.execute(
+        "SELECT recurring_uid FROM recurring_events WHERE recurring_uid LIKE 'REC-%' "
+        "ORDER BY CAST(SUBSTR(recurring_uid, 5) AS INTEGER) DESC LIMIT 1"
+    ).fetchone()
+    if not row or not row["recurring_uid"]:
+        return "REC-001"
+    try:
+        n = int(row["recurring_uid"].split("-")[1]) + 1
+    except (IndexError, ValueError):
+        n = 1
+    return f"REC-{n:03d}"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Date arithmetic — pure functions, no config or DB I/O
+# ─────────────────────────────────────────────────────────────────────────
+
+def _parse(value) -> date | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, date):
+        return value
+    return datetime.strptime(str(value)[:10], "%Y-%m-%d").date()
+
+
+def _snap_dow(d: date, day_of_week: int | None) -> date:
+    """Snap forward to the next occurrence of day_of_week (0=Mon..6=Sun)."""
+    if day_of_week is None:
+        return d
+    delta = (day_of_week - d.weekday()) % 7
+    return d + timedelta(days=delta)
+
+
+def _add_months(d: date, months: int, day_of_month: int | None) -> date:
+    """Add months, clamping to month-end for day_of_month > 28 in short months."""
+    total = d.month - 1 + months
+    y = d.year + total // 12
+    m = total % 12 + 1
+    target_day = day_of_month if day_of_month else d.day
+    last_day = monthrange(y, m)[1]
+    return date(y, m, min(target_day, last_day))
+
+
+def _advance(
+    anchor: date,
+    cadence: str,
+    interval_n: int,
+    day_of_week: int | None,
+    day_of_month: int | None,
+) -> date:
+    """Advance anchor by exactly one cadence step."""
+    n = max(1, int(interval_n or 1))
+    cadence_norm = (cadence or "").strip()
+
+    if cadence_norm == "Daily":
+        return anchor + timedelta(days=n)
+    if cadence_norm == "Weekly":
+        return _snap_dow(anchor + timedelta(weeks=n), day_of_week)
+    if cadence_norm == "Biweekly":
+        return _snap_dow(anchor + timedelta(weeks=2 * n), day_of_week)
+    if cadence_norm == "Monthly":
+        return _add_months(anchor, 1 * n, day_of_month)
+    if cadence_norm == "Quarterly":
+        return _add_months(anchor, 3 * n, day_of_month)
+    if cadence_norm == "Semi-Annual":
+        return _add_months(anchor, 6 * n, day_of_month)
+    if cadence_norm == "Annual":
+        return _add_months(anchor, 12 * n, day_of_month)
+
+    logger.warning("Unknown cadence %r; defaulting to +7 days", cadence_norm)
+    return anchor + timedelta(days=7)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Generator — called from init_db and from build_focus_queue
+# ─────────────────────────────────────────────────────────────────────────
+
+def generate_due_recurring_instances(
+    conn: sqlite3.Connection, today: date | None = None
+) -> int:
+    """Materialize activity_log issue rows for every template whose
+    next_occurrence falls within the generation horizon.
+
+    Idempotent: safe to call repeatedly on the same day, on startup, and on
+    every Focus Queue build. Returns number of instance rows inserted.
+    """
+    today = today or date.today()
+    horizon_days = int(cfg.get("recurring_event_generation_horizon_days", 14))
+    max_catchup = int(cfg.get("recurring_event_max_catchup", 12))
+    horizon = today + timedelta(days=horizon_days)
+
+    rows = conn.execute(
+        """
+        SELECT re.*
+        FROM recurring_events re
+        JOIN clients c ON re.client_id = c.id
+        WHERE re.active = 1
+          AND c.archived = 0
+          AND re.next_occurrence <= ?
+          AND (re.end_date IS NULL OR re.end_date >= ?)
+        """,
+        (horizon.isoformat(), today.isoformat()),
+    ).fetchall()
+
+    severities_cfg = cfg.get("issue_severities", []) or []
+    inserted = 0
+    for raw in rows:
+        r = dict(raw)
+        try:
+            inserted += _materialize_template(
+                conn, r, today, horizon, max_catchup, severities_cfg
+            )
+        except Exception:
+            logger.exception(
+                "Recurring event generation failed for id=%s", r.get("id")
+            )
+
+    if inserted:
+        conn.commit()
+        logger.info(
+            "Recurring events: materialized %d issue instance(s)", inserted
+        )
+    return inserted
+
+
+def _sla_for_severity(severities_cfg: list, severity: str) -> int:
+    for sev in severities_cfg:
+        if sev.get("label") == severity:
+            try:
+                return int(sev.get("sla_days", 7))
+            except (TypeError, ValueError):
+                return 7
+    return 7
+
+
+def _materialize_template(
+    conn: sqlite3.Connection,
+    r: dict,
+    today: date,
+    horizon: date,
+    max_catchup: int,
+    severities_cfg: list,
+) -> int:
+    """Insert zero or more issue rows for a single template. Advance pointer."""
+    count = 0
+    next_occ = _parse(r["next_occurrence"]) or today
+    end_date = _parse(r.get("end_date"))
+    start_date = _parse(r.get("start_date")) or today
+    mode = r.get("catch_up_mode") or "collapse"
+    lead_days = int(r.get("lead_days") or 0)
+    severity = r.get("default_severity") or "Normal"
+    sla_days = _sla_for_severity(severities_cfg, severity)
+    subject = r.get("subject_template") or r.get("name") or "Recurring event"
+    details = r.get("details_template") or ""
+    activity_type = "Issue"
+
+    # Don't materialize before start_date
+    if next_occ < start_date:
+        next_occ = start_date
+
+    # Collapse catch-up: if many occurrences are in the past, fast-forward
+    # the pointer to the most recent one <= today and emit only one row.
+    if mode == "collapse" and next_occ < today:
+        while True:
+            candidate = _advance(
+                next_occ,
+                r["cadence"],
+                r["interval_n"],
+                r.get("day_of_week"),
+                r.get("day_of_month"),
+            )
+            if candidate > today:
+                break
+            next_occ = candidate
+
+    # Emit rows for every next_occ within [-∞, horizon], bounded by max_catchup
+    last_inserted_date = None
+    while next_occ <= horizon and count < max_catchup:
+        if end_date is not None and next_occ > end_date:
+            break
+
+        # Idempotency: skip insert if a row already exists for this
+        # (template, instance_date) pair. Still advance the pointer.
+        already = conn.execute(
+            "SELECT 1 FROM activity_log WHERE recurring_event_id = ? AND recurring_instance_date = ? LIMIT 1",
+            (r["id"], next_occ.isoformat()),
+        ).fetchone()
+
+        if not already:
+            fu_date = next_occ - timedelta(days=lead_days)
+            uid = generate_issue_uid()
+            ae = r.get("account_exec") or cfg.get("default_account_exec", "") or ""
+            conn.execute(
+                """
+                INSERT INTO activity_log (
+                    activity_date, client_id, policy_id, activity_type, subject, details,
+                    item_kind, issue_uid, issue_status, issue_severity, issue_sla_days,
+                    due_date, account_exec, recurring_event_id, recurring_instance_date,
+                    created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, 'issue', ?, 'Open', ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+                """,
+                (
+                    today.isoformat(),
+                    r["client_id"],
+                    r.get("policy_id"),
+                    activity_type,
+                    subject,
+                    details,
+                    uid,
+                    severity,
+                    sla_days,
+                    fu_date.isoformat(),
+                    ae,
+                    r["id"],
+                    next_occ.isoformat(),
+                ),
+            )
+            count += 1
+            last_inserted_date = next_occ
+
+        next_occ = _advance(
+            next_occ,
+            r["cadence"],
+            r["interval_n"],
+            r.get("day_of_week"),
+            r.get("day_of_month"),
+        )
+
+    # Persist advanced pointer and last_generated_date
+    conn.execute(
+        "UPDATE recurring_events SET next_occurrence = ?, last_generated_date = ? WHERE id = ?",
+        (
+            next_occ.isoformat(),
+            last_inserted_date.isoformat() if last_inserted_date else r.get("last_generated_date"),
+            r["id"],
+        ),
+    )
+    return count
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Completion hook — called from /issues/{id}/resolve
+# ─────────────────────────────────────────────────────────────────────────
+
+def advance_template_for_completion(
+    conn: sqlite3.Connection, activity_id: int
+) -> None:
+    """If the resolved activity is a recurring instance, re-run the generator
+    so the next occurrence materializes immediately. Safe no-op otherwise."""
+    try:
+        row = conn.execute(
+            "SELECT recurring_event_id FROM activity_log WHERE id = ?",
+            (activity_id,),
+        ).fetchone()
+    except sqlite3.OperationalError:
+        # activity_log.recurring_event_id doesn't exist yet (pre-migration 144)
+        return
+    if not row or not row["recurring_event_id"]:
+        return
+    generate_due_recurring_instances(conn)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Template CRUD helpers (used by route module)
+# ─────────────────────────────────────────────────────────────────────────
+
+def compute_initial_next_occurrence(
+    start_date: date,
+    cadence: str,
+    day_of_week: int | None,
+    day_of_month: int | None,
+) -> date:
+    """Snap start_date forward to the first valid occurrence based on DOW/DOM."""
+    cadence_norm = (cadence or "").strip()
+    if cadence_norm in ("Weekly", "Biweekly") and day_of_week is not None:
+        return _snap_dow(start_date, day_of_week)
+    if cadence_norm in ("Monthly", "Quarterly", "Semi-Annual", "Annual") and day_of_month:
+        last_day = monthrange(start_date.year, start_date.month)[1]
+        target = date(start_date.year, start_date.month, min(day_of_month, last_day))
+        if target < start_date:
+            return _add_months(start_date, 1, day_of_month)
+        return target
+    return start_date

--- a/src/policydb/web/app.py
+++ b/src/policydb/web/app.py
@@ -327,7 +327,7 @@ def get_db() -> Generator[sqlite3.Connection, None, None]:
 
 
 # ── Register routers ──────────────────────────────────────────────────────────
-from policydb.web.routes import dashboard, clients, policies, activities, settings, reconcile, templates as tpl_routes, contacts, review, briefing, inbox, ref_lookup, compliance, action_center, logs, compose, import_history, geocoder as geocoder_routes, charts as charts_routes, programs as programs_routes, exports as exports_routes, issues as issues_routes, data_health as data_health_routes, anomalies as anomalies_routes, kb as kb_routes, attachments as attachments_routes, pinned_notes as pinned_notes_routes, outlook_routes, prompt_builder as prompt_builder_routes, bind_order as bind_order_routes  # noqa: E402
+from policydb.web.routes import dashboard, clients, policies, activities, settings, reconcile, templates as tpl_routes, contacts, review, briefing, inbox, ref_lookup, compliance, action_center, logs, compose, import_history, geocoder as geocoder_routes, charts as charts_routes, programs as programs_routes, exports as exports_routes, issues as issues_routes, data_health as data_health_routes, anomalies as anomalies_routes, kb as kb_routes, attachments as attachments_routes, pinned_notes as pinned_notes_routes, outlook_routes, prompt_builder as prompt_builder_routes, bind_order as bind_order_routes, recurring_events as recurring_events_routes  # noqa: E402
 
 app.include_router(dashboard.router)
 app.include_router(clients.router)
@@ -359,6 +359,7 @@ app.include_router(pinned_notes_routes.router)
 app.include_router(outlook_routes.router)
 app.include_router(prompt_builder_routes.router)
 app.include_router(bind_order_routes.router)
+app.include_router(recurring_events_routes.router)
 
 # Static files (charts JS/CSS assets)
 STATIC_DIR = Path(__file__).parent / "static"

--- a/src/policydb/web/routes/clients.py
+++ b/src/policydb/web/routes/clients.py
@@ -1525,6 +1525,73 @@ def client_tab_issues(request: Request, client_id: int, conn=Depends(get_db)):
     })
 
 
+@router.get("/{client_id}/tab/recurring", response_class=HTMLResponse)
+def client_tab_recurring(request: Request, client_id: int, conn=Depends(get_db)):
+    """Recurring events tab — schedule templates + upcoming/resolved instances."""
+    client = get_client_by_id(conn, client_id, include_archived=True)
+    if not client:
+        return HTMLResponse("Not found", status_code=404)
+
+    templates_rows = [dict(r) for r in conn.execute(
+        """
+        SELECT re.*, p.policy_uid, p.policy_type,
+               (SELECT COUNT(*) FROM activity_log a
+                WHERE a.recurring_event_id = re.id
+                  AND a.item_kind = 'issue'
+                  AND a.issue_status NOT IN ('Resolved','Closed')) AS open_instance_count
+        FROM recurring_events re
+        LEFT JOIN policies p ON re.policy_id = p.id
+        WHERE re.client_id = ?
+        ORDER BY re.active DESC, re.next_occurrence ASC, re.id DESC
+        """,
+        (client_id,),
+    ).fetchall()]
+
+    upcoming = [dict(r) for r in conn.execute(
+        """
+        SELECT a.id, a.issue_uid, a.subject, a.due_date, a.issue_severity,
+               a.issue_status, a.recurring_event_id, a.recurring_instance_date,
+               re.name AS template_name, re.recurring_uid,
+               CAST(julianday(a.due_date) - julianday('now') AS INTEGER) AS days_until_due
+        FROM activity_log a
+        JOIN recurring_events re ON a.recurring_event_id = re.id
+        WHERE a.client_id = ?
+          AND a.item_kind = 'issue'
+          AND a.issue_status NOT IN ('Resolved','Closed')
+        ORDER BY a.due_date ASC, a.id ASC
+        LIMIT 25
+        """,
+        (client_id,),
+    ).fetchall()]
+
+    recent_resolved = [dict(r) for r in conn.execute(
+        """
+        SELECT a.id, a.issue_uid, a.subject, a.resolved_date, a.resolution_type,
+               a.recurring_instance_date, re.name AS template_name, re.recurring_uid
+        FROM activity_log a
+        JOIN recurring_events re ON a.recurring_event_id = re.id
+        WHERE a.client_id = ?
+          AND a.item_kind = 'issue'
+          AND a.issue_status IN ('Resolved','Closed')
+          AND a.resolved_date >= date('now','-60 days')
+        ORDER BY a.resolved_date DESC, a.id DESC
+        LIMIT 25
+        """,
+        (client_id,),
+    ).fetchall()]
+
+    return templates.TemplateResponse("clients/_tab_recurring.html", {
+        "request": request,
+        "client": dict(client),
+        "templates_rows": templates_rows,
+        "upcoming": upcoming,
+        "recent_resolved": recent_resolved,
+        "cadences": cfg.get("recurring_event_cadences", []),
+        "event_types": cfg.get("recurring_event_types", []),
+        "severities": cfg.get("issue_severities", []),
+    })
+
+
 @router.get("/{client_id}/tab/files", response_class=HTMLResponse)
 def client_tab_files(
     request: Request,
@@ -2192,6 +2259,12 @@ def client_detail(request: Request, client_id: int, add_contact: str = "", conn=
         (client_id,),
     ).fetchall()]
 
+    recurring_count_row = conn.execute(
+        "SELECT COUNT(*) AS n FROM recurring_events WHERE client_id = ? AND active = 1",
+        (client_id,),
+    ).fetchone()
+    recurring_count = recurring_count_row["n"] if recurring_count_row else 0
+
     return templates.TemplateResponse("clients/detail.html", {
         "request": request,
         "active": "clients",
@@ -2291,6 +2364,7 @@ def client_detail(request: Request, client_id: int, add_contact: str = "", conn=
         "health_threshold": cfg.get("data_health_threshold", 85),
         "sidebar_issues": sidebar_issues,
         "attachment_count": _att_count,
+        "recurring_count": recurring_count,
         "pinned_notes": _pinned_notes_for_page(conn, "client", client_id),
         "pinned_scope": "client",
         "pinned_scope_id": str(client_id),

--- a/src/policydb/web/routes/issues.py
+++ b/src/policydb/web/routes/issues.py
@@ -238,6 +238,16 @@ def resolve_issue(
     closed = auto_close_followups(
         conn, issue_id=issue_id, reason="issue_resolved", closed_by="issue_resolve",
     )
+
+    # If this is a recurring event instance, advance the template's
+    # next_occurrence so the next occurrence appears in the Focus Queue
+    # on the next build pass.
+    try:
+        from policydb.recurring_events import advance_template_for_completion
+        advance_template_for_completion(conn, issue_id)
+    except Exception:
+        pass
+
     conn.commit()
 
     # Redirect to action center issues tab after resolve

--- a/src/policydb/web/routes/recurring_events.py
+++ b/src/policydb/web/routes/recurring_events.py
@@ -1,0 +1,364 @@
+"""Recurring event template routes — CRUD + skip wrapper.
+
+Templates live in the recurring_events table. Each active template materializes
+pending occurrences as activity_log issue rows via the generator module. The
+UI lives under the Recurring tab on the client detail page.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Form, Request
+from fastapi.responses import HTMLResponse
+
+import policydb.config as cfg
+from policydb.recurring_events import (
+    advance_template_for_completion,
+    compute_initial_next_occurrence,
+    generate_due_recurring_instances,
+    next_recurring_uid,
+)
+from policydb.web.app import get_db, templates
+
+router = APIRouter(prefix="/recurring-events")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────
+
+def _parse_date(value: str) -> Optional[date]:
+    value = (value or "").strip()
+    if not value:
+        return None
+    try:
+        return datetime.strptime(value[:10], "%Y-%m-%d").date()
+    except ValueError:
+        return None
+
+
+def _parse_int(value, default: Optional[int] = None) -> Optional[int]:
+    if value is None or value == "":
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _get_template(conn, recurring_id: int) -> Optional[dict]:
+    row = conn.execute(
+        "SELECT * FROM recurring_events WHERE id = ?", (recurring_id,)
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def _render_client_tab(request: Request, conn, client_id: int) -> HTMLResponse:
+    """Render the client Recurring tab partial — used as HTMX swap target."""
+    from policydb.web.routes.clients import client_tab_recurring  # local import to avoid cycles
+    return client_tab_recurring(request=request, client_id=client_id, conn=conn)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Slideover forms (new + edit)
+# ─────────────────────────────────────────────────────────────────────────
+
+@router.get("/new", response_class=HTMLResponse)
+def new_template_slideover(request: Request, client_id: int, conn=Depends(get_db)):
+    """Return the create slideover bound to a specific client."""
+    client = conn.execute(
+        "SELECT id, name FROM clients WHERE id = ?", (client_id,)
+    ).fetchone()
+    if not client:
+        return HTMLResponse("<p class='p-4 text-sm text-gray-400'>Client not found.</p>", status_code=404)
+
+    policies = [dict(r) for r in conn.execute(
+        "SELECT id, policy_uid, policy_type, carrier FROM policies "
+        "WHERE client_id = ? AND archived = 0 ORDER BY policy_type, policy_uid",
+        (client_id,),
+    ).fetchall()]
+
+    return templates.TemplateResponse("clients/_recurring_slideover.html", {
+        "request": request,
+        "template": None,
+        "client": dict(client),
+        "policies": policies,
+        "cadences": cfg.get("recurring_event_cadences", []),
+        "event_types": cfg.get("recurring_event_types", []),
+        "severities": cfg.get("issue_severities", []),
+        "today_iso": date.today().isoformat(),
+    })
+
+
+@router.get("/{recurring_id}/edit", response_class=HTMLResponse)
+def edit_template_slideover(recurring_id: int, request: Request, conn=Depends(get_db)):
+    template = _get_template(conn, recurring_id)
+    if not template:
+        return HTMLResponse("<p class='p-4 text-sm text-gray-400'>Not found.</p>", status_code=404)
+
+    client = conn.execute(
+        "SELECT id, name FROM clients WHERE id = ?", (template["client_id"],)
+    ).fetchone()
+    policies = [dict(r) for r in conn.execute(
+        "SELECT id, policy_uid, policy_type, carrier FROM policies "
+        "WHERE client_id = ? AND archived = 0 ORDER BY policy_type, policy_uid",
+        (template["client_id"],),
+    ).fetchall()]
+
+    return templates.TemplateResponse("clients/_recurring_slideover.html", {
+        "request": request,
+        "template": template,
+        "client": dict(client) if client else {"id": template["client_id"], "name": ""},
+        "policies": policies,
+        "cadences": cfg.get("recurring_event_cadences", []),
+        "event_types": cfg.get("recurring_event_types", []),
+        "severities": cfg.get("issue_severities", []),
+        "today_iso": date.today().isoformat(),
+    })
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Create / update
+# ─────────────────────────────────────────────────────────────────────────
+
+@router.post("", response_class=HTMLResponse)
+@router.post("/", response_class=HTMLResponse)
+def create_template(
+    request: Request,
+    client_id: int = Form(...),
+    name: str = Form(...),
+    cadence: str = Form(...),
+    start_date: str = Form(...),
+    policy_id: int = Form(0),
+    event_type: str = Form(""),
+    interval_n: int = Form(1),
+    day_of_week: str = Form(""),
+    day_of_month: str = Form(""),
+    lead_days: int = Form(0),
+    end_date: str = Form(""),
+    default_severity: str = Form("Normal"),
+    subject_template: str = Form(""),
+    details_template: str = Form(""),
+    account_exec: str = Form(""),
+    catch_up_mode: str = Form("collapse"),
+    notes: str = Form(""),
+    conn=Depends(get_db),
+):
+    """Create a new recurring event template."""
+    start = _parse_date(start_date) or date.today()
+    end = _parse_date(end_date)
+    dow = _parse_int(day_of_week)
+    dom = _parse_int(day_of_month)
+    next_occ = compute_initial_next_occurrence(start, cadence, dow, dom)
+
+    uid = next_recurring_uid(conn)
+    conn.execute(
+        """
+        INSERT INTO recurring_events (
+            recurring_uid, client_id, policy_id, event_type, name,
+            subject_template, details_template, default_severity,
+            cadence, interval_n, day_of_week, day_of_month, lead_days,
+            start_date, end_date, next_occurrence,
+            account_exec, active, catch_up_mode, notes
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
+        """,
+        (
+            uid,
+            client_id,
+            policy_id or None,
+            event_type or None,
+            name,
+            subject_template or None,
+            details_template or None,
+            default_severity or "Normal",
+            cadence,
+            max(1, int(interval_n or 1)),
+            dow,
+            dom,
+            max(0, int(lead_days or 0)),
+            start.isoformat(),
+            end.isoformat() if end else None,
+            next_occ.isoformat(),
+            account_exec or None,
+            catch_up_mode or "collapse",
+            notes or None,
+        ),
+    )
+    conn.commit()
+
+    # Run the generator so any immediately-due instance appears without a refresh
+    try:
+        generate_due_recurring_instances(conn)
+    except Exception:
+        pass
+
+    return _render_client_tab(request, conn, client_id)
+
+
+@router.post("/{recurring_id}", response_class=HTMLResponse)
+def update_template(
+    recurring_id: int,
+    request: Request,
+    name: str = Form(...),
+    cadence: str = Form(...),
+    start_date: str = Form(...),
+    policy_id: int = Form(0),
+    event_type: str = Form(""),
+    interval_n: int = Form(1),
+    day_of_week: str = Form(""),
+    day_of_month: str = Form(""),
+    lead_days: int = Form(0),
+    end_date: str = Form(""),
+    default_severity: str = Form("Normal"),
+    subject_template: str = Form(""),
+    details_template: str = Form(""),
+    account_exec: str = Form(""),
+    catch_up_mode: str = Form("collapse"),
+    notes: str = Form(""),
+    conn=Depends(get_db),
+):
+    """Update an existing template. next_occurrence is NOT rewritten so the
+    current cycle stays on its existing pointer; new cadence/DOW values take
+    effect on the next _advance() call."""
+    template = _get_template(conn, recurring_id)
+    if not template:
+        return HTMLResponse("Not found", status_code=404)
+
+    dow = _parse_int(day_of_week)
+    dom = _parse_int(day_of_month)
+    end = _parse_date(end_date)
+    start = _parse_date(start_date) or _parse_date(template.get("start_date")) or date.today()
+
+    conn.execute(
+        """
+        UPDATE recurring_events
+        SET name = ?, policy_id = ?, event_type = ?, cadence = ?, interval_n = ?,
+            day_of_week = ?, day_of_month = ?, lead_days = ?, start_date = ?,
+            end_date = ?, default_severity = ?, subject_template = ?,
+            details_template = ?, account_exec = ?, catch_up_mode = ?, notes = ?
+        WHERE id = ?
+        """,
+        (
+            name,
+            policy_id or None,
+            event_type or None,
+            cadence,
+            max(1, int(interval_n or 1)),
+            dow,
+            dom,
+            max(0, int(lead_days or 0)),
+            start.isoformat(),
+            end.isoformat() if end else None,
+            default_severity or "Normal",
+            subject_template or None,
+            details_template or None,
+            account_exec or None,
+            catch_up_mode or "collapse",
+            notes or None,
+            recurring_id,
+        ),
+    )
+    conn.commit()
+    return _render_client_tab(request, conn, template["client_id"])
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Activate / deactivate / delete / manual advance
+# ─────────────────────────────────────────────────────────────────────────
+
+@router.post("/{recurring_id}/deactivate", response_class=HTMLResponse)
+def deactivate_template(recurring_id: int, request: Request, conn=Depends(get_db)):
+    template = _get_template(conn, recurring_id)
+    if not template:
+        return HTMLResponse("Not found", status_code=404)
+    conn.execute("UPDATE recurring_events SET active = 0 WHERE id = ?", (recurring_id,))
+    conn.commit()
+    return _render_client_tab(request, conn, template["client_id"])
+
+
+@router.post("/{recurring_id}/activate", response_class=HTMLResponse)
+def activate_template(recurring_id: int, request: Request, conn=Depends(get_db)):
+    template = _get_template(conn, recurring_id)
+    if not template:
+        return HTMLResponse("Not found", status_code=404)
+    conn.execute("UPDATE recurring_events SET active = 1 WHERE id = ?", (recurring_id,))
+    conn.commit()
+    try:
+        generate_due_recurring_instances(conn)
+    except Exception:
+        pass
+    return _render_client_tab(request, conn, template["client_id"])
+
+
+@router.post("/{recurring_id}/delete", response_class=HTMLResponse)
+def delete_template(recurring_id: int, request: Request, conn=Depends(get_db)):
+    template = _get_template(conn, recurring_id)
+    if not template:
+        return HTMLResponse("Not found", status_code=404)
+    client_id = template["client_id"]
+    conn.execute("DELETE FROM recurring_events WHERE id = ?", (recurring_id,))
+    conn.commit()
+    return _render_client_tab(request, conn, client_id)
+
+
+@router.post("/{recurring_id}/advance", response_class=HTMLResponse)
+def advance_template(recurring_id: int, request: Request, conn=Depends(get_db)):
+    """Manually bump next_occurrence by one cadence step — lets the user skip
+    an upcoming occurrence that hasn't been materialized yet."""
+    from policydb.recurring_events import _advance, _parse
+    template = _get_template(conn, recurring_id)
+    if not template:
+        return HTMLResponse("Not found", status_code=404)
+    next_occ = _parse(template["next_occurrence"]) or date.today()
+    advanced = _advance(
+        next_occ,
+        template["cadence"],
+        template.get("interval_n") or 1,
+        template.get("day_of_week"),
+        template.get("day_of_month"),
+    )
+    conn.execute(
+        "UPDATE recurring_events SET next_occurrence = ? WHERE id = ?",
+        (advanced.isoformat(), recurring_id),
+    )
+    conn.commit()
+    return _render_client_tab(request, conn, template["client_id"])
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Skip a materialized instance
+# ─────────────────────────────────────────────────────────────────────────
+
+@router.post("/instance/{issue_id}/skip", response_class=HTMLResponse)
+def skip_instance(issue_id: int, request: Request, conn=Depends(get_db)):
+    """Skip a recurring issue instance: close it as Withdrawn and advance the
+    template. Thin wrapper around the standard issue resolve path."""
+    row = conn.execute(
+        "SELECT client_id, recurring_event_id FROM activity_log WHERE id = ? AND item_kind = 'issue'",
+        (issue_id,),
+    ).fetchone()
+    if not row:
+        return HTMLResponse("Not found", status_code=404)
+
+    conn.execute(
+        """
+        UPDATE activity_log
+        SET issue_status = 'Closed',
+            resolution_type = 'Withdrawn',
+            resolution_notes = COALESCE(NULLIF(resolution_notes, ''), 'Skipped — recurring event'),
+            resolved_date = ?,
+            auto_close_reason = 'recurring_skipped'
+        WHERE id = ? AND item_kind = 'issue'
+        """,
+        (date.today().isoformat(), issue_id),
+    )
+
+    try:
+        advance_template_for_completion(conn, issue_id)
+    except Exception:
+        pass
+
+    conn.commit()
+    return _render_client_tab(request, conn, row["client_id"])

--- a/src/policydb/web/routes/settings.py
+++ b/src/policydb/web/routes/settings.py
@@ -65,6 +65,8 @@ EDITABLE_LISTS: dict[str, str] = {
     "relationship_risk_levels": "Relationship Risk Levels",
     "risk_review_prompt_categories": "Risk Review Prompt Categories",
     "import_source_names": "Import Source Names",
+    "recurring_event_cadences": "Recurring Event Cadences",
+    "recurring_event_types": "Recurring Event Types",
 }
 
 # Scalar config keys for review thresholds — edited via anomaly_thresholds
@@ -79,6 +81,8 @@ TAB_LISTS: dict[str, dict[str, str]] = {
         "critical_milestones": "Critical Milestones",
         "activity_types": "Activity Types",
             "request_categories": "Request Categories",
+        "recurring_event_cadences": "Recurring Event Cadences",
+        "recurring_event_types": "Recurring Event Types",
     },
     "readiness": {},
     "carriers": {

--- a/src/policydb/web/templates/clients/_recurring_slideover.html
+++ b/src/policydb/web/templates/clients/_recurring_slideover.html
@@ -1,0 +1,190 @@
+{# Create / edit recurring event schedule — rendered inside #recurring-slideover-content #}
+{% set is_edit = template is not none %}
+{% set t = template or {} %}
+<div>
+  <div class="flex items-center justify-between mb-4">
+    <h2 class="text-base font-semibold text-gray-900">
+      {% if is_edit %}Edit Recurring Schedule{% else %}New Recurring Schedule{% endif %}
+    </h2>
+    <button type="button" onclick="closeRecurringSlideover()" class="text-gray-400 hover:text-gray-600 text-xl leading-none">&times;</button>
+  </div>
+
+  <div class="text-xs text-gray-500 mb-4">
+    Schedule a repeating touchpoint for
+    <span class="font-medium text-gray-700">{{ client.name }}</span>.
+    Each occurrence is materialized as an issue on its due date.
+  </div>
+
+  <form
+    {% if is_edit %}
+      hx-post="/recurring-events/{{ t.id }}"
+    {% else %}
+      hx-post="/recurring-events/"
+    {% endif %}
+    hx-target="#client-recurring-tab"
+    hx-swap="outerHTML"
+    onsubmit="setTimeout(closeRecurringSlideover, 100);"
+    class="space-y-4">
+
+    {% if not is_edit %}
+    <input type="hidden" name="client_id" value="{{ client.id }}">
+    {% endif %}
+
+    {# Name #}
+    <div>
+      <label class="block text-xs font-medium text-gray-600 mb-1">Name <span class="text-red-500">*</span></label>
+      <input type="text" name="name" required
+        value="{{ t.name or '' }}"
+        placeholder="e.g. Weekly open items call"
+        class="w-full rounded border-gray-300 text-sm px-3 py-1.5">
+    </div>
+
+    {# Event type + severity #}
+    <div class="grid grid-cols-2 gap-3">
+      <div>
+        <label class="block text-xs font-medium text-gray-600 mb-1">Type</label>
+        <select name="event_type" class="w-full rounded border-gray-300 text-sm px-2 py-1.5">
+          <option value="">—</option>
+          {% for opt in event_types %}
+          <option value="{{ opt }}" {% if t.event_type == opt %}selected{% endif %}>{{ opt }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-gray-600 mb-1">Severity</label>
+        <select name="default_severity" class="w-full rounded border-gray-300 text-sm px-2 py-1.5">
+          {% for sev in severities %}
+          <option value="{{ sev.label }}" {% if t.default_severity == sev.label or (not t.default_severity and sev.label == 'Normal') %}selected{% endif %}>
+            {{ sev.label }} ({{ sev.sla_days }}d SLA)
+          </option>
+          {% endfor %}
+        </select>
+      </div>
+    </div>
+
+    {# Cadence + interval #}
+    <div class="grid grid-cols-3 gap-3">
+      <div class="col-span-2">
+        <label class="block text-xs font-medium text-gray-600 mb-1">Cadence <span class="text-red-500">*</span></label>
+        <select name="cadence" required class="w-full rounded border-gray-300 text-sm px-2 py-1.5">
+          {% for c in cadences %}
+          <option value="{{ c }}" {% if t.cadence == c %}selected{% endif %}>{{ c }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-gray-600 mb-1">Every</label>
+        <input type="number" name="interval_n" min="1" max="52"
+          value="{{ t.interval_n or 1 }}"
+          class="w-full rounded border-gray-300 text-sm px-2 py-1.5">
+      </div>
+    </div>
+
+    {# Day of week / day of month (both always shown; relevant one used based on cadence) #}
+    <div class="grid grid-cols-2 gap-3">
+      <div>
+        <label class="block text-xs font-medium text-gray-600 mb-1">Day of week (Weekly/Biweekly)</label>
+        <select name="day_of_week" class="w-full rounded border-gray-300 text-sm px-2 py-1.5">
+          <option value="">Any</option>
+          {% set dows = [('0','Monday'),('1','Tuesday'),('2','Wednesday'),('3','Thursday'),('4','Friday'),('5','Saturday'),('6','Sunday')] %}
+          {% for v, label in dows %}
+          <option value="{{ v }}" {% if t.day_of_week is not none and t.day_of_week|string == v %}selected{% endif %}>{{ label }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-gray-600 mb-1">Day of month (Monthly+)</label>
+        <input type="number" name="day_of_month" min="1" max="31"
+          value="{{ t.day_of_month or '' }}"
+          placeholder="e.g. 15"
+          class="w-full rounded border-gray-300 text-sm px-3 py-1.5">
+      </div>
+    </div>
+
+    {# Start / end date #}
+    <div class="grid grid-cols-2 gap-3">
+      <div>
+        <label class="block text-xs font-medium text-gray-600 mb-1">Start date <span class="text-red-500">*</span></label>
+        <input type="date" name="start_date" required
+          value="{{ t.start_date or today_iso }}"
+          class="w-full rounded border-gray-300 text-sm px-3 py-1.5">
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-gray-600 mb-1">End date (optional)</label>
+        <input type="date" name="end_date"
+          value="{{ t.end_date or '' }}"
+          class="w-full rounded border-gray-300 text-sm px-3 py-1.5">
+      </div>
+    </div>
+
+    {# Lead days + catch-up mode #}
+    <div class="grid grid-cols-2 gap-3">
+      <div>
+        <label class="block text-xs font-medium text-gray-600 mb-1">Lead days</label>
+        <input type="number" name="lead_days" min="0" max="60"
+          value="{{ t.lead_days or 0 }}"
+          class="w-full rounded border-gray-300 text-sm px-3 py-1.5"
+          title="Materialize the issue N days before its due date">
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-gray-600 mb-1">If missed</label>
+        <select name="catch_up_mode" class="w-full rounded border-gray-300 text-sm px-2 py-1.5">
+          <option value="collapse" {% if (t.catch_up_mode or 'collapse') == 'collapse' %}selected{% endif %}>Collapse (1 catch-up)</option>
+          <option value="materialize_all" {% if t.catch_up_mode == 'materialize_all' %}selected{% endif %}>Fire every missed</option>
+        </select>
+      </div>
+    </div>
+
+    {# Optional policy scoping #}
+    <div>
+      <label class="block text-xs font-medium text-gray-600 mb-1">Link to policy (optional)</label>
+      <select name="policy_id" class="w-full rounded border-gray-300 text-sm px-2 py-1.5">
+        <option value="0">— Client-level only —</option>
+        {% for p in policies %}
+        <option value="{{ p.id }}" {% if t.policy_id == p.id %}selected{% endif %}>
+          {{ p.policy_uid }} &middot; {{ p.policy_type }}{% if p.carrier %} &middot; {{ p.carrier }}{% endif %}
+        </option>
+        {% endfor %}
+      </select>
+    </div>
+
+    {# Subject + details templates #}
+    <div>
+      <label class="block text-xs font-medium text-gray-600 mb-1">Subject template</label>
+      <input type="text" name="subject_template"
+        value="{{ t.subject_template or '' }}"
+        placeholder="Leave blank to use the name above"
+        class="w-full rounded border-gray-300 text-sm px-3 py-1.5">
+    </div>
+    <div>
+      <label class="block text-xs font-medium text-gray-600 mb-1">Details template</label>
+      <textarea name="details_template" rows="3"
+        placeholder="Optional — copied to each instance"
+        class="w-full rounded border-gray-300 text-sm px-3 py-1.5">{{ t.details_template or '' }}</textarea>
+    </div>
+
+    {# Account exec #}
+    <div>
+      <label class="block text-xs font-medium text-gray-600 mb-1">Account exec (optional)</label>
+      <input type="text" name="account_exec"
+        value="{{ t.account_exec or '' }}"
+        class="w-full rounded border-gray-300 text-sm px-3 py-1.5">
+    </div>
+
+    {# Notes #}
+    <div>
+      <label class="block text-xs font-medium text-gray-600 mb-1">Internal notes</label>
+      <textarea name="notes" rows="2" class="w-full rounded border-gray-300 text-sm px-3 py-1.5">{{ t.notes or '' }}</textarea>
+    </div>
+
+    {# Buttons #}
+    <div class="flex items-center justify-end gap-2 pt-2 border-t">
+      <button type="button" onclick="closeRecurringSlideover()"
+        class="text-xs text-gray-500 hover:text-gray-700 px-3 py-1.5">Cancel</button>
+      <button type="submit"
+        class="text-xs bg-marsh text-white px-4 py-1.5 rounded font-medium hover:bg-marsh-light transition-colors">
+        {% if is_edit %}Save changes{% else %}Create schedule{% endif %}
+      </button>
+    </div>
+  </form>
+</div>

--- a/src/policydb/web/templates/clients/_tab_recurring.html
+++ b/src/policydb/web/templates/clients/_tab_recurring.html
@@ -1,0 +1,197 @@
+{# Client Recurring Events Tab — schedule templates + upcoming/resolved instances #}
+<div id="client-recurring-tab">
+
+  {# Header #}
+  <div class="flex items-center justify-between mb-4">
+    <div class="flex items-center gap-2">
+      <h2 class="text-sm font-semibold text-gray-900">Recurring Events</h2>
+      {% set active_count = templates_rows | selectattr('active') | list | length %}
+      {% if active_count %}
+      <span class="text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded-full font-medium">{{ active_count }} active</span>
+      {% endif %}
+      {% set paused_count = templates_rows | length - active_count %}
+      {% if paused_count %}
+      <span class="text-xs bg-gray-100 text-gray-500 px-2 py-0.5 rounded-full">{{ paused_count }} paused</span>
+      {% endif %}
+    </div>
+    <button type="button"
+      hx-get="/recurring-events/new?client_id={{ client.id }}"
+      hx-target="#recurring-slideover-content"
+      hx-swap="innerHTML"
+      onclick="openRecurringSlideover()"
+      class="text-xs bg-marsh text-white px-3 py-1.5 rounded font-medium hover:bg-marsh-light transition-colors no-print">+ New Recurring Event</button>
+  </div>
+
+  {# ── Templates list ── #}
+  {% if templates_rows %}
+  <div class="space-y-2 mb-6">
+    {% for t in templates_rows %}
+    <div class="card px-4 py-3 flex items-center gap-3 {% if not t.active %}opacity-60 bg-gray-50{% endif %}">
+      {# Cadence badge #}
+      <div class="flex-shrink-0 flex flex-col items-center justify-center w-14 text-center">
+        <div class="text-[10px] uppercase text-gray-400 font-semibold">{{ t.cadence }}</div>
+        {% if t.interval_n and t.interval_n > 1 %}
+        <div class="text-[10px] text-gray-400">&times;{{ t.interval_n }}</div>
+        {% endif %}
+      </div>
+
+      {# Name + details #}
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center gap-2">
+          <span class="text-sm font-medium text-gray-900 truncate">{{ t.name }}</span>
+          <button type="button" onclick="copyRefTag(this,'{{ t.recurring_uid }}')"
+            class="inline-flex items-center text-[10px] font-mono text-gray-400 hover:text-marsh bg-gray-50 border border-gray-200 hover:border-marsh/40 rounded-full px-1.5 py-0.5 cursor-pointer transition-colors whitespace-nowrap no-print flex-shrink-0"
+            title="Click to copy recurring event ref tag">{{ t.recurring_uid }}</button>
+          {% if not t.active %}
+          <span class="text-[10px] text-gray-400 italic">Paused</span>
+          {% endif %}
+        </div>
+        <div class="flex items-center gap-2 text-xs text-gray-500 mt-0.5 flex-wrap">
+          {% if t.event_type %}<span class="text-gray-600">{{ t.event_type }}</span><span class="text-gray-300">&middot;</span>{% endif %}
+          <span>Next: <span class="font-medium text-gray-700">{{ t.next_occurrence }}</span></span>
+          {% if t.lead_days %}
+          <span class="text-gray-300">&middot;</span>
+          <span>Lead {{ t.lead_days }}d</span>
+          {% endif %}
+          <span class="text-gray-300">&middot;</span>
+          <span>{{ t.default_severity }}</span>
+          {% if t.policy_uid %}
+          <span class="text-gray-300">&middot;</span>
+          <a href="/policies/{{ t.policy_uid }}/edit" class="text-marsh hover:underline">{{ t.policy_uid }}{% if t.policy_type %} {{ t.policy_type }}{% endif %}</a>
+          {% endif %}
+          {% if t.open_instance_count and t.open_instance_count > 0 %}
+          <span class="text-gray-300">&middot;</span>
+          <span class="text-blue-600 font-medium">{{ t.open_instance_count }} open</span>
+          {% endif %}
+        </div>
+      </div>
+
+      {# Actions #}
+      <div class="flex items-center gap-1 flex-shrink-0 no-print">
+        <button type="button"
+          hx-get="/recurring-events/{{ t.id }}/edit"
+          hx-target="#recurring-slideover-content"
+          hx-swap="innerHTML"
+          onclick="openRecurringSlideover()"
+          class="text-xs text-gray-400 hover:text-marsh transition-colors px-1.5"
+          title="Edit schedule">&#9998;</button>
+        <button type="button"
+          hx-post="/recurring-events/{{ t.id }}/{{ 'deactivate' if t.active else 'activate' }}"
+          hx-target="#client-recurring-tab"
+          hx-swap="outerHTML"
+          class="text-xs text-gray-400 hover:text-marsh transition-colors px-1.5"
+          title="{{ 'Pause schedule' if t.active else 'Resume schedule' }}">
+          {% if t.active %}&#10073;&#10073;{% else %}&#9654;{% endif %}
+        </button>
+        <button type="button"
+          hx-post="/recurring-events/{{ t.id }}/delete"
+          hx-target="#client-recurring-tab"
+          hx-swap="outerHTML"
+          hx-confirm="Delete this recurring schedule? Existing open instances will remain."
+          class="text-xs text-gray-400 hover:text-red-600 transition-colors px-1.5"
+          title="Delete schedule">&times;</button>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+  {% else %}
+  <div class="text-center py-8 mb-6 border border-dashed border-gray-200 rounded">
+    <div class="text-gray-300 text-3xl mb-2">&#8634;</div>
+    <p class="text-sm text-gray-400">No recurring schedules yet.</p>
+    <p class="text-xs text-gray-400 mt-1">Add a weekly call, monthly report, quarterly stewardship, etc.</p>
+  </div>
+  {% endif %}
+
+  {# ── Upcoming instances ── #}
+  {% if upcoming %}
+  <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Upcoming</h3>
+  <div class="space-y-1.5 mb-6">
+    {% for u in upcoming %}
+    {% set sev = u.issue_severity or 'Normal' %}
+    <div class="card px-3 py-2 flex items-center gap-3 hover:bg-gray-50 transition-colors">
+      <span class="w-2 h-2 rounded-full flex-shrink-0
+        {% if sev == 'Critical' %}bg-red-500
+        {% elif sev == 'High' %}bg-amber-500
+        {% elif sev == 'Normal' %}bg-blue-500
+        {% else %}bg-gray-400{% endif %}"
+        title="{{ sev }}"></span>
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center gap-2">
+          <a href="/issues/{{ u.issue_uid }}" class="text-sm text-gray-900 hover:text-marsh hover:underline truncate">{{ u.subject }}</a>
+          <span class="text-[10px] font-mono text-gray-400">{{ u.issue_uid }}</span>
+        </div>
+        <div class="text-xs text-gray-500 mt-0.5">
+          <span>Due <span class="font-medium">{{ u.due_date }}</span></span>
+          {% if u.days_until_due is not none %}
+          <span class="text-gray-300">&middot;</span>
+          <span class="{% if u.days_until_due < 0 %}text-red-600 font-medium{% elif u.days_until_due <= 2 %}text-amber-600{% endif %}">
+            {% if u.days_until_due < 0 %}{{ (0 - u.days_until_due) }}d overdue
+            {% elif u.days_until_due == 0 %}today
+            {% else %}in {{ u.days_until_due }}d{% endif %}
+          </span>
+          {% endif %}
+          <span class="text-gray-300">&middot;</span>
+          <span class="text-gray-400">{{ u.template_name }}</span>
+        </div>
+      </div>
+      <button type="button"
+        hx-post="/recurring-events/instance/{{ u.id }}/skip"
+        hx-target="#client-recurring-tab"
+        hx-swap="outerHTML"
+        hx-confirm="Skip this occurrence? It will be closed as Withdrawn and the next one will be scheduled."
+        class="text-xs text-gray-400 hover:text-amber-600 transition-colors no-print flex-shrink-0"
+        title="Skip this occurrence">Skip</button>
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  {# ── Recently resolved history ── #}
+  {% if recent_resolved %}
+  <details class="mb-4">
+    <summary class="text-xs font-semibold text-gray-500 uppercase tracking-wide cursor-pointer hover:text-gray-700 mb-2">
+      History ({{ recent_resolved | length }} resolved, last 60 days)
+    </summary>
+    <div class="space-y-1">
+      {% for r in recent_resolved %}
+      <div class="px-3 py-1.5 flex items-center gap-3 text-xs text-gray-500">
+        <span class="w-1.5 h-1.5 rounded-full bg-gray-300 flex-shrink-0"></span>
+        <a href="/issues/{{ r.issue_uid }}" class="truncate hover:text-marsh hover:underline">{{ r.subject }}</a>
+        {% if r.resolution_type %}
+        <span class="text-gray-300">&middot;</span>
+        <span>{{ r.resolution_type }}</span>
+        {% endif %}
+        {% if r.resolved_date %}
+        <span class="text-gray-300">&middot;</span>
+        <span>{{ r.resolved_date }}</span>
+        {% endif %}
+        <span class="text-gray-300">&middot;</span>
+        <span class="text-gray-400">{{ r.template_name }}</span>
+      </div>
+      {% endfor %}
+    </div>
+  </details>
+  {% endif %}
+
+</div>
+
+{# Slideover container — shared across open/edit #}
+<div id="recurring-slideover"
+     class="fixed inset-0 z-50 hidden"
+     onclick="if(event.target===this) closeRecurringSlideover()">
+  <div class="absolute inset-0 bg-black/30"></div>
+  <div class="absolute right-0 top-0 h-full w-full max-w-lg bg-white shadow-xl overflow-y-auto">
+    <div id="recurring-slideover-content" class="p-5"></div>
+  </div>
+</div>
+
+<script>
+function openRecurringSlideover() {
+  var el = document.getElementById('recurring-slideover');
+  if (el) el.classList.remove('hidden');
+}
+function closeRecurringSlideover() {
+  var el = document.getElementById('recurring-slideover');
+  if (el) el.classList.add('hidden');
+}
+</script>

--- a/src/policydb/web/templates/clients/detail.html
+++ b/src/policydb/web/templates/clients/detail.html
@@ -83,6 +83,11 @@
           Issues
           {% if open_issues %}<span class="tab-badge" style="background:#3b82f6;color:white">{{ open_issues | length }}</span>{% endif %}
         </button>
+        <button class="tab-btn" data-tab="recurring"
+          data-tab-url="/clients/{{ client.id }}/tab/recurring">
+          Recurring
+          {% if recurring_count %}<span class="tab-badge">{{ recurring_count }}</span>{% endif %}
+        </button>
         <button class="tab-btn" data-tab="files"
           data-tab-url="/clients/{{ client.id }}/tab/files">
           Files

--- a/tests/test_recurring_events.py
+++ b/tests/test_recurring_events.py
@@ -1,0 +1,309 @@
+"""Tests for the recurring events generator."""
+
+from datetime import date, timedelta
+
+import pytest
+
+import policydb.config as cfg
+from policydb.db import get_connection, init_db
+from policydb.recurring_events import (
+    _advance,
+    advance_template_for_completion,
+    compute_initial_next_occurrence,
+    generate_due_recurring_instances,
+    next_recurring_uid,
+)
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.sqlite"
+    config_path = tmp_path / "config.yaml"
+    monkeypatch.setattr("policydb.db.DB_PATH", db_path)
+    monkeypatch.setattr("policydb.db.DB_DIR", tmp_path)
+    monkeypatch.setattr("policydb.db.EXPORTS_DIR", tmp_path / "exports")
+    monkeypatch.setattr("policydb.db.CONFIG_PATH", config_path)
+    monkeypatch.setattr("policydb.config.CONFIG_PATH", config_path)
+    cfg.reload_config()
+    init_db(path=db_path)
+    return db_path
+
+
+def _make_client(conn, name="Test Client"):
+    conn.execute(
+        "INSERT INTO clients (name, industry_segment, account_exec) VALUES (?, 'Other', 'Tester')",
+        (name,),
+    )
+    conn.commit()
+    return conn.execute("SELECT id FROM clients WHERE name = ?", (name,)).fetchone()["id"]
+
+
+def _make_template(conn, client_id, **overrides):
+    defaults = dict(
+        recurring_uid="REC-001",
+        client_id=client_id,
+        name="Weekly open items call",
+        cadence="Weekly",
+        interval_n=1,
+        day_of_week=None,
+        day_of_month=None,
+        lead_days=0,
+        start_date=date.today().isoformat(),
+        end_date=None,
+        next_occurrence=date.today().isoformat(),
+        default_severity="Normal",
+        active=1,
+        catch_up_mode="collapse",
+    )
+    defaults.update(overrides)
+    cols = ", ".join(defaults.keys())
+    placeholders = ", ".join("?" * len(defaults))
+    conn.execute(
+        f"INSERT INTO recurring_events ({cols}) VALUES ({placeholders})",
+        tuple(defaults.values()),
+    )
+    conn.commit()
+    return conn.execute(
+        "SELECT id FROM recurring_events WHERE recurring_uid = ?",
+        (defaults["recurring_uid"],),
+    ).fetchone()["id"]
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Schema checks
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_recurring_events_table_exists(tmp_db):
+    conn = get_connection(tmp_db)
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='recurring_events'"
+    ).fetchone()
+    assert row is not None
+
+
+def test_activity_log_has_recurring_columns(tmp_db):
+    conn = get_connection(tmp_db)
+    cols = {r["name"] for r in conn.execute("PRAGMA table_info(activity_log)").fetchall()}
+    assert "recurring_event_id" in cols
+    assert "recurring_instance_date" in cols
+
+
+def test_uid_sequence_seeded(tmp_db):
+    conn = get_connection(tmp_db)
+    row = conn.execute("SELECT next_val FROM uid_sequence WHERE prefix = 'REC'").fetchone()
+    assert row is not None
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _advance() date arithmetic
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_advance_weekly():
+    anchor = date(2026, 4, 13)  # Monday
+    assert _advance(anchor, "Weekly", 1, None, None) == date(2026, 4, 20)
+
+
+def test_advance_biweekly_snaps_dow():
+    anchor = date(2026, 4, 13)  # Monday
+    # Biweekly with day_of_week=2 (Wednesday) → 2 weeks later, snapped to Wed
+    result = _advance(anchor, "Biweekly", 1, 2, None)
+    assert result.weekday() == 2
+
+
+def test_advance_monthly_clamps_month_end():
+    # Jan 31 → Feb 28 (or 29 in leap year)
+    anchor = date(2026, 1, 31)
+    result = _advance(anchor, "Monthly", 1, None, 31)
+    assert result == date(2026, 2, 28)
+
+
+def test_advance_quarterly():
+    anchor = date(2026, 1, 15)
+    result = _advance(anchor, "Quarterly", 1, None, 15)
+    assert result == date(2026, 4, 15)
+
+
+def test_advance_annual():
+    anchor = date(2026, 4, 13)
+    result = _advance(anchor, "Annual", 1, None, None)
+    assert result == date(2027, 4, 13)
+
+
+def test_advance_daily():
+    anchor = date(2026, 4, 13)
+    assert _advance(anchor, "Daily", 3, None, None) == date(2026, 4, 16)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Generator behavior
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_generator_materializes_instances(tmp_db):
+    """Weekly cadence + 14-day horizon → expect 2–3 issue rows (today, +7, +14)."""
+    conn = get_connection(tmp_db)
+    client_id = _make_client(conn)
+    tmpl_id = _make_template(conn, client_id)
+
+    inserted = generate_due_recurring_instances(conn)
+    assert inserted >= 1
+    assert inserted <= 3  # bounded by horizon
+
+    rows = conn.execute(
+        "SELECT * FROM activity_log WHERE recurring_event_id = ? ORDER BY recurring_instance_date",
+        (tmpl_id,),
+    ).fetchall()
+    assert len(rows) == inserted
+
+    row = dict(rows[0])
+    assert row["item_kind"] == "issue"
+    assert row["issue_status"] == "Open"
+    assert row["issue_severity"] == "Normal"
+    assert row["issue_uid"] is not None
+    assert row["recurring_instance_date"] is not None
+    assert row["activity_type"] == "Issue"
+
+
+def test_generator_is_idempotent(tmp_db):
+    conn = get_connection(tmp_db)
+    client_id = _make_client(conn)
+    _make_template(conn, client_id)
+
+    generate_due_recurring_instances(conn)
+    # Second call with no change in time: no new rows
+    second_pass = generate_due_recurring_instances(conn)
+    total = conn.execute(
+        "SELECT COUNT(*) AS n FROM activity_log WHERE recurring_event_id IS NOT NULL"
+    ).fetchone()["n"]
+    assert second_pass == 0
+    # Total should still be 1 from the first pass (within horizon)
+    assert total >= 1
+
+
+def test_generator_advances_next_occurrence(tmp_db):
+    conn = get_connection(tmp_db)
+    client_id = _make_client(conn)
+    tmpl_id = _make_template(conn, client_id)
+
+    before = conn.execute(
+        "SELECT next_occurrence FROM recurring_events WHERE id = ?", (tmpl_id,)
+    ).fetchone()["next_occurrence"]
+    generate_due_recurring_instances(conn)
+    after = conn.execute(
+        "SELECT next_occurrence FROM recurring_events WHERE id = ?", (tmpl_id,)
+    ).fetchone()["next_occurrence"]
+
+    assert after > before
+
+
+def test_generator_skips_inactive_templates(tmp_db):
+    conn = get_connection(tmp_db)
+    client_id = _make_client(conn)
+    _make_template(conn, client_id, active=0)
+
+    inserted = generate_due_recurring_instances(conn)
+    assert inserted == 0
+
+
+def test_generator_skips_past_end_date(tmp_db):
+    conn = get_connection(tmp_db)
+    client_id = _make_client(conn)
+    yesterday = (date.today() - timedelta(days=1)).isoformat()
+    _make_template(conn, client_id, end_date=yesterday)
+
+    inserted = generate_due_recurring_instances(conn)
+    assert inserted == 0
+
+
+def test_generator_catch_up_collapse(tmp_db):
+    """A template with next_occurrence 30 days in the past (collapse mode)
+    should only emit ONE catch-up instance, not 4+ weekly rows."""
+    conn = get_connection(tmp_db)
+    client_id = _make_client(conn)
+    thirty_ago = (date.today() - timedelta(days=30)).isoformat()
+    _make_template(conn, client_id, next_occurrence=thirty_ago, catch_up_mode="collapse")
+
+    inserted = generate_due_recurring_instances(conn)
+    # Collapse mode: exactly one catch-up + whatever falls inside the forward horizon
+    # (14 days). Since the collapsed anchor is <= today, then advance steps forward.
+    # We primarily care that it's bounded — not dozens of rows.
+    assert inserted >= 1
+    assert inserted <= 4  # collapsed + a few weeks forward within horizon
+
+
+def test_generator_respects_client_archived(tmp_db):
+    conn = get_connection(tmp_db)
+    client_id = _make_client(conn)
+    _make_template(conn, client_id)
+    conn.execute("UPDATE clients SET archived = 1 WHERE id = ?", (client_id,))
+    conn.commit()
+
+    inserted = generate_due_recurring_instances(conn)
+    assert inserted == 0
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Completion hook
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_advance_on_completion_creates_next(tmp_db):
+    conn = get_connection(tmp_db)
+    client_id = _make_client(conn)
+    tmpl_id = _make_template(conn, client_id)
+    generate_due_recurring_instances(conn)
+
+    # Pretend the user resolved the instance
+    row = conn.execute(
+        "SELECT id FROM activity_log WHERE recurring_event_id = ? ORDER BY id DESC LIMIT 1",
+        (tmpl_id,),
+    ).fetchone()
+    conn.execute(
+        "UPDATE activity_log SET issue_status='Resolved', resolved_date=? WHERE id=?",
+        (date.today().isoformat(), row["id"]),
+    )
+    conn.commit()
+
+    before_count = conn.execute(
+        "SELECT COUNT(*) AS n FROM activity_log WHERE recurring_event_id = ?", (tmpl_id,)
+    ).fetchone()["n"]
+
+    advance_template_for_completion(conn, row["id"])
+
+    after_count = conn.execute(
+        "SELECT COUNT(*) AS n FROM activity_log WHERE recurring_event_id = ?", (tmpl_id,)
+    ).fetchone()["n"]
+
+    # The generator may or may not have emitted a new row depending on whether
+    # next_occurrence is within the horizon. We just verify the call is safe.
+    assert after_count >= before_count
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# UID issuance
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_next_recurring_uid_increments(tmp_db):
+    conn = get_connection(tmp_db)
+    uid1 = next_recurring_uid(conn)
+    uid2 = next_recurring_uid(conn)
+    assert uid1 != uid2
+    assert uid1.startswith("REC-")
+    assert uid2.startswith("REC-")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Initial next_occurrence computation
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_compute_initial_weekly_snaps_forward():
+    start = date(2026, 4, 13)  # Monday
+    # Weekly, day_of_week=3 (Thursday) → snap to Apr 16
+    result = compute_initial_next_occurrence(start, "Weekly", 3, None)
+    assert result.weekday() == 3
+    assert result >= start
+
+
+def test_compute_initial_monthly_clamps():
+    start = date(2026, 2, 10)
+    # Monthly, day_of_month=31 → Feb 28 (2026 is not a leap year)
+    result = compute_initial_next_occurrence(start, "Monthly", None, 31)
+    assert result == date(2026, 2, 28)


### PR DESCRIPTION
## Summary
Implements a complete recurring events system that allows users to schedule repeating touchpoints (weekly calls, monthly reports, quarterly reviews, etc.) for clients. Each active template automatically materializes pending occurrences as issue rows in the activity log, inheriting the full issue lifecycle including severity, SLA, and resolution tracking.

## Key Changes

### Core Recurring Events Module (`src/policydb/recurring_events.py`)
- **Generator function** (`generate_due_recurring_instances`): Materializes pending occurrences as activity_log issue rows within a configurable horizon (default 14 days)
- **Date arithmetic** (`_advance`): Implements cadence stepping for Daily, Weekly, Biweekly, Monthly, Quarterly, Semi-Annual, and Annual schedules with support for day-of-week and day-of-month snapping
- **Catch-up handling**: Supports "collapse" mode to emit only one catch-up instance when a template falls behind, preventing backlog explosions
- **Completion hook** (`advance_template_for_completion`): Automatically advances template pointer and generates next occurrence when user resolves an instance
- **UID generation** (`next_recurring_uid`): Atomic sequence-based generation of REC-NNN identifiers

### Web Routes (`src/policydb/web/routes/recurring_events.py`)
- **CRUD endpoints**: Create, read, update, delete, activate, and deactivate recurring event templates
- **Slideover forms**: Modal UI for creating and editing schedules with full cadence/interval/date configuration
- **Manual advance**: Endpoint to skip an occurrence or manually trigger generation
- **Client tab integration**: Renders templates and upcoming/resolved instances within the client detail page

### Database Schema (`src/policydb/migrations/144_recurring_events.sql`)
- **recurring_events table**: Stores templates with cadence rules, date ranges, content templates, and severity defaults
- **activity_log extensions**: Added `recurring_event_id` and `recurring_instance_date` columns to link instances back to templates
- **uid_sequence support**: Atomic sequence table for REC-NNN UID generation

### UI Templates
- **`_tab_recurring.html`**: Client Recurring tab showing active/paused templates, upcoming instances, and resolved history
- **`_recurring_slideover.html`**: Form for creating/editing schedules with cadence, interval, day-of-week/month, lead days, and catch-up mode configuration

### Integration Points
- **Issue resolution flow**: Hooks into `/issues/{id}/resolve` to advance template and generate next occurrence
- **Focus Queue**: Recurring instances appear as regular issues with proper severity/SLA
- **Client detail page**: New "Recurring" tab alongside Issues, Activities, and Policies
- **Settings**: Configuration UI for cadence labels, event types, and generation parameters

## Notable Implementation Details

- **Idempotent generation**: Safe to call repeatedly on the same day; uses (template_id, instance_date) uniqueness to prevent duplicates
- **Lead days support**: Issues can be materialized N days before their due date for advance preparation
- **Configurable horizon**: Generation looks ahead 14 days by default; configurable via `recurring_event_generation_horizon_days`
- **Catch-up bounds**: Max 12 catch-up instances per template to prevent runaway generation
- **Template preservation**: Updating a template does not rewrite `next_occurrence`, allowing current cycle to complete before new rules take effect
- **Client/policy scoping**: Templates are client-specific; policy linkage is optional for cross-policy schedules

https://claude.ai/code/session_01VpgQ2E91eSvq9JF3WDNUiq