### PR TITLE
fix(programs): clearing currency cells like attachment_point sticks

### DIFF
--- a/src/policydb/web/routes/programs.py
+++ b/src/policydb/web/routes/programs.py
@@ -1007,12 +1007,23 @@ _EXCESS_ALLOWED = {"policy_type", "carrier", "policy_number", "limit_amount",
 
 
 def _parse_and_format_currency(raw: str):
-    """Parse currency input, return (db_value, formatted, error)."""
+    """Parse currency input, return (db_value, formatted, error).
+
+    Empty/whitespace input and parsed zero both return an EMPTY display
+    string so the row templates' `{% if value %}` guards stay consistent
+    with what the JS writes back into the cell. Returning "$0" here
+    caused a sticky-zero bug on fields like attachment_point: the cell
+    would display "$0" after clearing, `data-original` would cache "$0"
+    on the next focus, and subsequent clears would keep round-tripping
+    back to "$0" — the field felt unclearable.
+    """
     if not raw or not str(raw).strip():
-        return 0, "$0", None
+        return 0, "", None
     val = parse_currency_with_magnitude(str(raw).strip())
     if val is None:
         return None, None, f"Could not parse '{raw}'"
+    if val == 0:
+        return 0, "", None
     formatted = f"${val:,.0f}" if val == int(val) else f"${val:,.2f}"
     return val, formatted, None
 

--- a/src/policydb/web/templates/base.html
+++ b/src/policydb/web/templates/base.html
@@ -445,7 +445,11 @@
         var rowId = getRowId(row);
         var field = cell.dataset.field;
         saveCell(rowId, field, newVal, function(data) {
-          if (data.ok && data.formatted) {
+          // Check for 'formatted' key explicitly — an empty string is a
+          // valid "clear the cell" signal (e.g. a currency field parsed
+          // to zero). Using truthiness would skip that update and let a
+          // stale "$0" or user-typed value linger in the cell.
+          if (data.ok && data.formatted !== undefined && data.formatted !== null) {
             cell.textContent = data.formatted;
             if (data.formatted !== newVal) flashCell(cell);
           }

--- a/tests/test_program_cell_patch_clear_currency.py
+++ b/tests/test_program_cell_patch_clear_currency.py
@@ -1,0 +1,178 @@
+"""Regression tests for clearing currency fields via the program cell PATCH
+routes (patch_underlying_cell_v2 / patch_excess_cell_v2 / patch_child_cell).
+
+Bug: sending an empty value for a currency field like attachment_point
+used to make the handler return `{"formatted": "$0"}`. The `initMatrix`
+focusout callback then wrote "$0" into the cell, and on the next focus
+the cell's `data-original` cached "$0", so subsequent clears round-
+tripped back to "$0" forever. Users reported they "couldn't clear
+attachment_point to make a policy primary."
+
+Fix: `_parse_and_format_currency` now returns an empty display string
+for empty/whitespace input AND for parsed zero. The DB still gets 0 so
+template `{% if value %}` guards hide the cell on reload. Paired with a
+base.html tweak that accepts `formatted == ""` as a legitimate "blank
+this cell out" signal.
+"""
+
+import pytest
+from starlette.testclient import TestClient
+
+from policydb.db import init_db, get_connection
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.sqlite"
+    monkeypatch.setattr("policydb.db.DB_PATH", db_path)
+    monkeypatch.setattr("policydb.db.DB_DIR", tmp_path)
+    monkeypatch.setattr("policydb.db.EXPORTS_DIR", tmp_path / "exports")
+    monkeypatch.setattr("policydb.db.CONFIG_PATH", tmp_path / "config.yaml")
+    init_db(path=db_path)
+
+    conn = get_connection(db_path)
+    conn.execute(
+        "INSERT INTO clients (id, name, industry_segment) "
+        "VALUES (1, 'Acme Construction', 'Construction')"
+    )
+    conn.execute(
+        "INSERT INTO programs (id, program_uid, client_id, name, line_of_business) "
+        "VALUES (1, 'PGM-001', 1, 'Casualty', 'Casualty')"
+    )
+    # Excess policy with $5M attachment — this is the one we'll try to clear.
+    conn.execute(
+        """INSERT INTO policies (id, policy_uid, client_id, program_id, tower_group,
+                layer_position, policy_type, carrier, policy_number, premium,
+                limit_amount, attachment_point, effective_date, expiration_date,
+                renewal_status, is_opportunity, archived)
+           VALUES (20, 'POL-020', 1, 1, 'Casualty', 'Excess',
+                   'Excess Liability', 'Berkshire', 'XS-20', 25000,
+                   10000000, 5000000, '2026-01-01', '2027-01-01',
+                   'Bound', 0, 0)"""
+    )
+    conn.commit()
+    conn.close()
+
+    from policydb.web.app import app
+    tc = TestClient(app, raise_server_exceptions=False)
+    yield tc
+
+
+def _attachment(db_path, policy_id):
+    conn = get_connection(db_path)
+    row = conn.execute(
+        "SELECT attachment_point, layer_position FROM policies WHERE id = ?",
+        (policy_id,),
+    ).fetchone()
+    conn.close()
+    return dict(row) if row else None
+
+
+# ── child cell PATCH (Overview tab grid) ─────────────────────────────────
+
+
+def test_child_cell_clear_attachment_point_empty_string(client, tmp_path):
+    db_path = tmp_path / "test.sqlite"
+    assert _attachment(db_path, 20)["attachment_point"] == 5000000
+
+    resp = client.patch(
+        "/programs/PGM-001/child/20/cell",
+        json={"field": "attachment_point", "value": ""},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    # Display must be empty — the row template hides zero via {% if %} and
+    # the JS must not write "$0" into the cell on the user's screen.
+    assert body["formatted"] == "", (
+        f"Clearing attachment_point returned {body['formatted']!r} instead "
+        "of an empty string. A non-empty 'formatted' makes the cell sticky: "
+        "the user's blank input gets replaced with '$0' and the next clear "
+        "round-trips back to '$0' because data-original is now '$0'."
+    )
+    # DB is zeroed.
+    assert _attachment(db_path, 20)["attachment_point"] == 0
+
+
+def test_child_cell_clear_attachment_point_explicit_zero(client, tmp_path):
+    """Typing '0' or '$0' should be treated exactly like clearing."""
+    db_path = tmp_path / "test.sqlite"
+
+    for raw in ("0", "$0", "$0.00", " "):
+        resp = client.patch(
+            "/programs/PGM-001/child/20/cell",
+            json={"field": "attachment_point", "value": raw},
+        )
+        assert resp.status_code == 200, f"PATCH failed for {raw!r}"
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["formatted"] == "", (
+            f"Input {raw!r} returned {body['formatted']!r} instead of ''."
+        )
+        assert _attachment(db_path, 20)["attachment_point"] == 0
+
+
+def test_child_cell_set_attachment_point_still_formats(client, tmp_path):
+    """Non-zero values should still come back pretty-formatted."""
+    db_path = tmp_path / "test.sqlite"
+    resp = client.patch(
+        "/programs/PGM-001/child/20/cell",
+        json={"field": "attachment_point", "value": "5M"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["formatted"] == "$5,000,000"
+    assert _attachment(db_path, 20)["attachment_point"] == 5000000
+
+
+# ── excess matrix PATCH (Schematic tab) ──────────────────────────────────
+
+
+def test_excess_cell_clear_attachment_point(client, tmp_path):
+    db_path = tmp_path / "test.sqlite"
+    resp = client.patch(
+        "/programs/PGM-001/excess/20/cell",
+        json={"field": "attachment_point", "value": ""},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["formatted"] == ""
+    # The excess route also returns the recomputed layer notation.
+    assert "notation" in body
+    assert _attachment(db_path, 20)["attachment_point"] == 0
+
+
+# ── underlying matrix PATCH (symmetry check) ─────────────────────────────
+
+
+def test_underlying_cell_clear_currency_field(client, tmp_path):
+    """Same fix applies to premium/deductible on the underlying matrix."""
+    db_path = tmp_path / "test.sqlite"
+    conn = get_connection(db_path)
+    conn.execute(
+        """INSERT INTO policies (id, policy_uid, client_id, program_id, tower_group,
+                layer_position, policy_type, carrier, policy_number, premium,
+                limit_amount, deductible, effective_date, expiration_date,
+                renewal_status, is_opportunity, archived)
+           VALUES (21, 'POL-021', 1, 1, 'Casualty', 'Primary',
+                   'General Liability', 'Zurich', 'GL-21', 50000,
+                   1000000, 5000, '2026-01-01', '2027-01-01',
+                   'Bound', 0, 0)"""
+    )
+    conn.commit()
+    conn.close()
+
+    resp = client.patch(
+        "/programs/PGM-001/underlying/21/cell",
+        json={"field": "deductible", "value": ""},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["formatted"] == ""
+    conn = get_connection(db_path)
+    val = conn.execute("SELECT deductible FROM policies WHERE id = 21").fetchone()[0]
+    conn.close()
+    assert val == 0


### PR DESCRIPTION
## Summary
- `_parse_and_format_currency` returns an **empty** display string for empty-or-whitespace input AND for parsed zero. DB still gets `0` so row templates' `{% if value %}` guards hide the cell on reload.
- `initMatrix` focusout callback in `base.html` now treats `formatted === ""` as a valid "blank this cell" signal instead of skipping the update because `""` is falsy.

## Root cause
Before this change, clearing an attachment_point cell sent `{"value": ""}` → the handler returned `{"formatted": "$0"}` → the JS wrote `"$0"` into the cell → `data-original` was re-cached as `"$0"` on next focus → the next clear round-tripped back to `"$0"` again. The field felt unclearable and users couldn't demote an excess policy to primary.

## Test plan
- [x] `pytest tests/test_program_cell_patch_clear_currency.py` — 5 passed
  - child cell: clear via empty string returns `formatted=""`, DB `attachment_point=0`
  - child cell: `"0"`, `"$0"`, `"$0.00"`, `" "` all treated the same way
  - child cell: `"5M"` still returns `"$5,000,000"` (non-zero path unchanged)
  - excess matrix: same clear semantics, plus recomputed notation in response
  - underlying matrix: same fix applies to deductible/premium
- [x] `pytest tests/test_program_delete_row_preserves_policy.py tests/test_programs_v2.py` — 39 passed (no regression in adjacent program tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)