### PR TITLE
fix(focus-queue): keep overdue waiting items in Waiting Sidebar

### DIFF
--- a/src/policydb/focus_queue.py
+++ b/src/policydb/focus_queue.py
@@ -1341,11 +1341,11 @@ def build_focus_queue(
                     promote_reason = f"⚠ Expired {abs(exp_days)}d ago — still waiting"
                 else:
                     promote_reason = f"⚠ Expires in {exp_days}d — still waiting"
-            # Promote if follow-up date is overdue
-            elif days is not None and days <= 0:
-                promote = True
-                promote_reason = f"Overdue — still waiting"
-            # Promote if follow-up date falls within horizon
+            # Promote if follow-up date falls within horizon (horizon > 0 only).
+            # Overdue waiting items (days <= 0) intentionally stay in the
+            # Waiting Sidebar until `focus_auto_promote_days` (branch 1); the
+            # sidebar template handles escalating visual weight via
+            # `focus_nudge_alert_days`.
             elif days is not None and days <= promote_window and horizon_days > 0:
                 promote = True
                 promote_reason = f"Due in {days}d — still waiting"


### PR DESCRIPTION
## Summary
- The Focus Queue's "Waiting On Others" sidebar always rendered 0 items because an overly aggressive branch in `build_focus_queue()` promoted any waiting item with `days_until_deadline <= 0` into the Focus Queue the moment its follow-up date passed.
- This made `focus_auto_promote_days` (14) and `focus_nudge_alert_days` (10) unreachable — the sidebar template's stale-amber border and "10+ days waiting" banner were dead code.
- Drop the `days <= 0` branch. Overdue waiting items now stay in the sidebar and escalate through the 14-day threshold (branch 1), matching the template's design intent. Horizon-based and expiration-based promotion branches are unchanged.

## Verification
- Live `build_focus_queue()` against the real DB: `waiting_count = 1` (was `0`) on all / today / overdue views. The remaining 18-day-overdue "Sent Email" item correctly still promotes via the 14-day rule.
- Browser render of `/action-center?tab=focus`: sidebar shows "Waiting On Others (1)" with "9d waiting", "Re-check: 2026-04-05", working Nudge + Pull to Focus buttons.

## Test plan
- [ ] Open Action Center → Focus, confirm Waiting On Others shows expected `waiting_external` items
- [ ] Nudge + Pull to Focus buttons still work on waiting rows
- [ ] Slide horizon to "This Week" / "Next 2 Weeks" and confirm horizon-based promotion still fires (items with near deadlines surface in Focus)
- [ ] Verify items waiting 10+ days get amber border; 14+ days promote to Focus with "Waiting N days — consider nudging"

🤖 Generated with [Claude Code](https://claude.com/claude-code)