### PR TITLE
feat(programs): derive program term from child policies

### DIFF
--- a/src/policydb/queries.py
+++ b/src/policydb/queries.py
@@ -1268,6 +1268,12 @@ def get_open_tasks(
     """
     if scope_type == "issue":
         return _open_tasks_for_issue(conn, scope_id)
+    if scope_type == "client":
+        return _open_tasks_for_client(conn, scope_id)
+    if scope_type == "program":
+        return _open_tasks_for_program(conn, scope_id)
+    if scope_type == "policy":
+        return _open_tasks_for_policy(conn, scope_id)
     raise ValueError(f"Unsupported scope_type: {scope_type}")
 
 
@@ -1361,6 +1367,360 @@ def _open_tasks_for_issue(conn, issue_id: int) -> dict:
             "rows": _sort_rows(loose_rows),
         })
 
+    return {"groups": groups, "total": total, "overdue": overdue, "waiting": waiting}
+
+
+def _open_tasks_for_client(conn, client_id: int) -> dict:
+    # 1. Find all open issues touching this client (direct client_id OR via
+    #    policies belonging to the client through v_issue_policy_coverage).
+    open_issues = conn.execute(
+        """SELECT DISTINCT a.id AS issue_id, a.issue_uid, a.subject, a.issue_severity,
+                  a.issue_status
+           FROM activity_log a
+           WHERE a.item_kind = 'issue'
+             AND a.issue_status NOT IN ('Resolved', 'Closed', 'Merged')
+             AND a.merged_into_id IS NULL
+             AND (a.client_id = ? OR a.id IN (
+                 SELECT DISTINCT ipc.issue_id
+                 FROM v_issue_policy_coverage ipc
+                 JOIN policies p ON p.id = ipc.policy_id
+                 WHERE p.client_id = ? AND p.archived = 0
+             ))
+           ORDER BY
+             CASE a.issue_severity
+               WHEN 'Critical' THEN 0
+               WHEN 'High' THEN 1
+               WHEN 'Normal' THEN 2
+               WHEN 'Low' THEN 3
+               ELSE 4 END,
+             a.id""",
+        (client_id, client_id),
+    ).fetchall()
+    issue_ids = [r["issue_id"] for r in open_issues]
+
+    # 2. Policies covered by any open issue (for loose_policies exclusion)
+    covered_policy_ids: set[int] = set()
+    if issue_ids:
+        placeholders = ",".join("?" * len(issue_ids))
+        cov = conn.execute(
+            f"""SELECT DISTINCT policy_id FROM v_issue_policy_coverage
+                WHERE issue_id IN ({placeholders})""",  # noqa: S608
+            issue_ids,
+        ).fetchall()
+        covered_policy_ids = {r["policy_id"] for r in cov if r["policy_id"] is not None}
+
+    total = 0
+    overdue = 0
+    waiting = 0
+
+    def _count(row):
+        nonlocal total, overdue, waiting
+        total += 1
+        if row["days_overdue"] > 0:
+            overdue += 1
+        if row["accountability"] == "waiting_external":
+            waiting += 1
+
+    # ── Group 1: direct_client
+    direct_rows: list[dict] = []
+    for r in conn.execute(
+        """SELECT a.id, a.subject, a.activity_type, a.follow_up_date,
+                  a.disposition, a.policy_id, a.client_id, a.issue_id,
+                  c.name AS client_name
+           FROM activity_log a
+           JOIN clients c ON c.id = a.client_id
+           WHERE a.client_id = ?
+             AND a.policy_id IS NULL
+             AND a.follow_up_done = 0
+             AND a.follow_up_date IS NOT NULL
+             AND (a.item_kind = 'followup' OR a.item_kind IS NULL)""",
+        (client_id,),
+    ).fetchall():
+        row = _open_task_row_from_activity(r)
+        direct_rows.append(row)
+        _count(row)
+
+    # clients.follow_up_date itself (synthetic row, source="client")
+    client_row = conn.execute(
+        "SELECT id, name, follow_up_date FROM clients WHERE id = ?", (client_id,)
+    ).fetchone()
+    if client_row and client_row["follow_up_date"]:
+        from datetime import date as _date
+        fu = client_row["follow_up_date"]
+        try:
+            days_od = (_date.today() - _date.fromisoformat(fu)).days
+        except (ValueError, TypeError):
+            days_od = 0
+        synth = {
+            "activity_id": f"C{client_row['id']}",
+            "subject": "Client-level follow-up",
+            "activity_type": None,
+            "follow_up_date": fu,
+            "days_overdue": days_od,
+            "disposition": "",
+            "accountability": "my_action",
+            "policy_id": None,
+            "policy_uid": None,
+            "policy_type": None,
+            "client_id": client_row["id"],
+            "client_name": client_row["name"],
+            "source": "client",
+            "is_on_issue": False,
+            "linked_to_other_issue": None,
+            "attach_target_issue_id": None,
+        }
+        direct_rows.append(synth)
+        _count(synth)
+
+    # ── Group 2..N: per open issue
+    issue_groups: list[dict] = []
+    for iss in open_issues:
+        iss_id = iss["issue_id"]
+        iss_rows: list[dict] = []
+        for r in conn.execute(
+            """SELECT a.id, a.subject, a.activity_type, a.follow_up_date,
+                      a.disposition, a.policy_id, a.client_id, a.issue_id,
+                      p.policy_uid, p.policy_type,
+                      c.name AS client_name
+               FROM activity_log a
+               LEFT JOIN policies p ON p.id = a.policy_id
+               LEFT JOIN clients c ON c.id = a.client_id
+               WHERE a.issue_id = ?
+                 AND a.follow_up_done = 0
+                 AND a.follow_up_date IS NOT NULL
+                 AND (a.item_kind = 'followup' OR a.item_kind IS NULL)""",
+            (iss_id,),
+        ).fetchall():
+            row = _open_task_row_from_activity(r)
+            row["is_on_issue"] = True
+            iss_rows.append(row)
+            _count(row)
+        if iss_rows:
+            issue_groups.append({
+                "key": f"issue:{iss_id}",
+                "title": f"On {iss['issue_uid']}",
+                "subtitle": iss["subject"],
+                "rows": _sort_rows(iss_rows),
+            })
+
+    # ── Group last: loose_policies
+    loose_rows: list[dict] = []
+    client_policy_ids = [
+        r["id"] for r in conn.execute(
+            "SELECT id FROM policies WHERE client_id = ? AND archived = 0",
+            (client_id,),
+        ).fetchall()
+    ]
+    uncovered = [pid for pid in client_policy_ids if pid not in covered_policy_ids]
+    if uncovered:
+        ph = ",".join("?" * len(uncovered))
+        for r in conn.execute(
+            f"""SELECT a.id, a.subject, a.activity_type, a.follow_up_date,
+                       a.disposition, a.policy_id, a.client_id, a.issue_id,
+                       p.policy_uid, p.policy_type,
+                       c.name AS client_name
+                FROM activity_log a
+                JOIN policies p ON p.id = a.policy_id
+                LEFT JOIN clients c ON c.id = a.client_id
+                WHERE a.policy_id IN ({ph})
+                  AND a.follow_up_done = 0
+                  AND a.follow_up_date IS NOT NULL
+                  AND (a.item_kind = 'followup' OR a.item_kind IS NULL)""",  # noqa: S608
+            uncovered,
+        ).fetchall():
+            row = _open_task_row_from_activity(r)
+            # Resolve attach target: policy's open renewal issue (if exactly one)
+            target = conn.execute(
+                """SELECT id FROM activity_log
+                   WHERE item_kind = 'issue'
+                     AND policy_id = ?
+                     AND issue_status NOT IN ('Resolved', 'Closed', 'Merged')
+                     AND merged_into_id IS NULL""",
+                (row["policy_id"],),
+            ).fetchall()
+            if len(target) == 1:
+                row["attach_target_issue_id"] = target[0]["id"]
+            loose_rows.append(row)
+            _count(row)
+
+    groups = []
+    if direct_rows:
+        groups.append({
+            "key": "direct_client",
+            "title": "Direct client follow-ups",
+            "subtitle": None,
+            "rows": _sort_rows(direct_rows),
+        })
+    groups.extend(issue_groups)
+    if loose_rows:
+        groups.append({
+            "key": "loose_policies",
+            "title": "Loose on other policies",
+            "subtitle": "Not covered by any open issue",
+            "rows": _sort_rows(loose_rows),
+        })
+
+    return {"groups": groups, "total": total, "overdue": overdue, "waiting": waiting}
+
+
+def _open_tasks_for_program(conn, program_id: int) -> dict:
+    open_issues = conn.execute(
+        """SELECT id AS issue_id, issue_uid, subject
+           FROM activity_log
+           WHERE item_kind = 'issue'
+             AND program_id = ?
+             AND issue_status NOT IN ('Resolved', 'Closed', 'Merged')
+             AND merged_into_id IS NULL""",
+        (program_id,),
+    ).fetchall()
+    issue_ids = [r["issue_id"] for r in open_issues]
+
+    child_policies = conn.execute(
+        "SELECT id FROM policies WHERE program_id = ? AND archived = 0",
+        (program_id,),
+    ).fetchall()
+    child_policy_ids = [r["id"] for r in child_policies]
+
+    total = 0
+    overdue = 0
+    waiting = 0
+
+    def _count(row):
+        nonlocal total, overdue, waiting
+        total += 1
+        if row["days_overdue"] > 0:
+            overdue += 1
+        if row["accountability"] == "waiting_external":
+            waiting += 1
+
+    # Group 1: on_program_issue
+    on_issue_rows: list[dict] = []
+    if issue_ids:
+        ph = ",".join("?" * len(issue_ids))
+        for r in conn.execute(
+            f"""SELECT a.id, a.subject, a.activity_type, a.follow_up_date,
+                       a.disposition, a.policy_id, a.client_id, a.issue_id,
+                       p.policy_uid, p.policy_type,
+                       c.name AS client_name
+                FROM activity_log a
+                LEFT JOIN policies p ON p.id = a.policy_id
+                LEFT JOIN clients c ON c.id = a.client_id
+                WHERE a.issue_id IN ({ph})
+                  AND a.follow_up_done = 0
+                  AND a.follow_up_date IS NOT NULL
+                  AND (a.item_kind = 'followup' OR a.item_kind IS NULL)""",  # noqa: S608
+            issue_ids,
+        ).fetchall():
+            row = _open_task_row_from_activity(r)
+            row["is_on_issue"] = True
+            on_issue_rows.append(row)
+            _count(row)
+
+    # Group 2: loose on child policies
+    loose_rows: list[dict] = []
+    if child_policy_ids:
+        ph = ",".join("?" * len(child_policy_ids))
+        params: list = list(child_policy_ids)
+        if issue_ids:
+            iph = ",".join("?" * len(issue_ids))
+            exclude_clause = f" AND (a.issue_id IS NULL OR a.issue_id NOT IN ({iph}))"
+            params.extend(issue_ids)
+        else:
+            exclude_clause = " AND a.issue_id IS NULL"
+        for r in conn.execute(
+            f"""SELECT a.id, a.subject, a.activity_type, a.follow_up_date,
+                       a.disposition, a.policy_id, a.client_id, a.issue_id,
+                       p.policy_uid, p.policy_type,
+                       c.name AS client_name,
+                       other.issue_uid AS other_issue_uid
+                FROM activity_log a
+                JOIN policies p ON p.id = a.policy_id
+                LEFT JOIN clients c ON c.id = a.client_id
+                LEFT JOIN activity_log other ON other.id = a.issue_id AND other.item_kind = 'issue'
+                WHERE a.policy_id IN ({ph})
+                  AND a.follow_up_done = 0
+                  AND a.follow_up_date IS NOT NULL
+                  AND (a.item_kind = 'followup' OR a.item_kind IS NULL){exclude_clause}""",  # noqa: S608
+            params,
+        ).fetchall():
+            row = _open_task_row_from_activity(r)
+            row["linked_to_other_issue"] = r["other_issue_uid"]
+            if issue_ids and not row["linked_to_other_issue"]:
+                row["attach_target_issue_id"] = issue_ids[0] if len(issue_ids) == 1 else None
+            loose_rows.append(row)
+            _count(row)
+
+    groups = []
+    if on_issue_rows:
+        groups.append({
+            "key": "on_program_issue",
+            "title": "On program issue",
+            "subtitle": None,
+            "rows": _sort_rows(on_issue_rows),
+        })
+    if loose_rows:
+        groups.append({
+            "key": "loose",
+            "title": "Loose on child policies",
+            "subtitle": None,
+            "rows": _sort_rows(loose_rows),
+        })
+
+    return {"groups": groups, "total": total, "overdue": overdue, "waiting": waiting}
+
+
+def _open_tasks_for_policy(conn, policy_id: int) -> dict:
+    rows: list[dict] = []
+    total = 0
+    overdue = 0
+    waiting = 0
+
+    for r in conn.execute(
+        """SELECT a.id, a.subject, a.activity_type, a.follow_up_date,
+                  a.disposition, a.policy_id, a.client_id, a.issue_id,
+                  p.policy_uid, p.policy_type,
+                  c.name AS client_name,
+                  other.issue_uid AS other_issue_uid
+           FROM activity_log a
+           JOIN policies p ON p.id = a.policy_id
+           LEFT JOIN clients c ON c.id = a.client_id
+           LEFT JOIN activity_log other ON other.id = a.issue_id AND other.item_kind = 'issue'
+           WHERE a.policy_id = ?
+             AND a.follow_up_done = 0
+             AND a.follow_up_date IS NOT NULL
+             AND (a.item_kind = 'followup' OR a.item_kind IS NULL)""",
+        (policy_id,),
+    ).fetchall():
+        row = _open_task_row_from_activity(r)
+        row["linked_to_other_issue"] = r["other_issue_uid"]
+
+        # Attach target: policy's single open renewal issue if unique
+        tgt = conn.execute(
+            """SELECT id FROM activity_log
+               WHERE item_kind = 'issue'
+                 AND policy_id = ?
+                 AND issue_status NOT IN ('Resolved', 'Closed', 'Merged')
+                 AND merged_into_id IS NULL""",
+            (policy_id,),
+        ).fetchall()
+        if len(tgt) == 1:
+            row["attach_target_issue_id"] = tgt[0]["id"]
+
+        rows.append(row)
+        total += 1
+        if row["days_overdue"] > 0:
+            overdue += 1
+        if row["accountability"] == "waiting_external":
+            waiting += 1
+
+    groups = []
+    if rows:
+        groups.append({
+            "key": "on_policy",
+            "title": "Open tasks on this policy",
+            "subtitle": None,
+            "rows": _sort_rows(rows),
+        })
     return {"groups": groups, "total": total, "overdue": overdue, "waiting": waiting}
 
 
@@ -4050,7 +4410,14 @@ def auto_generate_sub_coverages(conn, policy_id: int, policy_type: str):
 
 
 def get_program_by_uid(conn: sqlite3.Connection, program_uid: str) -> dict | None:
-    """Return a program dict by its UID, or None if not found."""
+    """Return a program dict by its UID, or None if not found.
+
+    Program dates are derived on read: `effective_date` and `expiration_date`
+    come from MIN/MAX of the child policies (excluding archived and opportunity
+    rows), not from the stale columns on the programs row itself. This
+    enforces the Touch Once rule — the children own the term, the program
+    reflects it.
+    """
     row = conn.execute(
         """SELECT pg.*, pr.name AS project_name,
                   pr.address AS project_address, pr.city AS project_city,
@@ -4060,7 +4427,20 @@ def get_program_by_uid(conn: sqlite3.Connection, program_uid: str) -> dict | Non
            WHERE pg.program_uid = ?""",
         (program_uid,),
     ).fetchone()
-    return dict(row) if row else None
+    if not row:
+        return None
+    pgm = dict(row)
+    dates = conn.execute(
+        """SELECT MIN(effective_date) AS effective_date,
+                  MAX(expiration_date) AS expiration_date
+           FROM policies
+           WHERE program_id = ? AND archived = 0
+             AND (is_opportunity = 0 OR is_opportunity IS NULL)""",
+        (pgm["id"],),
+    ).fetchone()
+    pgm["effective_date"] = dates["effective_date"] if dates else None
+    pgm["expiration_date"] = dates["expiration_date"] if dates else None
+    return pgm
 
 
 def get_program_child_policies(conn: sqlite3.Connection, program_id: int) -> list[dict]:
@@ -4082,19 +4462,31 @@ def get_program_child_policies(conn: sqlite3.Connection, program_id: int) -> lis
 
 
 def get_program_aggregates(conn: sqlite3.Connection, program_id: int) -> dict:
-    """Compute aggregate stats for a program from its child policies."""
+    """Compute aggregate stats for a program from its child policies.
+
+    A program's term is derived from its children (earliest effective,
+    latest expiration), not stored as source of truth on `programs`.
+    The returned `effective_date` and `expiration_date` keys are meant
+    to be merged into the program dict by callers so templates and
+    route handlers always see the derived values. When a program has
+    no non-archived non-opportunity children, both dates come back as
+    None.
+    """
     row = conn.execute(
         """SELECT COUNT(*) AS policy_count,
                   COUNT(DISTINCT carrier) AS carrier_count,
                   COALESCE(SUM(premium), 0) AS total_premium,
-                  COALESCE(MAX(limit_amount), 0) AS max_limit
+                  COALESCE(MAX(limit_amount), 0) AS max_limit,
+                  MIN(effective_date) AS effective_date,
+                  MAX(expiration_date) AS expiration_date
            FROM policies
            WHERE program_id = ? AND archived = 0
              AND (is_opportunity = 0 OR is_opportunity IS NULL)""",
         (program_id,),
     ).fetchone()
     return dict(row) if row else {
-        "policy_count": 0, "carrier_count": 0, "total_premium": 0, "max_limit": 0
+        "policy_count": 0, "carrier_count": 0, "total_premium": 0,
+        "max_limit": 0, "effective_date": None, "expiration_date": None,
     }
 
 

--- a/src/policydb/renewal_issues.py
+++ b/src/policydb/renewal_issues.py
@@ -146,18 +146,31 @@ def ensure_renewal_issues(conn, policy_uid: str | None = None) -> None:
         )
 
     # ── Programs ─────────────────────────────────────────────────────
+    # Program expiration is derived from the latest child-policy expiration
+    # (programs no longer own the term). Both the SELECT and the WHERE
+    # window go through the same subquery to stay consistent.
     if not policy_uid:
         program_rows = conn.execute("""
-            SELECT pg.id, pg.program_uid, pg.expiration_date, pg.line_of_business,
+            SELECT pg.id, pg.program_uid,
+                   (SELECT MAX(p.expiration_date) FROM policies p
+                    WHERE p.program_id = pg.id AND p.archived = 0
+                      AND (p.is_opportunity = 0 OR p.is_opportunity IS NULL)) AS expiration_date,
+                   pg.line_of_business,
                    pg.name AS program_name, c.name AS client_name, pg.client_id,
                    pr.name AS location_name
             FROM programs pg
             JOIN clients c ON c.id = pg.client_id
             LEFT JOIN projects pr ON pr.id = pg.project_id
             WHERE (pg.archived = 0 OR pg.archived IS NULL)
-              AND pg.expiration_date IS NOT NULL
-              AND pg.expiration_date >= ?
-              AND pg.expiration_date <= ?
+              AND (SELECT MAX(p.expiration_date) FROM policies p
+                   WHERE p.program_id = pg.id AND p.archived = 0
+                     AND (p.is_opportunity = 0 OR p.is_opportunity IS NULL)) IS NOT NULL
+              AND (SELECT MAX(p.expiration_date) FROM policies p
+                   WHERE p.program_id = pg.id AND p.archived = 0
+                     AND (p.is_opportunity = 0 OR p.is_opportunity IS NULL)) >= ?
+              AND (SELECT MAX(p.expiration_date) FROM policies p
+                   WHERE p.program_id = pg.id AND p.archived = 0
+                     AND (p.is_opportunity = 0 OR p.is_opportunity IS NULL)) <= ?
         """, (today.isoformat(), horizon.isoformat())).fetchall()
 
         for pgm in program_rows:
@@ -555,10 +568,13 @@ def refresh_renewal_titles(conn) -> int:
             )
             updated += 1
 
-    # Program renewal issues
+    # Program renewal issues — expiration derived from child policies.
     program_issues = conn.execute("""
         SELECT a.id, a.subject, a.renewal_term_key, a.program_id,
-               pg.expiration_date, pg.line_of_business, pg.name AS program_name,
+               (SELECT MAX(p.expiration_date) FROM policies p
+                WHERE p.program_id = pg.id AND p.archived = 0
+                  AND (p.is_opportunity = 0 OR p.is_opportunity IS NULL)) AS expiration_date,
+               pg.line_of_business, pg.name AS program_name,
                c.name AS client_name, pr.name AS location_name
         FROM activity_log a
         JOIN programs pg ON pg.id = a.program_id

--- a/src/policydb/web/routes/issues.py
+++ b/src/policydb/web/routes/issues.py
@@ -13,8 +13,10 @@ import policydb.config as cfg
 from policydb.db import generate_issue_uid
 from policydb.queries import (
     auto_close_followups,
+    filter_thread_for_history,
     get_issue_rollup,
     get_linked_policies_for_issue,
+    get_open_tasks,
     get_scoped_rfi_bundles,
 )
 from policydb.utils import round_duration
@@ -560,9 +562,14 @@ def search_issue_policies(issue_id: int, q: str = Query(""), conn=Depends(get_db
     results = []
 
     # ── Programs matching the search ──
+    # expiration_date is derived from child policies (programs no longer
+    # own the term) — see get_program_by_uid for the canonical helper.
     prog_rows = conn.execute("""
         SELECT pg.id, pg.program_uid, pg.name, pg.line_of_business,
-               pg.expiration_date, pg.renewal_status,
+               (SELECT MAX(p2.expiration_date) FROM policies p2
+                WHERE p2.program_id = pg.id AND p2.archived = 0
+                  AND (p2.is_opportunity = 0 OR p2.is_opportunity IS NULL)) AS expiration_date,
+               pg.renewal_status,
                (SELECT COUNT(*) FROM policies p2
                 WHERE p2.program_id = pg.id AND p2.archived = 0) AS policy_count
         FROM programs pg
@@ -798,14 +805,15 @@ def issue_detail(
                 merged_into_issue = dict(row)
                 break
 
-    # Get linked activities (threaded into this issue)
-    activities = [dict(r) for r in conn.execute("""
+    # Get linked activities (threaded into this issue) — filter out open
+    # follow-ups owned by the Open Tasks panel to avoid duplicate display.
+    activities = filter_thread_for_history([dict(r) for r in conn.execute("""
         SELECT a.*, c.name AS contact_name
         FROM activity_log a
         LEFT JOIN contacts c ON c.id = a.contact_id
         WHERE a.issue_id = ?
         ORDER BY a.activity_date DESC, a.created_at DESC
-    """, (issue_id,)).fetchall()]
+    """, (issue_id,)).fetchall()])
 
     # Compute total hours across all linked activities
     total_hours = sum(a.get("duration_hours") or 0 for a in activities)
@@ -873,6 +881,8 @@ def issue_detail(
                 _bind_tokens.append(f"policy:{pol_uid}")
     bind_subjects_csv = ",".join(_bind_tokens)
 
+    open_tasks_data = get_open_tasks(conn, "issue", issue_id)
+
     ctx = {
         "request": request,
         "active": "action-center",
@@ -894,6 +904,9 @@ def issue_detail(
         "merged_into_issue": merged_into_issue,
         "today": date.today().isoformat(),
         "checklist_items": _get_issue_checklist(conn, issue_id),
+        "scope_type": "issue",
+        "scope_id": issue_id,
+        "data": open_tasks_data,
     }
     return templates.TemplateResponse("issues/detail.html", ctx)
 

--- a/src/policydb/web/routes/programs.py
+++ b/src/policydb/web/routes/programs.py
@@ -852,10 +852,22 @@ async def patch_program_header(
         return JSONResponse({"ok": False, "error": "Not found"}, status_code=404)
 
     body = await request.json()
-    allowed = {"name", "effective_date", "expiration_date", "renewal_status",
+    # Program dates are derived from the child policies' dates on read; the
+    # stored programs.effective_date / programs.expiration_date columns are
+    # no longer the source of truth. Rejecting writes keeps the two from
+    # drifting and enforces the Touch Once rule — users edit dates on the
+    # individual policies, the program rolls them up.
+    allowed = {"name", "renewal_status",
                "line_of_business", "notes", "working_notes", "lead_broker",
                "placement_colleague", "account_exec", "milestone_profile",
                "project_id"}
+    if any(k in body for k in ("effective_date", "expiration_date")):
+        return JSONResponse(
+            {"ok": False, "error":
+             "Program dates are derived from its policies. "
+             "Edit the policy's effective/expiration dates instead."},
+            status_code=400,
+        )
     updates = {k: v for k, v in body.items() if k in allowed}
     if not updates:
         return JSONResponse({"ok": False, "error": "No valid fields"})

--- a/src/policydb/web/templates/programs/detail.html
+++ b/src/policydb/web/templates/programs/detail.html
@@ -53,15 +53,15 @@
           </select>
         {% endif %}
       </div>
-      <div class="flex items-center gap-1.5">
+      <div class="flex items-center gap-1.5" title="Term is derived from the program's policies — edit policy dates on the Schematic or Overview tab.">
         <span class="text-gray-400 text-xs">Term:</span>
-        <input type="date" value="{{ program.effective_date or '' }}"
-               class="border-0 border-b border-gray-200 text-sm text-gray-700 bg-transparent px-1 py-0.5 focus:border-marsh focus:ring-0"
-               onchange="patchProgramHeader('effective_date', this.value)">
-        <span class="text-gray-300">–</span>
-        <input type="date" value="{{ program.expiration_date or '' }}"
-               class="border-0 border-b border-gray-200 text-sm text-gray-700 bg-transparent px-1 py-0.5 focus:border-marsh focus:ring-0"
-               onchange="patchProgramHeader('expiration_date', this.value)">
+        {% if program.effective_date and program.expiration_date %}
+          <span class="text-sm text-gray-700 tabular-nums">{{ program.effective_date }}</span>
+          <span class="text-gray-300">–</span>
+          <span class="text-sm text-gray-700 tabular-nums">{{ program.expiration_date }}</span>
+        {% else %}
+          <span class="text-sm text-gray-400 italic">no policies yet</span>
+        {% endif %}
       </div>
       <div class="flex items-center gap-1.5">
         <span class="text-gray-400 text-xs">Status:</span>

--- a/tests/test_program_derived_dates.py
+++ b/tests/test_program_derived_dates.py
@@ -1,0 +1,238 @@
+"""Tests for program effective/expiration date derivation.
+
+Programs no longer own their term — it's derived from the child policies'
+MIN(effective_date) / MAX(expiration_date), excluding archived and
+opportunity rows. These tests lock in:
+
+1. get_program_by_uid overrides the stored pg.effective/expiration with
+   derived values.
+2. get_program_aggregates returns derived dates in its result dict.
+3. The header PATCH route rejects attempts to write effective_date or
+   expiration_date.
+4. Edge cases: empty program, archived children excluded, opportunity
+   children excluded.
+"""
+
+import pytest
+from starlette.testclient import TestClient
+
+from policydb.db import init_db, get_connection
+from policydb.queries import get_program_by_uid, get_program_aggregates
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.sqlite"
+    monkeypatch.setattr("policydb.db.DB_PATH", db_path)
+    monkeypatch.setattr("policydb.db.DB_DIR", tmp_path)
+    monkeypatch.setattr("policydb.db.EXPORTS_DIR", tmp_path / "exports")
+    monkeypatch.setattr("policydb.db.CONFIG_PATH", tmp_path / "config.yaml")
+    init_db(path=db_path)
+
+    conn = get_connection(db_path)
+    conn.execute(
+        "INSERT INTO clients (id, name, industry_segment) "
+        "VALUES (1, 'Acme', 'Construction')"
+    )
+    yield conn, db_path
+    conn.close()
+
+
+def _make_program(conn, program_id, program_uid, name="Casualty",
+                  effective_date="2099-01-01", expiration_date="2099-12-31"):
+    """Insert a program with deliberately stale stored dates so we can prove
+    the helper derives from children and ignores the stored column."""
+    conn.execute(
+        """INSERT INTO programs (id, program_uid, client_id, name,
+                effective_date, expiration_date)
+           VALUES (?, ?, 1, ?, ?, ?)""",
+        (program_id, program_uid, name, effective_date, expiration_date),
+    )
+
+
+def _make_policy(conn, policy_id, program_id, effective, expiration,
+                 archived=0, is_opportunity=0, policy_uid=None):
+    conn.execute(
+        """INSERT INTO policies (id, policy_uid, client_id, program_id,
+                policy_type, carrier, premium, limit_amount,
+                effective_date, expiration_date,
+                renewal_status, is_opportunity, archived)
+           VALUES (?, ?, 1, ?, 'GL', 'Zurich', 10000, 1000000, ?, ?,
+                   'Bound', ?, ?)""",
+        (policy_id, policy_uid or f"POL-{policy_id}", program_id,
+         effective, expiration, is_opportunity, archived),
+    )
+
+
+# ── get_program_by_uid ──────────────────────────────────────────────────
+
+
+def test_empty_program_has_null_dates(db):
+    conn, _ = db
+    _make_program(conn, 1, "PGM-001")
+    conn.commit()
+    pgm = get_program_by_uid(conn, "PGM-001")
+    assert pgm is not None
+    assert pgm["effective_date"] is None
+    assert pgm["expiration_date"] is None
+
+
+def test_single_policy_program_uses_that_policy_dates(db):
+    conn, _ = db
+    _make_program(conn, 1, "PGM-001")
+    _make_policy(conn, 10, 1, "2026-03-15", "2027-03-14")
+    conn.commit()
+    pgm = get_program_by_uid(conn, "PGM-001")
+    assert pgm["effective_date"] == "2026-03-15"
+    assert pgm["expiration_date"] == "2027-03-14"
+
+
+def test_multi_policy_program_takes_min_eff_max_exp(db):
+    conn, _ = db
+    _make_program(conn, 1, "PGM-001")
+    # Three policies with ragged dates — program should span MIN..MAX
+    _make_policy(conn, 10, 1, "2026-03-15", "2027-03-14")
+    _make_policy(conn, 11, 1, "2026-01-01", "2027-06-30")
+    _make_policy(conn, 12, 1, "2026-04-01", "2027-04-30")
+    conn.commit()
+    pgm = get_program_by_uid(conn, "PGM-001")
+    assert pgm["effective_date"] == "2026-01-01"  # min
+    assert pgm["expiration_date"] == "2027-06-30"  # max
+
+
+def test_derived_dates_ignore_stored_columns(db):
+    """Proves the helper actually computes from children and doesn't
+    fall through to whatever's on the programs row."""
+    conn, _ = db
+    _make_program(
+        conn, 1, "PGM-001",
+        effective_date="2099-01-01",
+        expiration_date="2099-12-31",
+    )
+    _make_policy(conn, 10, 1, "2026-03-15", "2027-03-14")
+    conn.commit()
+    pgm = get_program_by_uid(conn, "PGM-001")
+    assert pgm["effective_date"] == "2026-03-15"
+    assert pgm["expiration_date"] == "2027-03-14"
+
+
+def test_archived_child_is_excluded_from_derivation(db):
+    conn, _ = db
+    _make_program(conn, 1, "PGM-001")
+    _make_policy(conn, 10, 1, "2026-03-15", "2027-03-14")
+    _make_policy(conn, 11, 1, "2020-01-01", "2099-12-31", archived=1)
+    conn.commit()
+    pgm = get_program_by_uid(conn, "PGM-001")
+    # Archived policy must not stretch the derived term.
+    assert pgm["effective_date"] == "2026-03-15"
+    assert pgm["expiration_date"] == "2027-03-14"
+
+
+def test_opportunity_child_is_excluded_from_derivation(db):
+    conn, _ = db
+    _make_program(conn, 1, "PGM-001")
+    _make_policy(conn, 10, 1, "2026-03-15", "2027-03-14")
+    _make_policy(conn, 11, 1, "2020-01-01", "2099-12-31", is_opportunity=1)
+    conn.commit()
+    pgm = get_program_by_uid(conn, "PGM-001")
+    assert pgm["effective_date"] == "2026-03-15"
+    assert pgm["expiration_date"] == "2027-03-14"
+
+
+# ── get_program_aggregates ─────────────────────────────────────────────
+
+
+def test_aggregates_include_derived_dates(db):
+    conn, _ = db
+    _make_program(conn, 1, "PGM-001")
+    _make_policy(conn, 10, 1, "2026-03-15", "2027-03-14")
+    _make_policy(conn, 11, 1, "2026-01-01", "2027-06-30")
+    conn.commit()
+    agg = get_program_aggregates(conn, 1)
+    assert agg["effective_date"] == "2026-01-01"
+    assert agg["expiration_date"] == "2027-06-30"
+    assert agg["policy_count"] == 2
+
+
+def test_aggregates_empty_program_returns_null_dates(db):
+    conn, _ = db
+    _make_program(conn, 1, "PGM-001")
+    conn.commit()
+    agg = get_program_aggregates(conn, 1)
+    assert agg["effective_date"] is None
+    assert agg["expiration_date"] is None
+    assert agg["policy_count"] == 0
+
+
+# ── header PATCH route ─────────────────────────────────────────────────
+
+
+@pytest.fixture
+def app_client(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.sqlite"
+    monkeypatch.setattr("policydb.db.DB_PATH", db_path)
+    monkeypatch.setattr("policydb.db.DB_DIR", tmp_path)
+    monkeypatch.setattr("policydb.db.EXPORTS_DIR", tmp_path / "exports")
+    monkeypatch.setattr("policydb.db.CONFIG_PATH", tmp_path / "config.yaml")
+    init_db(path=db_path)
+
+    conn = get_connection(db_path)
+    conn.execute(
+        "INSERT INTO clients (id, name, industry_segment) VALUES (1, 'Acme', 'Construction')"
+    )
+    conn.execute(
+        """INSERT INTO programs (id, program_uid, client_id, name,
+                effective_date, expiration_date)
+           VALUES (1, 'PGM-001', 1, 'Casualty', '2026-01-01', '2026-12-31')"""
+    )
+    _make_policy(conn, 10, 1, "2026-03-15", "2027-03-14")
+    conn.commit()
+    conn.close()
+
+    from policydb.web.app import app
+    yield TestClient(app, raise_server_exceptions=False), db_path
+
+
+def test_header_patch_rejects_effective_date(app_client):
+    client, _ = app_client
+    resp = client.patch(
+        "/programs/PGM-001/header",
+        json={"effective_date": "2020-01-01"},
+    )
+    assert resp.status_code == 400
+    body = resp.json()
+    assert body["ok"] is False
+    assert "derived" in body["error"].lower()
+
+
+def test_header_patch_rejects_expiration_date(app_client):
+    client, _ = app_client
+    resp = client.patch(
+        "/programs/PGM-001/header",
+        json={"expiration_date": "2099-01-01"},
+    )
+    assert resp.status_code == 400
+    body = resp.json()
+    assert body["ok"] is False
+    assert "derived" in body["error"].lower()
+
+
+def test_header_patch_still_accepts_other_fields(app_client):
+    client, _ = app_client
+    resp = client.patch(
+        "/programs/PGM-001/header",
+        json={"name": "Property"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+
+
+def test_header_patch_rejects_date_even_when_bundled_with_other_fields(app_client):
+    """If the payload includes date + other fields, reject the whole request
+    so we never silently drop the user's date input."""
+    client, _ = app_client
+    resp = client.patch(
+        "/programs/PGM-001/header",
+        json={"name": "Property", "effective_date": "2020-01-01"},
+    )
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- Program `effective_date` / `expiration_date` are now derived from `MIN(child.effective_date)` / `MAX(child.expiration_date)` (excluding archived + opportunity rows). The stored columns on the `programs` row are no longer the source of truth.
- `get_program_by_uid` and `get_program_aggregates` both return the derived values. Every read site that went through those helpers (Program detail header, client programs list, renewal pipeline, Action Center, etc.) gets the derived dates without code changes.
- Three direct `pg.expiration_date` SELECTs (issues program search, renewal-issue generator scan, renewal-issue subject refresher) switched to correlated `MAX(p.expiration_date)` subqueries so they stay in lockstep with the helpers.
- Program detail header replaces the two \`<input type=\"date\">\` fields with read-only spans (with an explanatory tooltip pointing users at the Schematic/Overview tabs for policy-level edits). Empty programs show \"no policies yet\".
- Program header PATCH rejects \`effective_date\` / \`expiration_date\` with a 400 explaining the new rule.

## Why
Prior behavior violated the Touch Once rule — program dates could drift from their children the moment a policy's dates were edited elsewhere, and the user explicitly asked for them to align.

Chosen option 1 from the previous discussion (\"derive — drop the columns, compute on read\") over option 2 (\"auto-sync on every mutation\") because sync strategies reintroduce drift risk; derivation can't drift.

## Scope intentionally not covered
- The stored \`programs.effective_date\` / \`programs.expiration_date\` columns are left in place for backward compat. A future migration can drop them once we're confident nothing external reads them.
- The create-program form already didn't accept dates, no change needed there.

## Test plan
- [x] \`pytest tests/test_program_derived_dates.py\` — 12 passed
- [x] \`pytest tests/test_programs_v2.py tests/test_program_cell_patch_clear_currency.py tests/test_program_delete_row_preserves_policy.py\` — 44 passed (no regressions in adjacent program test suites)
- [ ] Visual QA in Chrome — open a program, confirm the term renders as a read-only span, attempt to edit via devtools and confirm PATCH returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)