### PR TITLE
Fix RFI bundle page stub render and Issue Create slideover client name

### DIFF
--- a/src/policydb/web/routes/clients.py
+++ b/src/policydb/web/routes/clients.py
@@ -5115,7 +5115,32 @@ def request_export_all(client_id: int, conn=Depends(get_db)):
 def get_request_bundle(
     request: Request, client_id: int, bundle_id: int, conn=Depends(get_db)
 ):
-    return _bundle_response(request, conn, client_id, bundle_id)
+    if request.headers.get("HX-Request"):
+        return _bundle_response(request, conn, client_id, bundle_id)
+    bundle = conn.execute(
+        "SELECT * FROM client_request_bundles WHERE id=? AND client_id=?",
+        (bundle_id, client_id),
+    ).fetchone()
+    if not bundle:
+        return HTMLResponse("Bundle not found", status_code=404)
+    items = _enrich_request_items(conn, [dict(r) for r in conn.execute(
+        "SELECT * FROM client_request_items WHERE bundle_id=? ORDER BY received ASC, sort_order ASC, id ASC",
+        (bundle_id,),
+    ).fetchall()])
+    client = conn.execute("SELECT id, name FROM clients WHERE id=?", (client_id,)).fetchone()
+    policies = [dict(r) for r in conn.execute(
+        "SELECT policy_uid, policy_type, carrier, project_name, effective_date FROM policies WHERE client_id=? AND archived=0 ORDER BY policy_type, effective_date DESC",
+        (client_id,),
+    ).fetchall()]
+    return templates.TemplateResponse("clients/request_bundle_page.html", {
+        "request": request,
+        "active": "clients",
+        "client": dict(client) if client else {"id": client_id, "name": ""},
+        "bundle": dict(bundle),
+        "items": items,
+        "policies": policies,
+        "request_categories": cfg.get("request_categories", []),
+    })
 
 
 @router.post("/{client_id}/requests/{bundle_id}/items", response_class=HTMLResponse)

--- a/src/policydb/web/templates/_issue_create_slideover.html
+++ b/src/policydb/web/templates/_issue_create_slideover.html
@@ -376,8 +376,19 @@
     });
   };
 
-  // Wire up client autocomplete for the editable (non-locked) case
-  initClientAutocomplete('issue-create-client-search', 'issue-create-client-select');
+  // Wire up client autocomplete for the editable (non-locked) case.
+  // initClientAutocomplete is defined in base.html's footer script block, which
+  // renders AFTER this include, so wait for the DOM to finish parsing.
+  function _wireIssueCreateClientAutocomplete() {
+    if (typeof initClientAutocomplete === 'function') {
+      initClientAutocomplete('issue-create-client-search', 'issue-create-client-select');
+    }
+  }
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', _wireIssueCreateClientAutocomplete);
+  } else {
+    _wireIssueCreateClientAutocomplete();
+  }
 
 })();
 </script>

--- a/src/policydb/web/templates/clients/request_bundle_page.html
+++ b/src/policydb/web/templates/clients/request_bundle_page.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{% block title %}{{ bundle.rfi_uid or bundle.title or 'RFI' }} — {{ client.name }}{% endblock %}
+
+{% block content %}
+<div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+
+  {# ── Breadcrumb ── #}
+  <div class="flex items-center gap-2 text-xs text-gray-500 mb-2">
+    <a href="/clients/{{ client.id }}" class="hover:text-marsh">&larr; {{ client.name }}</a>
+    <span class="text-gray-300">|</span>
+    <a href="/clients/{{ client.id }}?tab=requests" class="hover:text-marsh">Information Requests</a>
+    <span class="text-gray-300">|</span>
+    <span class="text-gray-700">{{ bundle.rfi_uid or ('Bundle #' ~ bundle.id) }}</span>
+  </div>
+
+  <h1 class="font-serif text-2xl text-gray-900 mb-4">{{ bundle.title or 'Information Request' }}</h1>
+
+  <div class="card">
+    {% include "clients/_request_bundle.html" %}
+  </div>
+
+</div>
+{% endblock %}

--- a/src/policydb/web/templates/policies/_tab_pulse.html
+++ b/src/policydb/web/templates/policies/_tab_pulse.html
@@ -61,7 +61,7 @@
   <div class="flex items-center justify-between mb-2">
     <span class="text-xs font-semibold text-gray-700">Issues ({{ open_issues|length }} open)</span>
     <button type="button"
-            onclick="openIssueCreateSlideover({client_id: {{ policy.client_id }}, policy_id: {{ policy.id }}})"
+            onclick="openIssueCreateSlideover({client_id:'{{ policy.client_id }}', client_name:'{{ client.name|e }}', policy_id:'{{ policy.id }}', policy_label:'{{ policy.policy_uid }} {{ policy.policy_type|default("",true)|e }}'})"
             class="text-[10px] text-marsh hover:underline font-semibold no-print">+ New Issue</button>
   </div>
   {% for issue in open_issues %}

--- a/src/policydb/web/templates/review/_client_review_slideover.html
+++ b/src/policydb/web/templates/review/_client_review_slideover.html
@@ -125,7 +125,7 @@
       <div class="flex items-center justify-between mb-2">
         <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide">Open Issues</h3>
         <button type="button"
-                onclick="openIssueCreateSlideover({client_id: {{ c.id }}})"
+                onclick="openIssueCreateSlideover({client_id:'{{ c.id }}', client_name:'{{ c.name|e }}'})"
                 class="text-xs text-marsh hover:underline">+ New</button>
       </div>
       <div id="slideover-client-issues-{{ c.id }}"

--- a/src/policydb/web/templates/review/_policy_review_slideover.html
+++ b/src/policydb/web/templates/review/_policy_review_slideover.html
@@ -216,7 +216,7 @@
       <div class="flex items-center justify-between mb-2">
         <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide">Open Issues</h3>
         <button type="button"
-                onclick="openIssueCreateSlideover({client_id: {{ p.client_id }}, policy_id: {{ p.id }}, policy_uid: '{{ p.policy_uid }}'})"
+                onclick="openIssueCreateSlideover({client_id:'{{ p.client_id }}', client_name:'{{ p.client_name|e }}', policy_id:'{{ p.id }}', policy_label:'{{ p.policy_uid }} {{ p.policy_type|default("",true)|e }}'})"
                 class="text-xs text-marsh hover:underline">+ New</button>
       </div>
       <div id="slideover-issues-{{ p.policy_uid }}"


### PR DESCRIPTION
## Summary
- **RFI bundle page stub:** `GET /clients/{id}/requests/{bundle_id}` was returning the `_request_bundle.html` partial with no base layout, so visiting it directly in a browser looked like an unstyled stub. Route now branches on `HX-Request` — HTMX still gets the partial (needed for inline updates on POSTs), direct browser visits get a new `clients/request_bundle_page.html` full-page wrapper with breadcrumb.
- **Issue Create slideover "Client #1":** Three call sites (`policies/_tab_pulse.html`, `review/_policy_review_slideover.html`, `review/_client_review_slideover.html`) passed `client_id` but no `client_name`, hitting the `'Client #' + id` fallback in the slideover. Fixed each to pass `client_name` (and `policy_label` where available) using the existing `|e` + single-quoted pattern.
- **`initClientAutocomplete` ReferenceError:** `_issue_create_slideover.html`'s inline script ran inside `{% block content %}` and called `initClientAutocomplete` before base.html's footer script block defined it. Wrapped the call in a `DOMContentLoaded` guard.

## Test plan
- [x] Direct browser visit to `/clients/4/requests/5` renders a full page with navbar, breadcrumb, and bundle content
- [x] HTMX POSTs (toggle item, add item, status change) still return the partial
- [x] Clicking "+ New Issue" on a policy's Pulse tab Issues section opens the slideover with the real client name and `POL-XXX Policy Type` label locked
- [x] Clicking "+ Create Issue" on the same page (Quick Log section) opens with identical context
- [x] Action Center loads with zero console errors (previously had `ReferenceError: initClientAutocomplete is not defined`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)