### PR TITLE
fix(programs): restore combo save on tower matrices + layer picker

### DIFF
--- a/src/policydb/web/routes/programs.py
+++ b/src/policydb/web/routes/programs.py
@@ -891,12 +891,14 @@ async def patch_program_header(
 
 
 @router.post("/programs/{program_uid}/assign/{policy_uid}")
-def assign_to_program_v2(
+async def assign_to_program_v2(
+    request: Request,
     program_uid: str,
     policy_uid: str,
     conn: sqlite3.Connection = Depends(get_db),
 ):
-    """Assign a policy to a program (sets tower_group for schematic compat)."""
+    """Assign a policy to a program. Optional JSON body {"layer_position": ...}
+    lets callers put the policy directly on the Primary/Umbrella/Excess layer."""
     program = get_program_by_uid(conn, program_uid)
     if not program:
         return JSONResponse({"ok": False, "error": "Program not found"}, status_code=404)
@@ -907,17 +909,33 @@ def assign_to_program_v2(
     if not policy:
         return JSONResponse({"ok": False, "error": "Policy not found"}, status_code=404)
 
-    # Set program_id FK + tower_group; force layer_position to Primary unless already Umbrella/Excess
-    conn.execute(
-        """UPDATE policies SET program_id = ?, tower_group = ?,
-           layer_position = CASE WHEN layer_position IN ('Umbrella', 'Excess') THEN layer_position ELSE 'Primary' END
-           WHERE policy_uid = ?""",
-        (program["id"], program["name"], policy_uid),
-    )
+    requested_layer: str | None = None
+    try:
+        body = await request.json()
+        if isinstance(body, dict):
+            raw = body.get("layer_position")
+            if isinstance(raw, str) and raw.strip() in {"Primary", "Umbrella", "Excess"}:
+                requested_layer = raw.strip()
+    except Exception:
+        pass
+
+    if requested_layer:
+        conn.execute(
+            "UPDATE policies SET program_id = ?, tower_group = ?, layer_position = ? WHERE policy_uid = ?",
+            (program["id"], program["name"], requested_layer, policy_uid),
+        )
+    else:
+        # Default: keep existing Umbrella/Excess or fall back to Primary
+        conn.execute(
+            """UPDATE policies SET program_id = ?, tower_group = ?,
+               layer_position = CASE WHEN layer_position IN ('Umbrella', 'Excess') THEN layer_position ELSE 'Primary' END
+               WHERE policy_uid = ?""",
+            (program["id"], program["name"], policy_uid),
+        )
     # Auto-sync location if program is scoped to a project/location
     _sync_policy_to_program_location(conn, policy_uid, program)
     conn.commit()
-    logger.info("Assigned %s to program %s", policy_uid, program_uid)
+    logger.info("Assigned %s to program %s as %s", policy_uid, program_uid, requested_layer or "Primary")
 
     return JSONResponse({"ok": True})
 

--- a/src/policydb/web/templates/programs/_child_row.html
+++ b/src/policydb/web/templates/programs/_child_row.html
@@ -3,12 +3,16 @@
   <td class="px-3 py-2">
     <a href="/policies/{{ child.policy_uid }}/edit" class="text-marsh hover:underline font-medium text-xs">{{ child.policy_uid }}</a>
   </td>
-  <td class="px-3 py-2 text-sm text-gray-800 matrix-cell-combo relative"
+  <td class="px-3 py-2 text-sm text-gray-800 matrix-cell-combo relative cursor-pointer"
       data-field="policy_type" data-placeholder="type"
-      data-options='{{ policy_types | tojson }}' contenteditable="true">{{ child.policy_type or '' }}</td>
-  <td class="px-3 py-2 text-sm text-gray-800 matrix-cell-combo relative"
+      data-options='{{ policy_types | tojson }}'>
+    <span class="cell-display">{% if child.policy_type %}{{ child.policy_type }}{% else %}<span class="text-gray-300 text-xs">&mdash;</span>{% endif %}</span>
+  </td>
+  <td class="px-3 py-2 text-sm text-gray-800 matrix-cell-combo relative cursor-pointer"
       data-field="carrier" data-placeholder="carrier"
-      data-options='{{ carriers | tojson }}' contenteditable="true">{{ child.carrier or '' }}</td>
+      data-options='{{ carriers | tojson }}'>
+    <span class="cell-display">{% if child.carrier %}{{ child.carrier }}{% else %}<span class="text-gray-300 text-xs">&mdash;</span>{% endif %}</span>
+  </td>
   <td class="px-3 py-2 text-sm text-gray-800 matrix-cell-editable"
       data-field="policy_number" data-placeholder="policy #" contenteditable="true">{{ child.policy_number or '' }}</td>
   <td class="px-3 py-2 text-sm text-gray-800 text-right tabular-nums matrix-cell-editable"
@@ -29,12 +33,16 @@
            class="text-xs border border-gray-200 rounded px-1.5 py-1 w-[110px] focus:ring-1 focus:ring-marsh focus:border-marsh"
            onchange="patchChildCell({{ child.id }}, 'expiration_date', this.value)">
   </td>
-  <td class="px-3 py-2 text-sm text-gray-800 matrix-cell-combo relative"
+  <td class="px-3 py-2 text-sm text-gray-800 matrix-cell-combo relative cursor-pointer"
       data-field="renewal_status" data-placeholder="status"
-      data-options='{{ renewal_statuses | tojson }}' contenteditable="true">{{ child.renewal_status or '' }}</td>
-  <td class="px-3 py-2 text-sm text-gray-800 matrix-cell-combo relative"
+      data-options='{{ renewal_statuses | tojson }}'>
+    <span class="cell-display">{% if child.renewal_status %}{{ child.renewal_status }}{% else %}<span class="text-gray-300 text-xs">&mdash;</span>{% endif %}</span>
+  </td>
+  <td class="px-3 py-2 text-sm matrix-cell-combo relative cursor-pointer"
       data-field="layer_position" data-placeholder="layer"
-      data-options='["Primary", "Umbrella", "Excess"]' contenteditable="true">{{ child.layer_position or '' }}</td>
+      data-options='["Primary", "Umbrella", "Excess"]'>
+    <span class="cell-display">{% if child.layer_position == 'Umbrella' %}<span class="text-[11px] font-semibold px-1.5 py-0.5 rounded bg-blue-100 text-blue-700">Umbrella</span>{% elif child.layer_position == 'Excess' %}<span class="text-[11px] font-semibold px-1.5 py-0.5 rounded bg-gray-100 text-gray-600">Excess</span>{% elif child.layer_position == 'Primary' %}<span class="text-[11px] font-semibold px-1.5 py-0.5 rounded bg-emerald-50 text-emerald-700">Primary</span>{% else %}<span class="text-gray-300 text-xs">&mdash;</span>{% endif %}</span>
+  </td>
   <td class="px-3 py-2 text-sm text-gray-800 text-right tabular-nums matrix-cell-editable"
       data-field="participation_of" data-placeholder="--" contenteditable="true">{% if child.participation_of %}{{ child.participation_of | currency }}{% endif %}</td>
   <td class="px-2 py-2 no-print">

--- a/src/policydb/web/templates/programs/_excess_row.html
+++ b/src/policydb/web/templates/programs/_excess_row.html
@@ -64,9 +64,11 @@
            class="text-xs border border-gray-200 rounded px-1.5 py-1 w-[110px] focus:ring-1 focus:ring-marsh focus:border-marsh"
            onchange="patchExcessDate('{{ _row_id }}', 'expiration_date', this.value)">
   </td>
-  <td class="px-3 py-2 text-sm text-gray-800 matrix-cell-combo relative"
+  <td class="px-3 py-2 text-sm text-gray-800 matrix-cell-combo relative cursor-pointer"
       data-field="renewal_status" data-placeholder="status"
-      data-options='{{ renewal_statuses | tojson }}' contenteditable="true">{{ p.renewal_status or '' }}</td>
+      data-options='{{ renewal_statuses | tojson }}'>
+    <span class="cell-display">{% if p.renewal_status %}{{ p.renewal_status }}{% else %}<span class="text-gray-300 text-xs">&mdash;</span>{% endif %}</span>
+  </td>
   <td class="px-2 py-2 no-print">
     <button type="button" onclick="deleteExcessRow(this, {{ p.id }})"
             class="text-red-300 hover:text-red-500 text-xs">&#10005;</button>

--- a/src/policydb/web/templates/programs/_tab_overview.html
+++ b/src/policydb/web/templates/programs/_tab_overview.html
@@ -154,10 +154,16 @@
               {% elif pol.renewal_status == 'In Progress' %}bg-blue-50 text-blue-700
               {% else %}bg-gray-100 text-gray-600{% endif %}">{{ pol.renewal_status or '---' }}</span>
           </td>
-          <td class="px-4 py-2.5 no-print">
+          <td class="px-4 py-2.5 no-print whitespace-nowrap">
+            <select class="text-xs border border-gray-200 rounded px-1 py-0.5 mr-1 bg-white" data-assign-layer
+                    title="Assign to which layer">
+              <option value="Primary">Primary</option>
+              <option value="Umbrella">Umbrella</option>
+              <option value="Excess">Excess</option>
+            </select>
             <button type="button"
               class="text-xs text-marsh border border-marsh/30 rounded px-2 py-0.5 hover:bg-marsh hover:text-white transition-colors"
-              onclick="assignPolicy('{{ pol.policy_uid }}')">+ Assign</button>
+              onclick="assignPolicy('{{ pol.policy_uid }}', this.previousElementSibling.value)">+ Assign</button>
           </td>
         </tr>
         {% endfor %}
@@ -263,8 +269,12 @@
     });
   };
 
-  window.assignPolicy = function(policyUid) {
-    fetch(_base + '/assign/' + policyUid, {method: 'POST'})
+  window.assignPolicy = function(policyUid, layer) {
+    fetch(_base + '/assign/' + policyUid, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(layer ? {layer_position: layer} : {})
+    })
       .then(function(r) { return r.json(); })
       .then(function(data) {
         if (data.ok) {

--- a/src/policydb/web/templates/programs/_tab_schematic.html
+++ b/src/policydb/web/templates/programs/_tab_schematic.html
@@ -43,8 +43,14 @@
           <td class="px-4 py-2 text-xs text-gray-500">{{ u.project_name or '—' }}</td>
           <td class="px-4 py-2 text-right text-gray-600 tabular-nums">{{ u.premium | currency_short if u.premium else '—' }}</td>
           <td class="px-4 py-2 text-right text-gray-600 tabular-nums">{{ u.limit_amount | currency_short if u.limit_amount else '—' }}</td>
-          <td class="px-4 py-2 no-print">
-            <button type="button" onclick="assignPolicy('{{ u.policy_uid }}')"
+          <td class="px-4 py-2 no-print whitespace-nowrap">
+            <select class="text-xs border border-gray-200 rounded px-1 py-0.5 mr-1 bg-white" data-assign-layer
+                    title="Assign to which layer">
+              <option value="Primary">Primary</option>
+              <option value="Umbrella">Umbrella</option>
+              <option value="Excess">Excess</option>
+            </select>
+            <button type="button" onclick="assignPolicy('{{ u.policy_uid }}', this.previousElementSibling.value)"
               class="text-xs text-marsh border border-marsh/30 rounded px-2 py-0.5 hover:bg-marsh hover:text-white transition-colors">+ Assign</button>
           </td>
         </tr>
@@ -176,10 +182,11 @@
   });
 
   // Assign policy to program (schematic context)
-  window.assignPolicy = window.assignPolicy || function(uid) {
+  window.assignPolicy = function(uid, layer) {
     fetch(_base + '/assign/' + uid, {
       method: 'POST',
-      headers: {'Content-Type': 'application/json'}
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(layer ? {layer_position: layer} : {})
     }).then(function(r) { return r.json(); }).then(function(resp) {
       if (resp.ok) {
         var el = document.getElementById('unassigned-' + uid);
@@ -190,7 +197,7 @@
         if (tbody && tbody.children.length === 0) {
           panel.closest('.card').remove();
         }
-        showToast('Assigned to program');
+        showToast('Assigned as ' + (layer || 'Primary'));
         window.location.reload();
       }
     });

--- a/src/policydb/web/templates/programs/_underlying_row.html
+++ b/src/policydb/web/templates/programs/_underlying_row.html
@@ -1,12 +1,16 @@
 {% set is_pkg = p.is_package_ghost is defined and p.is_package_ghost %}
 <tr data-row-id="{{ p.id }}" class="matrix-row hover:bg-gray-50 transition-colors {{ 'border-l-2 border-l-indigo-400' if is_pkg }}">
   <td class="px-2 py-2 text-gray-400 cursor-grab no-print underlying-drag" draggable="true">&#x2807;</td>
-  <td class="px-3 py-2 text-sm text-gray-800 matrix-cell-combo relative"
+  <td class="px-3 py-2 text-sm text-gray-800 matrix-cell-combo relative cursor-pointer"
       data-field="policy_type" data-placeholder="select line"
-      data-options='{{ policy_types | tojson }}' contenteditable="true">{{ p.policy_type or '' }}{% if is_pkg %}<span class="ml-1.5 inline-flex items-center text-[9px] font-semibold px-1.5 py-0.5 rounded bg-indigo-50 text-indigo-600 no-print" contenteditable="false">Package</span>{% endif %}</td>
-  <td class="px-3 py-2 text-sm text-gray-800 matrix-cell-combo relative"
+      data-options='{{ policy_types | tojson }}'>
+    <span class="cell-display">{% if p.policy_type %}{{ p.policy_type }}{% else %}<span class="text-gray-300 text-xs">&mdash;</span>{% endif %}{% if is_pkg %}<span class="ml-1.5 inline-flex items-center text-[9px] font-semibold px-1.5 py-0.5 rounded bg-indigo-50 text-indigo-600 no-print">Package</span>{% endif %}</span>
+  </td>
+  <td class="px-3 py-2 text-sm text-gray-800 matrix-cell-combo relative cursor-pointer"
       data-field="carrier" data-placeholder="carrier"
-      data-options='{{ carriers | tojson }}' contenteditable="true">{{ p.carrier or '' }}</td>
+      data-options='{{ carriers | tojson }}'>
+    <span class="cell-display">{% if p.carrier %}{{ p.carrier }}{% else %}<span class="text-gray-300 text-xs">&mdash;</span>{% endif %}</span>
+  </td>
   <td class="px-3 py-2 text-sm text-gray-800 text-right tabular-nums matrix-cell-editable"
       data-field="limit_amount" data-placeholder="$0" contenteditable="true">{% if p.limit_amount %}{{ p.limit_amount | currency }}{% endif %}</td>
   <td class="px-3 py-2 text-sm text-gray-800 text-right tabular-nums matrix-cell-editable"
@@ -15,9 +19,11 @@
       data-field="premium" data-placeholder="$0" contenteditable="true">{% if is_pkg %}pkg premium{% elif p.premium %}{{ p.premium | currency }}{% endif %}</td>
   <td class="px-3 py-2 text-sm text-gray-800 matrix-cell-editable"
       data-field="policy_number" data-placeholder="policy #" contenteditable="true">{{ p.policy_number or '' }}</td>
-  <td class="px-3 py-2 text-sm text-gray-800 matrix-cell-combo relative"
+  <td class="px-3 py-2 text-sm text-gray-800 matrix-cell-combo relative cursor-pointer"
       data-field="coverage_form" data-placeholder="form"
-      data-options='{{ coverage_forms | tojson }}' contenteditable="true">{{ p.coverage_form or '' }}</td>
+      data-options='{{ coverage_forms | tojson }}'>
+    <span class="cell-display">{% if p.coverage_form %}{{ p.coverage_form }}{% else %}<span class="text-gray-300 text-xs">&mdash;</span>{% endif %}</span>
+  </td>
   <td class="px-2 py-1.5">
     <input type="date" value="{{ p.effective_date or '' }}"
            class="text-xs border border-gray-200 rounded px-1.5 py-1 w-[110px] focus:ring-1 focus:ring-marsh focus:border-marsh"
@@ -28,9 +34,11 @@
            class="text-xs border border-gray-200 rounded px-1.5 py-1 w-[110px] focus:ring-1 focus:ring-marsh focus:border-marsh"
            onchange="patchUnderlyingDate({{ p.id }}, 'expiration_date', this.value)">
   </td>
-  <td class="px-3 py-2 text-sm text-gray-800 matrix-cell-combo relative"
+  <td class="px-3 py-2 text-sm text-gray-800 matrix-cell-combo relative cursor-pointer"
       data-field="renewal_status" data-placeholder="status"
-      data-options='{{ renewal_statuses | tojson }}' contenteditable="true">{{ p.renewal_status or '' }}</td>
+      data-options='{{ renewal_statuses | tojson }}'>
+    <span class="cell-display">{% if p.renewal_status %}{{ p.renewal_status }}{% else %}<span class="text-gray-300 text-xs">&mdash;</span>{% endif %}</span>
+  </td>
   <td class="px-2 py-2 no-print">
     <button type="button" onclick="deleteUnderlyingRow(this, {{ p.id }})"
             class="text-red-300 hover:text-red-500 text-xs">&#10005;</button>


### PR DESCRIPTION
## Summary
- Wrap `matrix-cell-combo` cells on `_child_row` / `_underlying_row` / `_excess_row` in `.cell-display` spans so `initMatrix.closeCombo` actually fires its save branch (`base.html:362-381`).
- Extend `POST /programs/{uid}/assign/{uid}` to accept an optional `{"layer_position": "Primary"|"Umbrella"|"Excess"}` body; default behavior unchanged.
- Add a layer `<select>` next to each `+ Assign` button on both Overview and Schematic tabs' Unassigned Policies panels so existing policies can drop directly onto the right layer.
- Render Primary / Umbrella / Excess as colored pill badges on the Overview grid's Layer column.

## Root cause
All `matrix-cell-combo` cells in the program row templates had `contenteditable="true"` on the `<td>` with text directly inside, no `.cell-display` wrapper. `closeCombo` wraps its save call in `if (display) { saveCell() }`, so every combo save on those grids was silently dropped. The user reported it as "selecting Umbrella doesn't stick," but `policy_type`, `carrier`, `coverage_form`, and `renewal_status` were equally broken. Regression from the package-policy refactor (`6a5988fa`, `06109413`) which introduced the combo class without the matching display wrapper.

Supersedes #223 (that PR branched from a long-lived feature branch that had conflicting duplicate commits with main — this one branches cleanly from main).

## Test plan
- [x] `PATCH /programs/PGM-001/child/{id}/cell` flips `layer_position` Primary → Umbrella → Primary and persists in DB.
- [x] `POST /programs/PGM-001/assign/TST-005` with `{"layer_position":"Umbrella"}` body lands the policy directly on the umbrella layer.
- [x] Empty body + invalid layer value both fall back to Primary (backward compat, no SQL injection).
- [x] Overview + Schematic tabs render 200 OK with the new `.cell-display` markup.
- [ ] Visual QA in Chrome — click a Layer cell, pick Umbrella, confirm the cell updates and the saved toast fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)