### PR TITLE
Bug sweep: fix briefing enrichment ID collision, timeline projection cascade, silent failures

### DIFF
--- a/src/policydb/timeline_engine.py
+++ b/src/policydb/timeline_engine.py
@@ -314,9 +314,12 @@ def recalculate_downstream(
         original_gap = (curr_ideal - prev_ideal).days if (curr_ideal and prev_ideal) else minimum_gap_days
         new_gap = max(original_gap, minimum_gap_days)
 
-        prev_projected = _parse_date(rows[i - 1]["projected_date"])
+        # Anchor off prev_projected; if the previous row has an unparseable
+        # projected_date, fall back to prev_ideal so downstream milestones
+        # still shift instead of silently cascading skips.
+        prev_projected = _parse_date(rows[i - 1]["projected_date"]) or prev_ideal
         if not prev_projected:
-            continue  # Skip if previous projected date is unparseable
+            continue  # No ideal either — nothing we can anchor to
         new_proj = prev_projected + timedelta(days=new_gap)
 
         # Clamp to expiration_date

--- a/src/policydb/utils.py
+++ b/src/policydb/utils.py
@@ -804,8 +804,8 @@ def clean_email(raw: str) -> str:
     # Final sanity: only return if it looks like an email
     if "@" in s and "." in s.split("@")[-1]:
         return s.lower()
-    # Fallback: return cleaned string as-is
-    return s.strip().lower() if s.strip() else raw
+    # Fallback: normalize the cleaned string (never leak original casing/whitespace)
+    return s.strip().lower()
 
 
 def format_phone(raw: str, default_region: str = "US") -> str:

--- a/src/policydb/web/routes/briefing.py
+++ b/src/policydb/web/routes/briefing.py
@@ -28,38 +28,58 @@ router = APIRouter()
 
 
 def _enrich_action_queue(conn, action_queue: list[dict]):
-    """Attach carrier, renewal_status, readiness, last activity, and contact info to action queue items."""
+    """Attach carrier, renewal_status, readiness, last activity, and contact info to action queue items.
+
+    Action queue items come from heterogeneous sources — escalation alerts carry
+    policies.id as ``item["id"]``, but follow-up rows from activity_log/projects
+    carry their own activity_log.id. Enrichment must key on ``policy_uid`` so
+    activity IDs don't collide with the policy ID space.
+    """
     today = date.today()
 
-    # Collect policy IDs for batch queries
-    policy_ids = [item["id"] for item in action_queue if item.get("id")]
+    # Collect policy UIDs for batch queries — only policy-scoped rows have a uid.
     policy_uids = [item["policy_uid"] for item in action_queue if item.get("policy_uid")]
 
-    # Batch-fetch last activity per policy
+    # Batch-fetch last activity per policy (keyed by policy_uid)
     last_activity_map: dict = {}
-    if policy_ids:
-        ph = ",".join("?" * len(policy_ids))
+    if policy_uids:
+        ph = ",".join("?" * len(policy_uids))
         rows = conn.execute(
-            f"SELECT policy_id, MAX(activity_date) AS last_date, "  # noqa: S608
-            f"(SELECT activity_type FROM activity_log a2 WHERE a2.policy_id = a1.policy_id ORDER BY activity_date DESC, id DESC LIMIT 1) AS last_type "
-            f"FROM activity_log a1 WHERE policy_id IN ({ph}) GROUP BY policy_id",
-            policy_ids,
+            f"""SELECT p.policy_uid,
+                       MAX(a.activity_date) AS last_date,
+                       (SELECT a2.activity_type FROM activity_log a2
+                        WHERE a2.policy_id = p.id
+                        ORDER BY a2.activity_date DESC, a2.id DESC LIMIT 1) AS last_type
+                FROM policies p
+                LEFT JOIN activity_log a ON a.policy_id = p.id
+                WHERE p.policy_uid IN ({ph})
+                GROUP BY p.policy_uid""",  # noqa: S608
+            policy_uids,
         ).fetchall()
-        last_activity_map = {r["policy_id"]: {"date": r["last_date"], "type": r["last_type"]} for r in rows}
+        last_activity_map = {
+            r["policy_uid"]: {"date": r["last_date"], "type": r["last_type"]} for r in rows
+        }
 
-    # Batch-fetch contact info (primary contact email) per policy
+    # Batch-fetch contact info (primary contact email) per policy (keyed by policy_uid)
     contact_map: dict = {}
-    if policy_ids:
-        ph = ",".join("?" * len(policy_ids))
+    if policy_uids:
+        ph = ",".join("?" * len(policy_uids))
         rows = conn.execute(
-            f"SELECT p.id AS policy_id, co.name AS contact_name, co.email AS contact_email "  # noqa: S608
-            f"FROM policies p "
-            f"JOIN contact_client_assignments cca ON cca.client_id = p.client_id AND cca.contact_type = 'client' AND cca.is_primary = 1 "
-            f"JOIN contacts co ON cca.contact_id = co.id "
-            f"WHERE p.id IN ({ph})",
-            policy_ids,
+            f"""SELECT p.policy_uid,
+                       co.name AS contact_name,
+                       co.email AS contact_email
+                FROM policies p
+                JOIN contact_client_assignments cca
+                  ON cca.client_id = p.client_id
+                 AND cca.contact_type = 'client'
+                 AND cca.is_primary = 1
+                JOIN contacts co ON cca.contact_id = co.id
+                WHERE p.policy_uid IN ({ph})""",  # noqa: S608
+            policy_uids,
         ).fetchall()
-        contact_map = {r["policy_id"]: {"name": r["contact_name"], "email": r["contact_email"]} for r in rows}
+        contact_map = {
+            r["policy_uid"]: {"name": r["contact_name"], "email": r["contact_email"]} for r in rows
+        }
 
     # Attach readiness scores to items with policy context
     policy_items = [item for item in action_queue if item.get("policy_uid") and item.get("days_to_renewal") is not None]
@@ -69,9 +89,9 @@ def _enrich_action_queue(conn, action_queue: list[dict]):
         _attach_readiness_score(conn, policy_items)
 
     for item in action_queue:
-        pid = item.get("id")
+        puid = item.get("policy_uid")
         # Last activity
-        la = last_activity_map.get(pid, {})
+        la = last_activity_map.get(puid, {}) if puid else {}
         item["last_activity_date"] = la.get("date")
         item["last_activity_type"] = la.get("type")
         if la.get("date"):
@@ -81,7 +101,7 @@ def _enrich_action_queue(conn, action_queue: list[dict]):
                 item["last_activity_days_ago"] = None
 
         # Contact info
-        ci = contact_map.get(pid, {})
+        ci = contact_map.get(puid, {}) if puid else {}
         if not item.get("contact_person"):
             item["contact_person"] = ci.get("name")
         if not item.get("contact_email"):

--- a/src/policydb/web/routes/recurring_events.py
+++ b/src/policydb/web/routes/recurring_events.py
@@ -7,6 +7,7 @@ UI lives under the Recurring tab on the client detail page.
 
 from __future__ import annotations
 
+import logging
 from datetime import date, datetime
 from typing import Optional
 
@@ -21,6 +22,8 @@ from policydb.recurring_events import (
     next_recurring_uid,
 )
 from policydb.web.app import get_db, templates
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/recurring-events")
 
@@ -192,7 +195,7 @@ def create_template(
     try:
         generate_due_recurring_instances(conn)
     except Exception:
-        pass
+        logger.exception("generate_due_recurring_instances failed after create_template")
 
     return _render_client_tab(request, conn, client_id)
 
@@ -288,7 +291,7 @@ def activate_template(recurring_id: int, request: Request, conn=Depends(get_db))
     try:
         generate_due_recurring_instances(conn)
     except Exception:
-        pass
+        logger.exception("generate_due_recurring_instances failed after activate_template")
     return _render_client_tab(request, conn, template["client_id"])
 
 
@@ -358,7 +361,7 @@ def skip_instance(issue_id: int, request: Request, conn=Depends(get_db)):
     try:
         advance_template_for_completion(conn, issue_id)
     except Exception:
-        pass
+        logger.exception("advance_template_for_completion failed for issue_id=%s", issue_id)
 
     conn.commit()
     return _render_client_tab(request, conn, row["client_id"])


### PR DESCRIPTION
Fix four bugs surfaced during a sweep of recently-added code:

**Briefing action queue — wrong ID used for enrichment lookups**
`_enrich_action_queue` collected `item["id"]` as a "policy id", but the
action queue is a heterogeneous merge: escalation rows carry policies.id
while follow-up rows from get_all_followups carry activity_log.id. That
meant last-activity and contact-info enrichment either missed entirely
or (when activity_id happened to collide with a real policy_id) joined
to the wrong policy. The briefing template reads these fields directly
("Last: ... Nd ago"), so the wrong data was user-visible. Re-key the
batch queries on `policy_uid` so only actual policy-scoped rows are
looked up and each row can only match itself.

**Timeline projection cascade skip**
In `_propagate_projected_date_change`, if a previous row's
`projected_date` was unparseable the loop called `continue`, which
caused the next iteration to read the same unchanged row — cascading
into every downstream milestone being skipped. Fall back to
`prev_ideal` so propagation still advances when the stored projected
date is missing/corrupt.

**Recurring events routes — silent `except Exception: pass`**
Three routes (create, activate, skip instance) called the generator
and swallowed any exception with a bare `pass`. A buggy generator run
would therefore leave no trace in logs, making debugging impossible.
Switch to `logger.exception` with context about which route triggered
the failure.

**utils.clean_email fallback leaked raw casing**
When the email regex failed and stripping quotes produced an empty
string, the function returned the original `raw` input — leaking
uppercase and surrounding whitespace that the rest of the system
assumes has been normalized. Always return the lowercased cleaned
string.

https://claude.ai/code/session_016SrGuddWKHbeppGDkkMxBk