### PR TITLE
fix(programs): aggregate + derived-term use in-force policy filter

### DIFF
--- a/src/policydb/queries.py
+++ b/src/policydb/queries.py
@@ -4408,15 +4408,28 @@ def auto_generate_sub_coverages(conn, policy_id: int, policy_type: str):
 
 # ─── PROGRAM QUERIES (v2 — standalone programs table) ────────────────────────
 
+# A child policy counts as "in-force" for program aggregation when it is not
+# archived, not an opportunity, and either has no known expiration or hasn't
+# expired yet. Expired rows used to bleed into the displayed premium and
+# stretch the derived term across last year's schedule; NULL expirations come
+# from brand-new policies being entered and still count. This predicate is
+# the single source of truth — every program rollup uses the same definition.
+_IN_FORCE_POLICY_FILTER = (
+    "archived = 0 "
+    "AND (is_opportunity = 0 OR is_opportunity IS NULL) "
+    "AND (expiration_date IS NULL OR expiration_date >= date('now'))"
+)
+
 
 def get_program_by_uid(conn: sqlite3.Connection, program_uid: str) -> dict | None:
     """Return a program dict by its UID, or None if not found.
 
     Program dates are derived on read: `effective_date` and `expiration_date`
-    come from MIN/MAX of the child policies (excluding archived and opportunity
-    rows), not from the stale columns on the programs row itself. This
-    enforces the Touch Once rule — the children own the term, the program
-    reflects it.
+    come from MIN/MAX of the child policies currently in force (see
+    `_IN_FORCE_POLICY_FILTER`). Expired rows are ignored so the displayed
+    term doesn't stretch across last year's schedule once the new term is
+    being assembled. This enforces the Touch Once rule — the children own
+    the term, the program reflects it.
     """
     row = conn.execute(
         """SELECT pg.*, pr.name AS project_name,
@@ -4431,11 +4444,10 @@ def get_program_by_uid(conn: sqlite3.Connection, program_uid: str) -> dict | Non
         return None
     pgm = dict(row)
     dates = conn.execute(
-        """SELECT MIN(effective_date) AS effective_date,
-                  MAX(expiration_date) AS expiration_date
-           FROM policies
-           WHERE program_id = ? AND archived = 0
-             AND (is_opportunity = 0 OR is_opportunity IS NULL)""",
+        f"""SELECT MIN(effective_date) AS effective_date,
+                   MAX(expiration_date) AS expiration_date
+            FROM policies
+            WHERE program_id = ? AND {_IN_FORCE_POLICY_FILTER}""",
         (pgm["id"],),
     ).fetchone()
     pgm["effective_date"] = dates["effective_date"] if dates else None
@@ -4462,26 +4474,27 @@ def get_program_child_policies(conn: sqlite3.Connection, program_id: int) -> lis
 
 
 def get_program_aggregates(conn: sqlite3.Connection, program_id: int) -> dict:
-    """Compute aggregate stats for a program from its child policies.
+    """Compute aggregate stats for a program from its in-force child policies.
 
-    A program's term is derived from its children (earliest effective,
-    latest expiration), not stored as source of truth on `programs`.
-    The returned `effective_date` and `expiration_date` keys are meant
-    to be merged into the program dict by callers so templates and
-    route handlers always see the derived values. When a program has
-    no non-archived non-opportunity children, both dates come back as
-    None.
+    Only rows that pass `_IN_FORCE_POLICY_FILTER` (not archived, not an
+    opportunity, and not yet expired) contribute to the totals. Expired
+    rows used to overstate premium and policy_count on programs where old
+    term rows hadn't been archived yet — that's the 'seems off' complaint.
+
+    The returned `effective_date` and `expiration_date` are derived from
+    the same in-force rows and are meant to be merged onto the program
+    dict by callers (get_programs_for_client, get_programs_for_project)
+    so templates see the derived term automatically.
     """
     row = conn.execute(
-        """SELECT COUNT(*) AS policy_count,
-                  COUNT(DISTINCT carrier) AS carrier_count,
-                  COALESCE(SUM(premium), 0) AS total_premium,
-                  COALESCE(MAX(limit_amount), 0) AS max_limit,
-                  MIN(effective_date) AS effective_date,
-                  MAX(expiration_date) AS expiration_date
-           FROM policies
-           WHERE program_id = ? AND archived = 0
-             AND (is_opportunity = 0 OR is_opportunity IS NULL)""",
+        f"""SELECT COUNT(*) AS policy_count,
+                   COUNT(DISTINCT carrier) AS carrier_count,
+                   COALESCE(SUM(premium), 0) AS total_premium,
+                   COALESCE(MAX(limit_amount), 0) AS max_limit,
+                   MIN(effective_date) AS effective_date,
+                   MAX(expiration_date) AS expiration_date
+            FROM policies
+            WHERE program_id = ? AND {_IN_FORCE_POLICY_FILTER}""",
         (program_id,),
     ).fetchone()
     return dict(row) if row else {

--- a/src/policydb/renewal_issues.py
+++ b/src/policydb/renewal_issues.py
@@ -146,31 +146,32 @@ def ensure_renewal_issues(conn, policy_uid: str | None = None) -> None:
         )
 
     # ── Programs ─────────────────────────────────────────────────────
-    # Program expiration is derived from the latest child-policy expiration
-    # (programs no longer own the term). Both the SELECT and the WHERE
-    # window go through the same subquery to stay consistent.
+    # Program expiration is derived from the latest in-force child policy
+    # (non-archived, non-opportunity, non-expired). A JOIN on a pre-computed
+    # GROUP BY gives us one row per program with the right expiration, which
+    # reads cleaner than four repeated correlated subqueries.
     if not policy_uid:
         program_rows = conn.execute("""
-            SELECT pg.id, pg.program_uid,
-                   (SELECT MAX(p.expiration_date) FROM policies p
-                    WHERE p.program_id = pg.id AND p.archived = 0
-                      AND (p.is_opportunity = 0 OR p.is_opportunity IS NULL)) AS expiration_date,
+            SELECT pg.id, pg.program_uid, d.expiration_date,
                    pg.line_of_business,
                    pg.name AS program_name, c.name AS client_name, pg.client_id,
                    pr.name AS location_name
             FROM programs pg
             JOIN clients c ON c.id = pg.client_id
             LEFT JOIN projects pr ON pr.id = pg.project_id
+            JOIN (
+                SELECT program_id, MAX(expiration_date) AS expiration_date
+                FROM policies
+                WHERE program_id IS NOT NULL
+                  AND archived = 0
+                  AND (is_opportunity = 0 OR is_opportunity IS NULL)
+                  AND (expiration_date IS NULL OR expiration_date >= date('now'))
+                GROUP BY program_id
+                HAVING MAX(expiration_date) IS NOT NULL
+            ) d ON d.program_id = pg.id
             WHERE (pg.archived = 0 OR pg.archived IS NULL)
-              AND (SELECT MAX(p.expiration_date) FROM policies p
-                   WHERE p.program_id = pg.id AND p.archived = 0
-                     AND (p.is_opportunity = 0 OR p.is_opportunity IS NULL)) IS NOT NULL
-              AND (SELECT MAX(p.expiration_date) FROM policies p
-                   WHERE p.program_id = pg.id AND p.archived = 0
-                     AND (p.is_opportunity = 0 OR p.is_opportunity IS NULL)) >= ?
-              AND (SELECT MAX(p.expiration_date) FROM policies p
-                   WHERE p.program_id = pg.id AND p.archived = 0
-                     AND (p.is_opportunity = 0 OR p.is_opportunity IS NULL)) <= ?
+              AND d.expiration_date >= ?
+              AND d.expiration_date <= ?
         """, (today.isoformat(), horizon.isoformat())).fetchall()
 
         for pgm in program_rows:
@@ -568,12 +569,14 @@ def refresh_renewal_titles(conn) -> int:
             )
             updated += 1
 
-    # Program renewal issues — expiration derived from child policies.
+    # Program renewal issues — expiration derived from in-force child policies.
     program_issues = conn.execute("""
         SELECT a.id, a.subject, a.renewal_term_key, a.program_id,
                (SELECT MAX(p.expiration_date) FROM policies p
                 WHERE p.program_id = pg.id AND p.archived = 0
-                  AND (p.is_opportunity = 0 OR p.is_opportunity IS NULL)) AS expiration_date,
+                  AND (p.is_opportunity = 0 OR p.is_opportunity IS NULL)
+                  AND (p.expiration_date IS NULL OR p.expiration_date >= date('now'))
+               ) AS expiration_date,
                pg.line_of_business, pg.name AS program_name,
                c.name AS client_name, pr.name AS location_name
         FROM activity_log a

--- a/src/policydb/web/routes/issues.py
+++ b/src/policydb/web/routes/issues.py
@@ -562,16 +562,22 @@ def search_issue_policies(issue_id: int, q: str = Query(""), conn=Depends(get_db
     results = []
 
     # ── Programs matching the search ──
-    # expiration_date is derived from child policies (programs no longer
-    # own the term) — see get_program_by_uid for the canonical helper.
+    # expiration_date is derived from in-force child policies (non-archived,
+    # non-opportunity, non-expired) — same filter that get_program_aggregates
+    # uses so the label matches what the program page displays.
     prog_rows = conn.execute("""
         SELECT pg.id, pg.program_uid, pg.name, pg.line_of_business,
                (SELECT MAX(p2.expiration_date) FROM policies p2
                 WHERE p2.program_id = pg.id AND p2.archived = 0
-                  AND (p2.is_opportunity = 0 OR p2.is_opportunity IS NULL)) AS expiration_date,
+                  AND (p2.is_opportunity = 0 OR p2.is_opportunity IS NULL)
+                  AND (p2.expiration_date IS NULL OR p2.expiration_date >= date('now'))
+               ) AS expiration_date,
                pg.renewal_status,
                (SELECT COUNT(*) FROM policies p2
-                WHERE p2.program_id = pg.id AND p2.archived = 0) AS policy_count
+                WHERE p2.program_id = pg.id AND p2.archived = 0
+                  AND (p2.is_opportunity = 0 OR p2.is_opportunity IS NULL)
+                  AND (p2.expiration_date IS NULL OR p2.expiration_date >= date('now'))
+               ) AS policy_count
         FROM programs pg
         WHERE pg.client_id = ? AND pg.archived = 0
           AND (pg.program_uid LIKE ? OR pg.name LIKE ? OR pg.line_of_business LIKE ?)

--- a/tests/test_program_in_force_filter.py
+++ b/tests/test_program_in_force_filter.py
@@ -1,0 +1,189 @@
+"""Regression tests for the 'in-force' filter on program aggregation.
+
+Bug: the client page showed program premium and policy count that
+included expired child policies, overstating the in-force numbers. The
+derived term (MIN effective / MAX expiration) also stretched across last
+year's schedule because expired rows were still pulled into the MIN/MAX.
+
+Fix: `get_program_aggregates` and `get_program_by_uid` now filter children
+through `_IN_FORCE_POLICY_FILTER`:
+    archived = 0
+    AND (is_opportunity = 0 OR is_opportunity IS NULL)
+    AND (expiration_date IS NULL OR expiration_date >= date('now'))
+
+NULL expiration is kept in-force because brand-new policies may not yet
+have the expiration filled in. These tests lock in:
+
+1. A program whose only children are expired → aggregate is (0, $0) and
+   derived dates are (None, None).
+2. A program with a mix of expired and current children → only current
+   contribute to count/premium and derived term.
+3. A policy with NULL expiration counts as in-force.
+4. A program with only current children behaves exactly like before
+   (no regression on the happy path).
+"""
+
+import pytest
+
+from policydb.db import init_db, get_connection
+from policydb.queries import get_program_by_uid, get_program_aggregates
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.sqlite"
+    monkeypatch.setattr("policydb.db.DB_PATH", db_path)
+    monkeypatch.setattr("policydb.db.DB_DIR", tmp_path)
+    monkeypatch.setattr("policydb.db.EXPORTS_DIR", tmp_path / "exports")
+    monkeypatch.setattr("policydb.db.CONFIG_PATH", tmp_path / "config.yaml")
+    init_db(path=db_path)
+
+    conn = get_connection(db_path)
+    conn.execute(
+        "INSERT INTO clients (id, name, industry_segment) "
+        "VALUES (1, 'Acme', 'Construction')"
+    )
+    yield conn
+    conn.close()
+
+
+def _make_program(conn, program_id, program_uid, name="Casualty"):
+    conn.execute(
+        "INSERT INTO programs (id, program_uid, client_id, name) "
+        "VALUES (?, ?, 1, ?)",
+        (program_id, program_uid, name),
+    )
+
+
+def _make_policy(conn, policy_id, program_id, effective, expiration,
+                 premium=10000, archived=0, is_opportunity=0):
+    conn.execute(
+        """INSERT INTO policies (id, policy_uid, client_id, program_id,
+                policy_type, carrier, premium, limit_amount,
+                effective_date, expiration_date,
+                renewal_status, is_opportunity, archived)
+           VALUES (?, ?, 1, ?, 'GL', 'Zurich', ?, 1000000, ?, ?,
+                   'Bound', ?, ?)""",
+        (policy_id, f"POL-{policy_id}", program_id, premium,
+         effective, expiration, is_opportunity, archived),
+    )
+
+
+# ── all-expired program ─────────────────────────────────────────────────
+
+
+def test_all_expired_program_aggregates_to_zero(db):
+    _make_program(db, 1, "PGM-001")
+    _make_policy(db, 10, 1, "2020-01-01", "2021-01-01", premium=50000)
+    _make_policy(db, 11, 1, "2022-01-01", "2023-01-01", premium=75000)
+    db.commit()
+
+    agg = get_program_aggregates(db, 1)
+    assert agg["policy_count"] == 0, (
+        "All children are expired — in-force count should be 0, not include "
+        "last year's policies."
+    )
+    assert agg["total_premium"] == 0
+    assert agg["effective_date"] is None
+    assert agg["expiration_date"] is None
+
+
+def test_all_expired_program_has_no_derived_term(db):
+    _make_program(db, 1, "PGM-001")
+    _make_policy(db, 10, 1, "2020-01-01", "2021-01-01")
+    db.commit()
+
+    pgm = get_program_by_uid(db, "PGM-001")
+    assert pgm is not None
+    assert pgm["effective_date"] is None
+    assert pgm["expiration_date"] is None
+
+
+# ── mixed expired + current ─────────────────────────────────────────────
+
+
+def test_mixed_program_only_counts_current(db):
+    _make_program(db, 1, "PGM-001")
+    # Last year's expired schedule
+    _make_policy(db, 10, 1, "2025-01-01", "2026-01-01", premium=50000)
+    _make_policy(db, 11, 1, "2025-03-01", "2026-03-01", premium=25000)
+    # This year's renewed schedule (effective 2026-01, exp 2027-01 — still in force)
+    _make_policy(db, 20, 1, "2026-01-01", "2027-01-01", premium=55000)
+    _make_policy(db, 21, 1, "2026-03-01", "2027-03-01", premium=28000)
+    db.commit()
+
+    agg = get_program_aggregates(db, 1)
+    assert agg["policy_count"] == 2, (
+        "Only the two current-term policies should count — expired rows "
+        "inflate the in-force premium number."
+    )
+    assert agg["total_premium"] == 55000 + 28000
+
+
+def test_mixed_program_derived_term_uses_current_only(db):
+    _make_program(db, 1, "PGM-001")
+    # Last year expired
+    _make_policy(db, 10, 1, "2025-01-01", "2026-01-01")
+    # Current
+    _make_policy(db, 20, 1, "2026-01-01", "2027-01-01")
+    _make_policy(db, 21, 1, "2026-03-01", "2027-03-01")
+    db.commit()
+
+    pgm = get_program_by_uid(db, "PGM-001")
+    # Expected: MIN and MAX over the two current policies only.
+    assert pgm["effective_date"] == "2026-01-01", (
+        "Derived effective must ignore expired rows — otherwise the header "
+        "would show last year's start date."
+    )
+    assert pgm["expiration_date"] == "2027-03-01"
+
+
+# ── NULL expiration treated as in-force ────────────────────────────────
+
+
+def test_null_expiration_counts_as_in_force(db):
+    _make_program(db, 1, "PGM-001")
+    # A brand new policy being entered with no expiration yet
+    db.execute(
+        """INSERT INTO policies (id, policy_uid, client_id, program_id,
+                policy_type, carrier, premium, limit_amount,
+                effective_date, expiration_date,
+                renewal_status, is_opportunity, archived)
+           VALUES (30, 'POL-030', 1, 1, 'GL', 'Zurich', 12000, 1000000,
+                   '2026-06-01', NULL, 'Not Started', 0, 0)"""
+    )
+    db.commit()
+
+    agg = get_program_aggregates(db, 1)
+    assert agg["policy_count"] == 1, (
+        "A policy mid-entry with NULL expiration is in-force, not expired."
+    )
+    assert agg["total_premium"] == 12000
+    assert agg["effective_date"] == "2026-06-01"
+    # MAX ignores NULL so derived expiration is None here — that's fine,
+    # the template `{% if %}` guard hides it until the user fills it in.
+    assert agg["expiration_date"] is None
+
+
+# ── happy path unchanged ───────────────────────────────────────────────
+
+
+def test_all_current_program_unchanged(db):
+    """Programs with only in-force children should behave exactly like
+    before the filter was added — ensures the test_program_derived_dates
+    scenarios are still correct and this PR is a pure additive fix."""
+    _make_program(db, 1, "PGM-001")
+    _make_policy(db, 10, 1, "2026-03-15", "2027-03-14", premium=10000)
+    _make_policy(db, 11, 1, "2026-01-01", "2027-06-30", premium=15000)
+    _make_policy(db, 12, 1, "2026-04-01", "2027-04-30", premium=20000)
+    db.commit()
+
+    agg = get_program_aggregates(db, 1)
+    assert agg["policy_count"] == 3
+    assert agg["total_premium"] == 45000
+    assert agg["effective_date"] == "2026-01-01"
+    assert agg["expiration_date"] == "2027-06-30"
+
+    pgm = get_program_by_uid(db, "PGM-001")
+    assert pgm["effective_date"] == "2026-01-01"
+    assert pgm["expiration_date"] == "2027-06-30"


### PR DESCRIPTION
## Summary
- New `_IN_FORCE_POLICY_FILTER` in `queries.py` — the single source of truth for which child policies count toward a program's rollup: `archived = 0 AND (is_opportunity = 0 OR is_opportunity IS NULL) AND (expiration_date IS NULL OR expiration_date >= date('now'))`.
- `get_program_aggregates` applies it so `policy_count`, `total_premium`, and the derived `effective_date` / `expiration_date` no longer include expired rows.
- `get_program_by_uid` applies it so the program detail header's \"Term\" stops stretching across last year's schedule.
- `renewal_issues.py` program renewal scan refactored from 4 repeated correlated subqueries to a single `GROUP BY` subquery that also uses the new filter (readability win on top of the fix).
- Same filter applied to the `issues.py` program-search helper (so the issue-link dropdown label matches what the program page shows) and the `renewal_issues.py` subject refresher.

## Why
User reported: \"confirm the aggregation of in-force premium and policy count shown under programs for clients - seems off.\" Agent investigation found `get_program_aggregates` had no expiration filter, so programs with both last year's expired schedule and this year's new schedule summed both. The derived term (shipped in #228) also inherited last year's effective date because MIN/MAX included expired rows.

Chose the not-expired definition over `renewal_status = 'Bound' AND not expired` because a program mid-placement has a real tower being assembled in Not Started / In Progress rows that users want to see in the rollup.

## Test plan
- [x] `pytest tests/test_program_in_force_filter.py` — 6 passed
  - all-expired program → aggregate is zero, derived dates are None
  - all-expired program → `get_program_by_uid` returns None dates
  - mixed expired + current → only current counted
  - mixed expired + current → derived term uses current only
  - NULL expiration counts as in-force (brand-new policies mid-entry)
  - all-current happy path unchanged (regression guard)
- [x] `pytest tests/test_program_derived_dates.py tests/test_programs_v2.py tests/test_program_cell_patch_clear_currency.py tests/test_program_delete_row_preserves_policy.py` — 56 passed (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)