### PR TITLE
fix(programs): tower delete unassigns real policies instead of dropping them

### DIFF
--- a/scripts/recover_deleted_program_policies.py
+++ b/scripts/recover_deleted_program_policies.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Recover policies that were hard-deleted by the pre-fix tower matrix
+delete buttons (delete_underlying_v2 / delete_excess_v2 in programs.py).
+
+Bug
+---
+Before this script's sibling fix, clicking the red X on an Underlying or
+Excess row in the Schematic tab did an unconditional hard DELETE on the
+`policies` row. That was fine for blank placeholder rows but wiped real
+policies that had been linked to a program via the `/assign` layer-picker
+flow. The user reports: "I deleted the Excess policy from the child
+policies table in the tower construction tab. However, it is now not
+showing up anywhere in the system."
+
+How this script works
+---------------------
+1. Reads the live DB at ~/.policydb/policydb.sqlite.
+2. Walks every backup in ~/.policydb/backups/ from newest to oldest.
+3. For every policy_uid present in any backup but missing from live,
+   picks the most recent backup that still contained the row and reports
+   it. That's our best reconstruction of the deleted record.
+4. With --restore, re-INSERTs those rows into the live `policies` table,
+   preserving `program_id` / `tower_group` / `layer_position` so they
+   pop back onto the correct program and layer.
+
+Usage
+-----
+    # Dry run (default) — show what would be restored, don't touch DB.
+    python scripts/recover_deleted_program_policies.py
+
+    # Inspect a specific policy_uid
+    python scripts/recover_deleted_program_policies.py --uid POL-042
+
+    # Actually restore. Makes a safety backup first.
+    python scripts/recover_deleted_program_policies.py --restore
+
+    # Only restore policies on a specific program
+    python scripts/recover_deleted_program_policies.py --restore --program PGM-001
+
+The script is idempotent — re-running after a restore is a no-op because
+the rows are back in live.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sqlite3
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+LIVE_DB = Path(os.path.expanduser("~/.policydb/policydb.sqlite"))
+BACKUP_DIR = Path(os.path.expanduser("~/.policydb/backups"))
+
+
+def _conn(path: Path) -> sqlite3.Connection:
+    c = sqlite3.connect(path)
+    c.row_factory = sqlite3.Row
+    return c
+
+
+def _policies_columns(conn: sqlite3.Connection) -> list[str]:
+    return [r[1] for r in conn.execute("PRAGMA table_info(policies)").fetchall()]
+
+
+@dataclass
+class Candidate:
+    uid: str
+    source_backup: Path
+    row: sqlite3.Row
+    program_uid: str | None  # resolved from backup's programs table
+
+
+def _resolve_program_uid(conn: sqlite3.Connection, program_id: int | None) -> str | None:
+    if not program_id:
+        return None
+    r = conn.execute(
+        "SELECT program_uid FROM programs WHERE id = ?", (program_id,)
+    ).fetchone()
+    return r["program_uid"] if r else None
+
+
+def find_missing_policies(
+    live_path: Path, backup_dir: Path, uid_filter: str | None = None
+) -> list[Candidate]:
+    live = _conn(live_path)
+    live_uids = {r[0] for r in live.execute("SELECT policy_uid FROM policies").fetchall()}
+    live.close()
+
+    backups = sorted(backup_dir.glob("policydb_*.sqlite"), reverse=True)
+    if not backups:
+        print(f"No backups found in {backup_dir}", file=sys.stderr)
+        return []
+
+    # Walk newest → oldest. First time we see a missing uid, that's the
+    # freshest copy of its data.
+    found: dict[str, Candidate] = {}
+    for b in backups:
+        try:
+            bconn = _conn(b)
+        except sqlite3.Error as e:
+            print(f"  ! could not open {b.name}: {e}", file=sys.stderr)
+            continue
+        try:
+            rows = bconn.execute("SELECT * FROM policies").fetchall()
+        except sqlite3.Error as e:
+            print(f"  ! {b.name}: schema mismatch, skipping ({e})", file=sys.stderr)
+            bconn.close()
+            continue
+        for r in rows:
+            uid = r["policy_uid"]
+            if uid in live_uids or uid in found:
+                continue
+            if uid_filter and uid != uid_filter:
+                continue
+            program_uid = _resolve_program_uid(bconn, r["program_id"])
+            found[uid] = Candidate(
+                uid=uid, source_backup=b, row=r, program_uid=program_uid
+            )
+        bconn.close()
+
+    return list(found.values())
+
+
+def _describe(c: Candidate) -> str:
+    r = c.row
+    bits = [
+        f"uid={c.uid}",
+        f"type={r['policy_type']!r}",
+        f"carrier={r['carrier']!r}",
+        f"number={r['policy_number']!r}",
+        f"limit={r['limit_amount']}",
+        f"layer={r['layer_position']!r}",
+        f"program={c.program_uid or '(none)'}",
+    ]
+    return " ".join(bits)
+
+
+def restore(candidates: list[Candidate], live_path: Path) -> tuple[int, int]:
+    """Re-INSERT each candidate. Skips if a row with that uid reappeared
+    between the scan and the write. Returns (restored, skipped)."""
+    if not candidates:
+        return 0, 0
+
+    ts = datetime.now().strftime("%Y-%m-%d_%H%M%S")
+    safety = live_path.parent / "backups" / f"policydb_{ts}_preres.sqlite"
+    safety.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(live_path, safety)
+    print(f"  Safety backup written: {safety}")
+
+    live = _conn(live_path)
+    live.execute("PRAGMA foreign_keys = OFF")  # we want to insert as-is
+    cols = _policies_columns(live)
+    restored = 0
+    skipped = 0
+    try:
+        for c in candidates:
+            exists = live.execute(
+                "SELECT 1 FROM policies WHERE policy_uid = ?", (c.uid,)
+            ).fetchone()
+            if exists:
+                print(f"  ~ {c.uid} already present in live, skipping")
+                skipped += 1
+                continue
+
+            # Resolve program_id on the LIVE db — the backup id may differ.
+            live_prog_id = None
+            if c.program_uid:
+                prow = live.execute(
+                    "SELECT id FROM programs WHERE program_uid = ?", (c.program_uid,)
+                ).fetchone()
+                live_prog_id = prow["id"] if prow else None
+
+            payload: dict[str, object] = {}
+            for col in cols:
+                if col == "id":
+                    continue  # let SQLite reuse the original id or pick a new one
+                if col == "program_id":
+                    payload[col] = live_prog_id
+                elif col in c.row.keys():
+                    payload[col] = c.row[col]
+                else:
+                    payload[col] = None
+
+            # If the original id is free, reuse it for referential stability.
+            orig_id = c.row["id"] if "id" in c.row.keys() else None
+            if orig_id is not None:
+                clash = live.execute(
+                    "SELECT 1 FROM policies WHERE id = ?", (orig_id,)
+                ).fetchone()
+                if not clash:
+                    payload = {"id": orig_id, **payload}
+
+            placeholders = ", ".join(["?"] * len(payload))
+            col_list = ", ".join(payload.keys())
+            live.execute(
+                f"INSERT INTO policies ({col_list}) VALUES ({placeholders})",
+                list(payload.values()),
+            )
+            restored += 1
+            print(f"  + restored {_describe(c)}")
+    except Exception:
+        live.rollback()
+        live.close()
+        raise
+    live.commit()
+    live.close()
+    return restored, skipped
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--live", type=Path, default=LIVE_DB, help="path to live policydb.sqlite"
+    )
+    parser.add_argument(
+        "--backups", type=Path, default=BACKUP_DIR, help="path to backups directory"
+    )
+    parser.add_argument(
+        "--uid", type=str, default=None, help="only consider this policy_uid"
+    )
+    parser.add_argument(
+        "--program",
+        type=str,
+        default=None,
+        help="only recover policies that were linked to this program_uid",
+    )
+    parser.add_argument(
+        "--restore",
+        action="store_true",
+        help="actually re-INSERT the rows (default: dry run)",
+    )
+    args = parser.parse_args()
+
+    if not args.live.exists():
+        print(f"Live DB not found: {args.live}", file=sys.stderr)
+        return 2
+    if not args.backups.exists():
+        print(f"Backups dir not found: {args.backups}", file=sys.stderr)
+        return 2
+
+    print(f"Live:    {args.live}")
+    print(f"Backups: {args.backups}")
+    print()
+
+    candidates = find_missing_policies(args.live, args.backups, uid_filter=args.uid)
+    if args.program:
+        candidates = [c for c in candidates if c.program_uid == args.program]
+
+    if not candidates:
+        print("Nothing to restore — no policy_uids in backups that are missing from live.")
+        return 0
+
+    print(f"Found {len(candidates)} policy row(s) in backups that are missing from live:")
+    for c in candidates:
+        print(f"  {_describe(c)}  ← {c.source_backup.name}")
+    print()
+
+    if not args.restore:
+        print("Dry run only. Re-run with --restore to apply.")
+        return 0
+
+    restored, skipped = restore(candidates, args.live)
+    print()
+    print(f"Done. Restored={restored}  Skipped={skipped}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/policydb/web/routes/programs.py
+++ b/src/policydb/web/routes/programs.py
@@ -1238,16 +1238,46 @@ async def reorder_underlying_v2(request: Request, program_uid: str,
     return JSONResponse({"ok": True})
 
 
+def _policy_has_real_data(row) -> bool:
+    """A program-layer row is 'real' if it has any business data beyond the
+    placeholder defaults created by + Add Underlying / + Add Excess /
+    + Add Umbrella. Real rows must be unassigned from the program on delete,
+    never dropped from the policies table."""
+    if row is None:
+        return False
+    keys = row.keys()
+    carrier = (row["carrier"] or "").strip() if "carrier" in keys else ""
+    number = (row["policy_number"] or "").strip() if "policy_number" in keys else ""
+    limit_amt = row["limit_amount"] if "limit_amount" in keys else 0
+    return bool(carrier) or bool(number) or (limit_amt and limit_amt > 0)
+
+
 @router.delete("/programs/{program_uid}/underlying/{policy_id}", response_class=HTMLResponse)
 async def delete_underlying_v2(request: Request, program_uid: str, policy_id: int,
                                conn: sqlite3.Connection = Depends(get_db)):
     pgm = _get_program_or_404(conn, program_uid)
-    conn.execute("DELETE FROM policies WHERE id = ?", (policy_id,))
+    row = conn.execute(
+        "SELECT carrier, policy_number, limit_amount FROM policies WHERE id = ?",
+        (policy_id,),
+    ).fetchone()
+    if _policy_has_real_data(row):
+        # Real pre-existing policy — unassign from the program, keep the record.
+        conn.execute(
+            "UPDATE policies SET program_id = NULL, tower_group = NULL, "
+            "layer_position = NULL, schematic_column = NULL, "
+            "updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+            (policy_id,),
+        )
+        logger.info("Unassigned underlying policy id=%s from program %s", policy_id, program_uid)
+    else:
+        # Blank placeholder created by + Add Underlying — safe to drop.
+        conn.execute("DELETE FROM policies WHERE id = ?", (policy_id,))
+        logger.info("Deleted placeholder underlying id=%s from program %s", policy_id, program_uid)
     remaining = conn.execute(
         "SELECT id FROM policies WHERE program_id = ? AND layer_position = 'Primary' AND archived = 0 ORDER BY schematic_column",
         (pgm["id"],)).fetchall()
-    for i, row in enumerate(remaining):
-        conn.execute("UPDATE policies SET schematic_column = ? WHERE id = ?", (i + 1, row["id"]))
+    for i, r in enumerate(remaining):
+        conn.execute("UPDATE policies SET schematic_column = ? WHERE id = ?", (i + 1, r["id"]))
     conn.commit()
     return HTMLResponse("")
 
@@ -1256,9 +1286,24 @@ async def delete_underlying_v2(request: Request, program_uid: str, policy_id: in
 async def delete_excess_v2(request: Request, program_uid: str, policy_id: int,
                            conn: sqlite3.Connection = Depends(get_db)):
     _get_program_or_404(conn, program_uid)
+    row = conn.execute(
+        "SELECT carrier, policy_number, limit_amount FROM policies WHERE id = ?",
+        (policy_id,),
+    ).fetchone()
+    # Tower mappings are program-scoped and go regardless of policy fate.
     conn.execute("DELETE FROM program_tower_coverage WHERE excess_policy_id = ?", (policy_id,))
     conn.execute("DELETE FROM program_tower_lines WHERE source_policy_id = ?", (policy_id,))
-    conn.execute("DELETE FROM policies WHERE id = ?", (policy_id,))
+    if _policy_has_real_data(row):
+        conn.execute(
+            "UPDATE policies SET program_id = NULL, tower_group = NULL, "
+            "layer_position = NULL, schematic_column = NULL, "
+            "updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+            (policy_id,),
+        )
+        logger.info("Unassigned excess policy id=%s from program %s", policy_id, program_uid)
+    else:
+        conn.execute("DELETE FROM policies WHERE id = ?", (policy_id,))
+        logger.info("Deleted placeholder excess id=%s from program %s", policy_id, program_uid)
     conn.commit()
     return HTMLResponse("")
 

--- a/tests/test_program_delete_row_preserves_policy.py
+++ b/tests/test_program_delete_row_preserves_policy.py
@@ -1,0 +1,194 @@
+"""Regression tests for programs tower construction delete buttons.
+
+Bug: clicking the red X on an Excess (or Underlying) row in the Schematic tab
+hard-deletes the underlying `policies` row. That's fine for blank placeholder
+rows created via `+ Add Excess` / `+ Add Underlying`, but destroys real
+pre-existing policies that were linked to the program via the `/assign` route
+(the layer picker on the Unassigned Policies panel). A user who drops an
+existing Excess policy onto a program via "+ Assign as Excess" and then later
+clicks the X on the schematic row expects the policy to be removed *from the
+program*, not wiped from the entire system.
+
+These tests drive the HTTP routes (the same path the browser takes) and assert
+that:
+
+1. Deleting a placeholder row (limit=0, no policy_number, no carrier) should
+   still hard-delete that row — backward compatibility.
+2. Deleting a real row (has policy_number OR carrier OR non-zero limit) should
+   **unassign** the policy from the program (clear `program_id` / `tower_group`
+   and `layer_position`) and leave the policy intact in the `policies` table.
+
+Both tests exist for underlying and excess delete routes.
+
+Driver bug report:
+  "I created a program with two policies (GL and Excess). I deleted the Excess
+   policy from the child policies table in the tower construction tab. However,
+   it is now not showing up anywhere in the system."
+"""
+
+import pytest
+from starlette.testclient import TestClient
+
+from policydb.db import init_db, get_connection
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.sqlite"
+    monkeypatch.setattr("policydb.db.DB_PATH", db_path)
+    monkeypatch.setattr("policydb.db.DB_DIR", tmp_path)
+    monkeypatch.setattr("policydb.db.EXPORTS_DIR", tmp_path / "exports")
+    monkeypatch.setattr("policydb.db.CONFIG_PATH", tmp_path / "config.yaml")
+    init_db(path=db_path)
+
+    conn = get_connection(db_path)
+    conn.execute(
+        "INSERT INTO clients (id, name, industry_segment) "
+        "VALUES (1, 'Acme Construction', 'Construction')"
+    )
+    conn.execute(
+        "INSERT INTO programs (id, program_uid, client_id, name, line_of_business) "
+        "VALUES (1, 'PGM-001', 1, 'Casualty', 'Casualty')"
+    )
+    # A real General Liability policy assigned to the program as Primary.
+    conn.execute(
+        """INSERT INTO policies (id, policy_uid, client_id, program_id, tower_group,
+                layer_position, policy_type, carrier, policy_number, premium,
+                limit_amount, deductible, effective_date, expiration_date,
+                renewal_status, is_opportunity, archived)
+           VALUES (10, 'POL-010', 1, 1, 'Casualty', 'Primary',
+                   'General Liability', 'Zurich', 'GL-12345', 50000,
+                   1000000, 5000, '2026-01-01', '2027-01-01',
+                   'Bound', 0, 0)"""
+    )
+    # A real Excess Liability policy assigned to the program as Excess —
+    # the policy the user is reporting on.
+    conn.execute(
+        """INSERT INTO policies (id, policy_uid, client_id, program_id, tower_group,
+                layer_position, policy_type, carrier, policy_number, premium,
+                limit_amount, attachment_point, effective_date, expiration_date,
+                renewal_status, is_opportunity, archived)
+           VALUES (11, 'POL-011', 1, 1, 'Casualty', 'Excess',
+                   'Excess Liability', 'Berkshire', 'XS-98765', 25000,
+                   10000000, 1000000, '2026-01-01', '2027-01-01',
+                   'Bound', 0, 0)"""
+    )
+    # A blank placeholder Excess row created via "+ Add Excess" in the UI —
+    # no carrier, no policy number, zero limit. Safe to hard-delete.
+    conn.execute(
+        """INSERT INTO policies (id, policy_uid, client_id, program_id, tower_group,
+                layer_position, policy_type, carrier, policy_number, premium,
+                limit_amount, attachment_point, effective_date, expiration_date,
+                renewal_status, is_opportunity, archived)
+           VALUES (12, 'POL-012', 1, 1, 'Casualty', 'Excess',
+                   'Excess Liability', '', '', 0,
+                   0, 0, NULL, NULL,
+                   'Not Started', 0, 0)"""
+    )
+    conn.commit()
+    conn.close()
+
+    from policydb.web.app import app
+    tc = TestClient(app, raise_server_exceptions=False)
+    yield tc
+
+
+def _policy_row(db_path, policy_id):
+    conn = get_connection(db_path)
+    row = conn.execute(
+        "SELECT id, policy_uid, program_id, tower_group, layer_position, "
+        "carrier, policy_number, limit_amount, archived "
+        "FROM policies WHERE id = ?",
+        (policy_id,),
+    ).fetchone()
+    conn.close()
+    return dict(row) if row else None
+
+
+# ── Excess ───────────────────────────────────────────────────────────────
+
+
+def test_delete_excess_preserves_real_policy(client, tmp_path):
+    """Deleting a real Excess policy from the schematic must unassign, not
+    hard-delete. This is the exact bug the user reported."""
+    db_path = tmp_path / "test.sqlite"
+
+    # Sanity: the real excess row starts linked to the program.
+    before = _policy_row(db_path, 11)
+    assert before is not None
+    assert before["program_id"] == 1
+    assert before["layer_position"] == "Excess"
+    assert before["carrier"] == "Berkshire"
+
+    resp = client.delete("/programs/PGM-001/excess/11")
+    assert resp.status_code == 200
+
+    after = _policy_row(db_path, 11)
+    # The policy row must still exist — we only wanted to remove it from the program.
+    assert after is not None, (
+        "Real Excess policy was hard-deleted from the database when the user "
+        "clicked the X in the schematic matrix. The delete endpoint must "
+        "unassign policies that have real data (carrier, policy_number, or "
+        "non-zero limit), not DROP them."
+    )
+    # And it should no longer be attached to the program.
+    assert after["program_id"] is None
+    assert after["tower_group"] in (None, "")
+    assert after["layer_position"] in (None, "Primary", "")
+    # Business data is preserved.
+    assert after["carrier"] == "Berkshire"
+    assert after["policy_number"] == "XS-98765"
+    assert after["limit_amount"] == 10000000
+    assert after["archived"] == 0
+
+
+def test_delete_excess_placeholder_still_hard_deletes(client, tmp_path):
+    """A blank placeholder row created by '+ Add Excess' (no carrier, no
+    policy_number, zero limit) should still be hard-deleted so the old
+    add-then-cancel workflow keeps working."""
+    db_path = tmp_path / "test.sqlite"
+
+    before = _policy_row(db_path, 12)
+    assert before is not None
+    assert before["carrier"] in (None, "")
+    assert before["policy_number"] in (None, "")
+    assert before["limit_amount"] in (None, 0)
+
+    resp = client.delete("/programs/PGM-001/excess/12")
+    assert resp.status_code == 200
+
+    after = _policy_row(db_path, 12)
+    assert after is None, (
+        "Placeholder rows (no carrier/number/limit) should still be hard-"
+        "deleted so '+ Add Excess' followed by X remains a no-op."
+    )
+
+
+# ── Underlying ───────────────────────────────────────────────────────────
+
+
+def test_delete_underlying_preserves_real_policy(client, tmp_path):
+    """Same bug lives in delete_underlying_v2. Deleting the GL row from the
+    underlying matrix must unassign it, not wipe it."""
+    db_path = tmp_path / "test.sqlite"
+
+    before = _policy_row(db_path, 10)
+    assert before is not None
+    assert before["program_id"] == 1
+    assert before["carrier"] == "Zurich"
+
+    resp = client.delete("/programs/PGM-001/underlying/10")
+    assert resp.status_code == 200
+
+    after = _policy_row(db_path, 10)
+    assert after is not None, (
+        "Real underlying policy was hard-deleted from the database when the "
+        "user clicked the X in the schematic underlying matrix. The delete "
+        "endpoint must unassign policies with real data, not DROP them."
+    )
+    assert after["program_id"] is None
+    assert after["tower_group"] in (None, "")
+    assert after["carrier"] == "Zurich"
+    assert after["policy_number"] == "GL-12345"
+    assert after["limit_amount"] == 1000000
+    assert after["archived"] == 0


### PR DESCRIPTION
## Summary
- Guard `delete_underlying_v2` and `delete_excess_v2` in `src/policydb/web/routes/programs.py` so they only hard-delete blank placeholder rows (no carrier / no policy number / zero limit). Rows with any real business data are unassigned from the program instead (`program_id` / `tower_group` / `layer_position` cleared).
- Add `tests/test_program_delete_row_preserves_policy.py` (3 tests) that drive the HTTP DELETE routes end-to-end with a TestClient and lock in the correct behavior for real, placeholder, and underlying cases.
- Add `scripts/recover_deleted_program_policies.py` — a standalone recovery tool that walks `~/.policydb/backups/` newest→oldest, finds policies present in backups but missing from live, and re-INSERTs them with `--restore` (safety backup taken first).

## Root cause
Before PR #224, the tower matrices could only contain placeholder rows created via `+ Add Underlying` / `+ Add Excess` — rows that started completely blank. A hard `DELETE FROM policies WHERE id = ?` in the delete routes was a safe "undo" for those. #224 shipped the layer picker on the Unassigned Policies panel, which lets users link a **real** existing policy onto the Umbrella/Excess slot. The delete routes never learned that distinction, so clicking the red X on a real Excess row was silently dropping it from the `policies` table.

User report:
> "I created a program with two policies (GL and Excess). I deleted the Excess policy from the child policies table in the tower construction tab. However, it is now not showing up anywhere in the system."

## Test plan
- [x] `pytest tests/test_program_delete_row_preserves_policy.py` — 3 passed
  - `test_delete_excess_preserves_real_policy` — real Berkshire Excess policy gets unassigned, not dropped
  - `test_delete_excess_placeholder_still_hard_deletes` — blank placeholder still goes away
  - `test_delete_underlying_preserves_real_policy` — same guard for the Underlying matrix
- [x] `pytest tests/test_programs_v2.py tests/test_program_delete_row_preserves_policy.py` — 39 passed (no regressions in the adjacent program test suite)
- [x] `scripts/recover_deleted_program_policies.py` dry-runs cleanly against a local DB with backups
- [ ] Visual QA in Chrome — assign an existing policy as Excess, click X, confirm the policy still exists in the client's schedule and can be re-assigned

## Recovery
For data already destroyed on a production machine:
```
python scripts/recover_deleted_program_policies.py                       # dry run, show what's recoverable
python scripts/recover_deleted_program_policies.py --restore             # actually restore (takes safety backup first)
python scripts/recover_deleted_program_policies.py --uid POL-042         # only one policy
python scripts/recover_deleted_program_policies.py --restore --program PGM-001  # scope to one program
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)