### PR TITLE
Compliance: tower stacking, richer link dropdown, limit/deductible write-back

### DIFF
--- a/src/policydb/compliance.py
+++ b/src/policydb/compliance.py
@@ -232,7 +232,8 @@ def propose_bulk_matches(conn, source_id: int, program_id: int | None = None) ->
             })
             continue
 
-        status = compute_auto_status(req, suggestion)
+        tower_total, tower_layers = compute_tower_total_limit(conn, suggestion["policy_uid"])
+        status = compute_auto_status(req, suggestion, effective_limit=tower_total)
         proposals.append({
             "requirement_id": req["id"],
             "coverage_line": req["coverage_line"],
@@ -240,6 +241,8 @@ def propose_bulk_matches(conn, source_id: int, program_id: int | None = None) ->
             "suggested_policy_uid": suggestion["policy_uid"],
             "suggested_policy_number": suggestion.get("policy_number"),
             "suggested_limit": suggestion.get("limit_amount"),
+            "tower_total": tower_total if len(tower_layers) > 1 else None,
+            "tower_layer_count": len(tower_layers),
             "computed_status": status,
             "missing_endorsements": missing_endorsements(req, suggestion),
         })
@@ -289,22 +292,106 @@ def compute_compliance_summary(governing: dict[str, dict]) -> dict:
     return {"total": total, "reviewed": reviewed, **counts, "compliance_pct": pct}
 
 
-def compute_auto_status(requirement: dict, policy: dict | None) -> str:
+def compute_tower_total_limit(conn, policy_uid: str) -> tuple[float, list[dict]]:
+    """Walk the tower containing the given policy and return (total, layers).
+
+    For insurance compliance purposes, a tower of stacked policies provides
+    combined limits:  primary $1M + 1st excess $2M over = $3M total. So a
+    $3M requirement is satisfied if the tower's top reaches $3M, regardless
+    of which layer was linked.
+
+    Returns:
+        (total_limit, layers) where total_limit is the max "ground-up" of
+        any layer (the top of the tower) and layers is the ordered list of
+        policy dicts with an added 'ground_up' field. If the policy has no
+        tower_group it's treated as a single-layer tower.
+    """
+    pol_row = conn.execute(
+        """SELECT policy_uid, policy_number, carrier, policy_type, tower_group,
+                  layer_position, limit_amount, attachment_point, participation_of
+             FROM policies
+            WHERE policy_uid = ? AND archived = 0""",
+        (policy_uid,),
+    ).fetchone()
+    if not pol_row:
+        return 0.0, []
+
+    pol = dict(pol_row)
+    tg = (pol.get("tower_group") or "").strip()
+    if not tg:
+        lim = float(pol.get("limit_amount") or 0)
+        pol["ground_up"] = lim
+        return lim, [pol]
+
+    rows = [dict(r) for r in conn.execute(
+        """SELECT policy_uid, policy_number, carrier, policy_type, tower_group,
+                  layer_position, limit_amount, attachment_point, participation_of
+             FROM policies
+            WHERE LOWER(TRIM(tower_group)) = LOWER(TRIM(?)) AND archived = 0""",
+        (tg,),
+    ).fetchall()]
+
+    # Sort: explicit attachment points ascending, then primary/no-attachment
+    # by layer_position. Mirrors the logic in policies._tab_details.
+    def _sort_key(r):
+        att = r.get("attachment_point")
+        if att is not None:
+            return (float(att), 0)
+        lp = r.get("layer_position") or "Primary"
+        try:
+            return (-1, int(lp))
+        except (ValueError, TypeError):
+            return (-1, 0)
+    rows.sort(key=_sort_key)
+
+    running = 0.0
+    layers: list[dict] = []
+    for r in rows:
+        lim = float(r.get("limit_amount") or 0)
+        att = r.get("attachment_point")
+        part = r.get("participation_of")
+        if att is not None and float(att) >= 0:
+            layer_size = float(part) if part else lim
+            ground_up = float(att) + layer_size
+        else:
+            running += lim
+            ground_up = running
+        r["ground_up"] = ground_up
+        layers.append(r)
+
+    total = max((l["ground_up"] for l in layers), default=0.0)
+    return total, layers
+
+
+def compute_auto_status(
+    requirement: dict,
+    policy: dict | None,
+    effective_limit: float | None = None,
+) -> str:
     """Auto-compute compliance status from requirement vs. linked policy.
 
     Returns "Compliant", "Partial", or "Gap".
     - No policy → Gap
-    - Policy limit < required limit → Gap
+    - Effective limit (tower total, if provided; else policy limit)
+      < required limit → Gap
     - Policy deductible > max deductible → Gap
     - Required endorsements: all present on policy → Compliant
     - Required endorsements: some missing → Partial
     - No required endorsements → Compliant
+
+    Pass ``effective_limit`` to make the comparison tower-aware when the
+    linked policy is part of a stacked program. The primary policy's
+    deductible and endorsements are still what we compare at the bottom
+    of the tower — limits are the only thing that stack.
     """
     if policy is None:
         return "Gap"
 
     req_limit = float(requirement.get("required_limit") or 0)
-    pol_limit = float(policy.get("limit_amount") or 0)
+    if effective_limit is not None:
+        pol_limit = float(effective_limit)
+    else:
+        pol_limit = float(policy.get("limit_amount") or 0)
     if req_limit > 0 and pol_limit < req_limit:
         return "Gap"
 
@@ -383,7 +470,8 @@ def detect_stale_compliance(conn, client_id: int) -> int:
             elif pol.get("expiration_date") and pol["expiration_date"] < today:
                 reason = f"{pol['policy_uid']} expired {pol['expiration_date']}"
             else:
-                new_status = compute_auto_status(req, pol)
+                tower_total, _ = compute_tower_total_limit(conn, pol["policy_uid"])
+                new_status = compute_auto_status(req, pol, effective_limit=tower_total)
                 if new_status == "Gap" and req["compliance_status"] in ("Compliant", "Partial"):
                     reason = f"{pol['policy_uid']} no longer meets requirement ({new_status})"
 
@@ -694,12 +782,14 @@ def get_client_compliance_data(conn, client_id: int) -> dict:
             if status != "Needs Review" or not gov_req.get("linked_policy_uid"):
                 continue
             pol = conn.execute(
-                "SELECT limit_amount, deductible, endorsements FROM policies "
+                "SELECT policy_uid, limit_amount, deductible, endorsements FROM policies "
                 "WHERE policy_uid = ? AND archived = 0",
                 (gov_req["linked_policy_uid"],),
             ).fetchone()
             if pol:
-                new_status = compute_auto_status(gov_req, dict(pol))
+                pol_dict = dict(pol)
+                tower_total, _ = compute_tower_total_limit(conn, pol_dict["policy_uid"])
+                new_status = compute_auto_status(gov_req, pol_dict, effective_limit=tower_total)
                 if new_status != status:
                     conn.execute(
                         "UPDATE coverage_requirements SET compliance_status = ? WHERE id = ?",

--- a/src/policydb/exporter.py
+++ b/src/policydb/exporter.py
@@ -2228,6 +2228,11 @@ _COMPLIANCE_FILLS = {
     "compliant": PatternFill("solid", fgColor="C6EFCE"),
     "gap": PatternFill("solid", fgColor="FFC7CE"),
     "partial": PatternFill("solid", fgColor="FFEB9C"),
+    # External = placed by another broker (satisfied but not our book)
+    "external": PatternFill("solid", fgColor="E2E8F0"),
+    # Pending Info = reviewer looked, can't decide yet
+    "pending info": PatternFill("solid", fgColor="DBEAFE"),
+    "pending_info": PatternFill("solid", fgColor="DBEAFE"),
     "n/a": PatternFill("solid", fgColor="D9D2E9"),
     "na": PatternFill("solid", fgColor="D9D2E9"),
     "needs review": PatternFill("solid", fgColor="D9D9D9"),
@@ -2310,6 +2315,8 @@ def _compliance_sheet_executive(wb: Workbook, data: dict, client_name: str) -> N
         ("Compliant", s["compliant"]),
         ("Gap", s["gap"]),
         ("Partial", s["partial"]),
+        ("External (placed by another broker)", s.get("external", 0)),
+        ("Pending Info", s.get("pending_info", 0)),
         ("Waived", s["waived"]),
         ("N/A", s["na"]),
         ("Needs Review", s["needs_review"]),
@@ -2400,13 +2407,19 @@ def _compliance_sheet_matrix(wb: Workbook, data: dict) -> None:
 
 
 def _compliance_sheet_gap_detail(wb: Workbook, data: dict) -> None:
-    """Sheet 3 — Gap Detail (non-compliant rows only)."""
+    """Sheet 3 — Gap Detail (non-compliant rows only).
+
+    Excludes External (placed by another broker — satisfied), Pending Info
+    (reviewer is waiting on info, not a gap yet), Waived, N/A, and Compliant.
+    """
     gap_rows: list[dict] = []
+    excluded = {"compliant", "external", "pending info", "pending_info",
+                "waived", "n/a", "na"}
     for loc in data["locations"]:
         loc_name = loc["project"].get("name", "Unknown")
         for line, gov in loc.get("governing", {}).items():
             status = (gov.get("compliance_status") or "Needs Review").lower()
-            if status not in ("compliant", "waived", "n/a", "na"):
+            if status not in excluded:
                 sources = gov.get("source_requirements", [])
                 source_names = ", ".join(
                     s.get("source_name", "") for s in sources if s.get("source_name")
@@ -2468,6 +2481,8 @@ def _compliance_sheet_all_requirements(wb: Workbook, data: dict) -> None:
                 "Deductible Type": req.get("deductible_type") or "",
                 "Required Endorsements": ", ".join(endorsements),
                 "Compliance Status": req.get("compliance_status") or "Needs Review",
+                "Reviewed At": req.get("reviewed_at") or "",
+                "Reviewed By": req.get("reviewed_by") or "",
                 "Linked Policies": linked_uids,
                 "Primary Policy": primary_uid,
                 "Link Types": link_types,
@@ -2573,6 +2588,8 @@ def export_compliance_md(
         f"| Compliant | {s['compliant']} |",
         f"| Gaps | {s['gap']} |",
         f"| Partial | {s['partial']} |",
+        f"| External (placed by another broker) | {s.get('external', 0)} |",
+        f"| Pending Info | {s.get('pending_info', 0)} |",
         f"| Waived | {s['waived']} |",
         f"| N/A | {s['na']} |",
         f"| Needs Review | {s['needs_review']} |",
@@ -2580,19 +2597,36 @@ def export_compliance_md(
     ]
 
     # ── Key Findings ──────────────────────────────────────────────────────────
+    # Only gaps and partials are actionable findings. External = satisfied
+    # by another broker, so we surface it separately. Pending Info is an
+    # in-progress state, not yet a finding.
     lines += ["## Key Findings", ""]
     findings: list[str] = []
+    external_items: list[str] = []
     for loc in locations:
         loc_name = loc["project"].get("name", "Unknown")
         for line_name, gov in loc.get("governing", {}).items():
             status = (gov.get("compliance_status") or "Needs Review").lower()
             if status in ("gap", "partial"):
                 findings.append(f"- **{status.capitalize()}:** {line_name} at {loc_name}")
+            elif status == "external":
+                external_items.append(f"- {line_name} at {loc_name}")
     if findings:
         lines += findings
     else:
         lines.append("No gaps or partial compliance issues found.")
     lines.append("")
+
+    # ── External Coverage (placed by another broker) ─────────────────────────
+    if external_items:
+        lines += [
+            "## Coverage Placed by Another Broker",
+            "",
+            "These coverages are in force but managed outside our book:",
+            "",
+        ]
+        lines += external_items
+        lines.append("")
 
     # ── Compliance Matrix ─────────────────────────────────────────────────────
     if locations:
@@ -2626,7 +2660,9 @@ def export_compliance_md(
         loc_name = loc["project"].get("name", "Unknown")
         for line_name, gov in loc.get("governing", {}).items():
             status = (gov.get("compliance_status") or "Needs Review").lower()
-            if status not in ("compliant", "waived", "n/a", "na"):
+            # External + Pending Info are not real gaps — see Key Findings.
+            if status not in ("compliant", "external", "pending info",
+                               "pending_info", "waived", "n/a", "na"):
                 sources = gov.get("source_requirements", [])
                 source_names = ", ".join(
                     src.get("source_name", "") for src in sources if src.get("source_name")

--- a/src/policydb/web/routes/compliance.py
+++ b/src/policydb/web/routes/compliance.py
@@ -17,6 +17,7 @@ from policydb import config as cfg
 from policydb.compliance import (
     compute_auto_status,
     compute_compliance_summary,
+    compute_tower_total_limit,
     get_client_compliance_data,
     get_linkable_policies,
     get_location_requirements,
@@ -782,14 +783,19 @@ def compliance_copy_table(client_id: int, conn=Depends(get_db)):
     for loc in data["locations"]:
         loc_name = loc["project"].get("name", "")
         for line, gov in loc["governing"].items():
+            reviewed_at = gov.get("reviewed_at") or ""
+            # Trim timestamp to date for a cleaner column
+            reviewed_date = reviewed_at.split("T")[0] if reviewed_at else ""
             rows.append({
                 "location": loc_name,
                 "coverage_line": gov.get("coverage_line") or line,
                 "required_limit": gov.get("required_limit"),
+                "max_deductible": gov.get("max_deductible"),
                 "status": gov.get("compliance_status") or "Needs Review",
                 "linked_policy": gov.get("linked_policy_uid") or "",
                 "source": gov.get("source_name") or "",
-                "max_deductible": gov.get("max_deductible"),
+                "reviewed": reviewed_date,
+                "reviewer": gov.get("reviewed_by") or "",
             })
     columns = [
         ("location", "Location", False),
@@ -799,6 +805,8 @@ def compliance_copy_table(client_id: int, conn=Depends(get_db)):
         ("status", "Status", False),
         ("linked_policy", "Linked Policy", False),
         ("source", "Source", False),
+        ("reviewed", "Reviewed", False),
+        ("reviewer", "By", False),
     ]
     return JSONResponse(build_generic_table(rows, columns))
 
@@ -1046,8 +1054,21 @@ def requirement_detail(
     # Policy used for comparison display (either linked primary or suggested)
     compare_policy = primary_policy or suggested_policy
 
-    # Compute auto-status for display (Compliant/Partial/Gap)
-    auto_status = compute_auto_status(req_dict, compare_policy) if compare_policy else "Gap"
+    # Tower-aware limit computation. When the compare_policy is part of a
+    # stacked tower (primary GL + excess layers), the total limit is the
+    # sum of layers — a $3M requirement is met by $1M primary + $2M xs.
+    tower_total: float | None = None
+    tower_layers: list[dict] = []
+    if compare_policy:
+        tower_total, tower_layers = compute_tower_total_limit(conn, compare_policy["policy_uid"])
+
+    # Compute auto-status for display (Compliant/Partial/Gap) with the
+    # tower-aware effective limit.
+    auto_status = (
+        compute_auto_status(req_dict, compare_policy, effective_limit=tower_total)
+        if compare_policy
+        else "Gap"
+    )
     missing_endos = missing_endorsements(req_dict, compare_policy) if compare_policy else req_dict.get("_endorsements_list", [])
 
     return templates.TemplateResponse("compliance/_requirement_slideover.html", {
@@ -1064,6 +1085,8 @@ def requirement_detail(
         "compare_policy": compare_policy,
         "auto_status": auto_status,
         "missing_endorsements": missing_endos,
+        "tower_total": tower_total,
+        "tower_layers": tower_layers,
         "compliance_statuses": cfg.get("compliance_statuses", []),
         "deductible_types": cfg.get("deductible_types", []),
         "policy_types": cfg.get("policy_types", []),
@@ -1997,14 +2020,18 @@ def _recompute_auto_status(conn, req_id: int):
         return
 
     primary = conn.execute(
-        """SELECT p.limit_amount, p.deductible, p.endorsements
+        """SELECT p.policy_uid, p.limit_amount, p.deductible, p.endorsements
            FROM requirement_policy_links rpl
            JOIN policies p ON p.policy_uid = rpl.policy_uid AND p.archived = 0
            WHERE rpl.requirement_id = ? AND rpl.is_primary = 1""",
         (req_id,),
     ).fetchone()
 
-    new_status = compute_auto_status(req_dict, dict(primary) if primary else None)
+    effective_limit = None
+    primary_dict = dict(primary) if primary else None
+    if primary_dict:
+        effective_limit, _ = compute_tower_total_limit(conn, primary_dict["policy_uid"])
+    new_status = compute_auto_status(req_dict, primary_dict, effective_limit=effective_limit)
     if new_status != status:
         conn.execute(
             "UPDATE coverage_requirements SET compliance_status = ? WHERE id = ?",

--- a/src/policydb/web/templates/compliance/_requirement_slideover.html
+++ b/src/policydb/web/templates/compliance/_requirement_slideover.html
@@ -14,6 +14,52 @@
 {% set effective_status = req.compliance_status if req.reviewed_at else (auto_status or 'Needs Review') %}
 {% set stored_status = req.compliance_status or 'Needs Review' %}
 
+{# Macro: render one linkable policy row inside the search dropdown with
+   enough context that a reviewer can tell similar policies apart —
+   carrier's policy_number, coverage type, program/location, limit, and
+   expiration year. `style` controls left-border accent. `tag` renders as
+   a small pill on the right (program/child/location). #}
+{% macro linkable_row(pol, style='default', tag='', tag_cls='') -%}
+  {% set searchable = ((pol.policy_uid or '') ~ ' ' ~ (pol.policy_number or '') ~ ' ' ~ (pol.policy_type or '') ~ ' ' ~ (pol.carrier or '') ~ ' ' ~ (pol.get('_project_name') or '')) | lower %}
+  {% set hover_bg = {'this': 'hover:bg-green-50', 'other': 'hover:bg-gray-50', 'program': 'hover:bg-indigo-50', 'child': 'hover:bg-purple-50', 'default': 'hover:bg-green-50'}.get(style, 'hover:bg-gray-50') %}
+  {% set border_left = 'border-l-2 border-l-green-400' if style == 'this' else '' %}
+  {% set muted = 'opacity-60' if style == 'other' else '' %}
+  {% set indent = 'pl-8 pr-3' if style == 'child' else 'px-3' %}
+  <button type="button"
+          data-search="{{ searchable }}"
+          class="w-full text-left {{ indent }} py-1.5 {{ hover_bg }} text-xs flex flex-col gap-0.5 border-b border-gray-50 {{ border_left }} {{ muted }}"
+          onclick="addPolicyLink('{{ pol.policy_uid }}'); document.getElementById('slideover-link-dropdown').classList.add('hidden'); document.getElementById('slideover-link-search').value = '';">
+    {# Row 1: UID · carrier policy # · coverage type · pill #}
+    <div class="flex items-center gap-2 w-full">
+      {% if style == 'child' %}<span class="text-gray-300">&#8627;</span>{% endif %}
+      <span class="font-mono text-gray-400">{{ pol.policy_uid }}</span>
+      {% if pol.policy_number %}
+        <span class="font-mono text-[10px] text-gray-400" title="Carrier policy number">{{ pol.policy_number }}</span>
+      {% endif %}
+      <span class="font-medium text-gray-900">{{ pol.policy_type or '' }}</span>
+      {% if tag %}
+      <span class="ml-auto {{ tag_cls }} px-1 py-0.5 rounded text-[10px]">{{ tag }}</span>
+      {% endif %}
+    </div>
+    {# Row 2: carrier · program/location · limit · exp #}
+    <div class="flex items-center gap-2 text-[10px] text-gray-500 w-full pl-1">
+      {% if pol.carrier %}<span>{{ pol.carrier }}</span>{% endif %}
+      {% if pol.get('_project_name') %}
+        {% if pol.carrier %}<span class="text-gray-300">·</span>{% endif %}
+        <span class="truncate max-w-[140px]" title="{{ pol._project_name }}">@ {{ pol._project_name }}</span>
+      {% endif %}
+      {% if pol.limit_amount %}
+        <span class="text-gray-300">·</span>
+        <span>{{ pol.limit_amount | currency_short }}</span>
+      {% endif %}
+      {% if pol.expiration_date %}
+        <span class="text-gray-300">·</span>
+        <span title="Expires {{ pol.expiration_date }}">exp {{ pol.expiration_date | string | truncate(7, True, '', 0) }}</span>
+      {% endif %}
+    </div>
+  </button>
+{%- endmacro %}
+
 {# ── Backdrop ── #}
 <div id="req-detail-backdrop"
      class="fixed inset-0 bg-black/30 z-40"
@@ -110,22 +156,67 @@
         <div class="text-[11px] text-gray-500 mt-1">{{ req._endorsements_list | join(', ') }}</div>
         {% endif %}
       </div>
-      <div class="bg-blue-50 border border-blue-200 rounded p-2.5">
+      <div class="bg-blue-50 border border-blue-200 rounded p-2.5" id="proposed-card"
+           data-policy-uid="{{ compare_policy.policy_uid }}">
         <div class="text-[10px] text-blue-600 uppercase tracking-wider mb-1">Proposed</div>
+        {% set has_tower = tower_layers and (tower_layers | length) > 1 %}
+        {% set effective_limit = tower_total if has_tower else compare_policy.limit_amount %}
+        {# Touch-once: if limit is missing/zero on the primary policy (not a
+           tower, else tower total is the source of truth), show an inline
+           input that writes back to policies.limit_amount. #}
         <div class="text-xs text-gray-800">
-          Limit: <span class="font-medium">{{ compare_policy.limit_amount | currency if compare_policy.limit_amount else 'Not set' }}</span>
-          {% if req.required_limit and compare_policy.limit_amount %}
-            {% if compare_policy.limit_amount >= req.required_limit %}
-            <span class="text-green-600 ml-1">&check;</span>
-            {% else %}
-            <span class="text-red-600 ml-1">&cross;</span>
+          Limit:
+          {% if (not effective_limit or effective_limit == 0) and not has_tower %}
+            <input type="text" inputmode="numeric"
+                   data-policy-field="limit_amount"
+                   placeholder="enter limit"
+                   class="policy-writeback-input ml-1 border border-blue-300 rounded px-1.5 py-0.5 text-xs w-24 bg-white"
+                   onchange="savePolicyField(this)" />
+            <span class="text-[10px] text-gray-500 ml-1">Not set on policy — enter once</span>
+          {% else %}
+            <span class="font-medium">{{ effective_limit | currency }}</span>
+            {% if req.required_limit %}
+              {% if effective_limit >= req.required_limit %}
+              <span class="text-green-600 ml-1">&check;</span>
+              {% else %}
+              <span class="text-red-600 ml-1">&cross;</span>
+              {% endif %}
+            {% endif %}
+            {% if has_tower %}
+            <span class="text-[10px] text-gray-500 ml-1">({{ tower_layers | length }}-layer tower)</span>
             {% endif %}
           {% endif %}
         </div>
+        {% if has_tower %}
+        <div class="mt-1 pl-2 border-l-2 border-blue-200 space-y-0.5">
+          {% for layer in tower_layers %}
+          <div class="text-[11px] text-gray-700">
+            <span class="font-mono text-gray-500">{{ layer.policy_number or layer.policy_uid }}</span>
+            <span class="text-gray-400">·</span>
+            <span>{{ layer.carrier or '' }}</span>
+            <span class="text-gray-500">
+              {% if layer.attachment_point is not none and layer.attachment_point|float > 0 %}
+                {{ ((layer.participation_of or layer.limit_amount) or 0) | currency }} xs {{ layer.attachment_point | currency }}
+              {% else %}
+                {{ (layer.limit_amount or 0) | currency }}
+              {% endif %}
+            </span>
+          </div>
+          {% endfor %}
+        </div>
+        {% endif %}
         {% if req.max_deductible is not none and req.max_deductible > 0 %}
-        <div class="text-xs text-gray-800 mt-0.5">
-          Ded: <span class="font-medium">{{ compare_policy.deductible | currency if compare_policy.deductible else 'Not set' }}</span>
-          {% if compare_policy.deductible is not none %}
+        <div class="text-xs text-gray-800 mt-1">
+          Ded:
+          {% if compare_policy.deductible is none %}
+            <input type="text" inputmode="numeric"
+                   data-policy-field="deductible"
+                   placeholder="enter deductible"
+                   class="policy-writeback-input ml-1 border border-blue-300 rounded px-1.5 py-0.5 text-xs w-24 bg-white"
+                   onchange="savePolicyField(this)" />
+            <span class="text-[10px] text-gray-500 ml-1">Not set — enter once</span>
+          {% else %}
+            <span class="font-medium">{{ compare_policy.deductible | currency }}</span>
             {% if compare_policy.deductible <= req.max_deductible %}
             <span class="text-green-600 ml-1">&check;</span>
             {% else %}
@@ -446,40 +537,17 @@
              autocomplete="off"
              onfocus="document.getElementById('slideover-link-dropdown').classList.remove('hidden')"
              oninput="(function(el){var dd=document.getElementById('slideover-link-dropdown');dd.classList.remove('hidden');var q=el.value.toLowerCase();dd.querySelectorAll('[data-search]').forEach(function(r){r.style.display=r.dataset.search.includes(q)?'':'none'});dd.querySelectorAll('[data-section-header]').forEach(function(h){var sec=h.nextElementSibling;var anyVisible=false;while(sec&&!sec.hasAttribute('data-section-header')){if(sec.style.display!=='none'&&sec.hasAttribute('data-search'))anyVisible=true;sec=sec.nextElementSibling}h.style.display=anyVisible||!q?'':'none'})})(this)">
-      <div id="slideover-link-dropdown" class="hidden absolute z-50 mt-1 w-full bg-white border border-gray-200 rounded shadow-lg max-h-48 overflow-y-auto">
+      <div id="slideover-link-dropdown" class="hidden absolute z-50 mt-1 w-full bg-white border border-gray-200 rounded shadow-lg max-h-80 overflow-y-auto">
 
         {# ── Programs section ── #}
         {% if ns.has_programs %}
         <div data-section-header class="px-2 py-1 bg-gray-50 text-[10px] text-gray-400 uppercase tracking-wider font-semibold sticky top-0">Programs</div>
         {% for pol in linkable_policies %}
           {% if pol.get('children') is not none %}
-          <button type="button"
-                  data-search="{{ (pol.policy_uid + ' ' + (pol.policy_type or '') + ' ' + (pol.carrier or '')) | lower }}"
-                  class="w-full text-left px-3 py-1.5 hover:bg-indigo-50 text-xs flex items-center gap-2 border-b border-gray-50"
-                  onclick="addPolicyLink('{{ pol.policy_uid }}'); document.getElementById('slideover-link-dropdown').classList.add('hidden'); document.getElementById('slideover-link-search').value = '';">
-            <span class="font-mono text-gray-400">{{ pol.policy_uid }}</span>
-            <span class="font-medium">{{ pol.policy_type or '' }}</span>
-            {% if pol.get('program_carrier_names') %}
-              <span class="text-gray-400">&middot; {{ pol.program_carrier_names | join(', ') }}</span>
-            {% elif pol.carrier %}
-              <span class="text-gray-400">&middot; {{ pol.carrier }}</span>
-            {% endif %}
-            <span class="bg-indigo-100 text-indigo-600 px-1 py-0.5 rounded text-[10px] ml-auto">program</span>
-          </button>
-          {% for child in pol.get('children', []) %}
-          <button type="button"
-                  data-search="{{ (child.policy_uid + ' ' + (child.policy_type or '') + ' ' + (child.carrier or '')) | lower }}"
-                  class="w-full text-left pl-8 pr-3 py-1 hover:bg-purple-50 text-xs flex items-center gap-2 border-b border-gray-50"
-                  onclick="addPolicyLink('{{ child.policy_uid }}'); document.getElementById('slideover-link-dropdown').classList.add('hidden'); document.getElementById('slideover-link-search').value = '';">
-            <span class="text-gray-300">&#8627;</span>
-            <span class="font-mono text-gray-400">{{ child.policy_uid }}</span>
-            <span>{{ child.policy_type or '' }}</span>
-            {% if child.carrier %}
-              <span class="text-gray-400">&middot; {{ child.carrier }}</span>
-            {% endif %}
-            <span class="bg-purple-100 text-purple-600 px-1 py-0.5 rounded text-[10px] ml-auto">child</span>
-          </button>
-          {% endfor %}
+            {{ linkable_row(pol, style='program', tag='program', tag_cls='bg-indigo-100 text-indigo-600') }}
+            {% for child in pol.get('children', []) %}
+              {{ linkable_row(child, style='child', tag='child', tag_cls='bg-purple-100 text-purple-600') }}
+            {% endfor %}
           {% endif %}
         {% endfor %}
         {% endif %}
@@ -490,29 +558,12 @@
           <div data-section-header class="px-2 py-1 bg-green-50 text-[10px] text-green-700 uppercase tracking-wider font-semibold sticky top-0 border-t border-green-100">&#9679; This Location</div>
           {% for pol in linkable_policies %}
             {% if not pol.get('children') is not none and not pol.get('program_id') and pol.get('_location_match') == 'this' %}
-            <button type="button"
-                    data-search="{{ (pol.policy_uid + ' ' + (pol.policy_type or '') + ' ' + (pol.carrier or '')) | lower }}"
-                    class="w-full text-left px-3 py-1.5 hover:bg-green-50 text-xs flex items-center gap-2 border-b border-gray-50 border-l-2 border-l-green-400"
-                    onclick="addPolicyLink('{{ pol.policy_uid }}'); document.getElementById('slideover-link-dropdown').classList.add('hidden'); document.getElementById('slideover-link-search').value = '';">
-              <span class="font-mono text-gray-400">{{ pol.policy_uid }}</span>
-              <span class="font-medium text-gray-900">{{ pol.policy_type or '' }}</span>
-              {% if pol.carrier %}<span class="text-gray-400">&middot; {{ pol.carrier }}</span>{% endif %}
-              {% if pol.limit_amount %}<span class="text-gray-400 ml-auto">{{ pol.limit_amount | currency_short }}</span>{% endif %}
-              <span class="bg-green-100 text-green-700 px-1 py-0.5 rounded text-[10px]">location</span>
-            </button>
+              {{ linkable_row(pol, style='this', tag='location', tag_cls='bg-green-100 text-green-700') }}
             {% endif %}
           {% endfor %}
           {% for pol in linkable_policies %}
             {% if not pol.get('children') is not none and not pol.get('program_id') and pol.get('_location_match') == 'corporate' %}
-            <button type="button"
-                    data-search="{{ (pol.policy_uid + ' ' + (pol.policy_type or '') + ' ' + (pol.carrier or '')) | lower }}"
-                    class="w-full text-left px-3 py-1.5 hover:bg-green-50 text-xs flex items-center gap-2 border-b border-gray-50"
-                    onclick="addPolicyLink('{{ pol.policy_uid }}'); document.getElementById('slideover-link-dropdown').classList.add('hidden'); document.getElementById('slideover-link-search').value = '';">
-              <span class="font-mono text-gray-400">{{ pol.policy_uid }}</span>
-              <span class="font-medium text-gray-700">{{ pol.policy_type or '' }}</span>
-              {% if pol.carrier %}<span class="text-gray-400">&middot; {{ pol.carrier }}</span>{% endif %}
-              {% if pol.limit_amount %}<span class="text-gray-400 ml-auto">{{ pol.limit_amount | currency_short }}</span>{% endif %}
-            </button>
+              {{ linkable_row(pol, style='default', tag='corporate', tag_cls='bg-slate-100 text-slate-600') }}
             {% endif %}
           {% endfor %}
           {% endif %}
@@ -522,17 +573,7 @@
           <div data-section-header class="px-2 py-1 bg-gray-100 text-[10px] text-gray-400 uppercase tracking-wider font-semibold sticky top-0 border-t border-gray-200">Other Locations</div>
           {% for pol in linkable_policies %}
             {% if not pol.get('children') is not none and not pol.get('program_id') and pol.get('_location_match') == 'other' %}
-            <button type="button"
-                    data-search="{{ (pol.policy_uid + ' ' + (pol.policy_type or '') + ' ' + (pol.carrier or '') + ' ' + (pol.get('_project_name') or '')) | lower }}"
-                    class="w-full text-left px-3 py-1.5 hover:bg-gray-50 text-xs flex items-center gap-2 border-b border-gray-50 opacity-60"
-                    onclick="addPolicyLink('{{ pol.policy_uid }}'); document.getElementById('slideover-link-dropdown').classList.add('hidden'); document.getElementById('slideover-link-search').value = '';">
-              <span class="font-mono text-gray-400">{{ pol.policy_uid }}</span>
-              <span class="text-gray-500">{{ pol.policy_type or '' }}</span>
-              {% if pol.carrier %}<span class="text-gray-400">&middot; {{ pol.carrier }}</span>{% endif %}
-              {% if pol.get('_project_name') %}
-                <span class="text-gray-400 text-[10px] ml-auto truncate max-w-[120px]" title="{{ pol._project_name }}">@ {{ pol._project_name }}</span>
-              {% endif %}
-            </button>
+              {{ linkable_row(pol, style='other', tag='', tag_cls='') }}
             {% endif %}
           {% endfor %}
           {% endif %}
@@ -541,15 +582,7 @@
           <div data-section-header class="px-2 py-1 bg-gray-50 text-[10px] text-gray-400 uppercase tracking-wider font-semibold sticky top-0">Policies</div>
           {% for pol in linkable_policies %}
             {% if not pol.get('children') is not none and not pol.get('program_id') %}
-            <button type="button"
-                    data-search="{{ (pol.policy_uid + ' ' + (pol.policy_type or '') + ' ' + (pol.carrier or '')) | lower }}"
-                    class="w-full text-left px-3 py-1.5 hover:bg-green-50 text-xs flex items-center gap-2 border-b border-gray-50"
-                    onclick="addPolicyLink('{{ pol.policy_uid }}'); document.getElementById('slideover-link-dropdown').classList.add('hidden'); document.getElementById('slideover-link-search').value = '';">
-              <span class="font-mono text-gray-400">{{ pol.policy_uid }}</span>
-              <span class="font-medium">{{ pol.policy_type or '' }}</span>
-              {% if pol.carrier %}<span class="text-gray-400">&middot; {{ pol.carrier }}</span>{% endif %}
-              {% if pol.limit_amount %}<span class="text-gray-400 ml-auto">{{ pol.limit_amount | currency_short }}</span>{% endif %}
-            </button>
+              {{ linkable_row(pol, style='default', tag='', tag_cls='') }}
             {% endif %}
           {% endfor %}
         {% endif %}
@@ -710,6 +743,35 @@ function linkAndMark(policyUid, status) {
         });
     }).then(function() {
         closeRequirementDetail();
+    });
+}
+
+/* ── Touch-once write-back: fix a missing limit or deductible on the linked
+     /suggested policy directly from the slideover. Same principle as the
+     endorsement checkboxes — the fact lives on the policy record. After
+     saving, re-fetch the slideover so auto-compute picks up the new value
+     and the tower total refreshes. Accepts currency shorthand (1m, 500k). ── */
+function savePolicyField(input) {
+    var card = document.getElementById('proposed-card');
+    if (!card) return;
+    var policyUid = card.dataset.policyUid;
+    var field = input.dataset.policyField;
+    var value = (input.value || '').trim();
+    if (!value) return;
+    fetch('/policies/' + policyUid + '/cell', {
+        method: 'PATCH',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({field: field, value: value})
+    }).then(function(r) { return r.json(); }).then(function(d) {
+        if (d && d.ok) {
+            htmx.ajax('GET', '/compliance/client/{{ client_id }}/requirements/{{ req.id }}/detail',
+                      {target: '#requirement-slideover-container', swap: 'innerHTML'});
+        } else {
+            input.classList.add('border-red-400');
+            input.title = (d && d.error) || 'Save failed';
+        }
+    }).catch(function(){
+        input.classList.add('border-red-400');
     });
 }
 


### PR DESCRIPTION
## Summary

Follow-up to PR #220 addressing three reviewer pain points:

- **Tower stacking in limit comparison** — A primary GL \$1M + excess \$2M xs \$1M now satisfies a \$3M requirement. New \`compute_tower_total_limit()\` walks the policy's \`tower_group\`, and \`compute_auto_status()\` takes an \`effective_limit\` override. Applied at every call site. Slideover renders the layer-by-layer breakdown with carrier and \"X xs Y\" notation.
- **Richer policy link dropdown** — Refactored into a Jinja2 macro. Each row now shows UID, carrier's policy number, coverage type, carrier, program/location, limit, and expiration date — enough context to tell similar-looking policies apart.
- **Touch-once write-back for limits/deductibles** — Same pattern as the endorsement checkboxes. When the Proposed card shows a missing limit or deductible, inline inputs save to \`policies.limit_amount\` / \`deductible\` via the existing \`/cell\` PATCH. After save, the slideover re-fetches so the tower total recomputes.
- **Exports flow the new data** — XLSX and MD Executive Summary count External/Pending Info; Gap Detail excludes them; All Requirements sheet adds Reviewed At/By columns; MD has a new \"Coverage Placed by Another Broker\" section; copy-table adds Reviewed/By columns.

## Test plan

- [x] \`compute_tower_total_limit\` verified against Meridian's real 4-layer GL tower (\$52M top) — linking any layer walks the full tower
- [x] Property tower with \`participation_of\` (\$150M top via shared layer) computes correctly
- [x] Slideover renders the tower breakdown when >1 layer
- [x] Dropdown macro renders across all sections (programs, children, this location, corporate, other locations, flat list)
- [x] Limit and deductible inline inputs appear when values are missing on the policy
- [x] XLSX Executive Summary shows External + Pending Info rows
- [x] XLSX All Requirements sheet includes Reviewed At / Reviewed By columns
- [x] Markdown export gets an External Coverage section when any rows are marked External
- [x] Copy-table includes Reviewed / By columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)