### PR TITLE
Potential fix for code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/src/policydb/web/templates/charts/manual/_tpl_callout_milestone.html
+++ b/src/policydb/web/templates/charts/manual/_tpl_callout_milestone.html
@@ -204,6 +204,11 @@
     });
   }
 
+  function sanitizeColor(color, fallback) {
+    var value = (color || '').trim();
+    return /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(value) ? value : fallback;
+  }
+
   // ── Build Card HTML ──────────────────────────────────────────────────
   function buildCard() {
     var superLabel  = document.getElementById('val-super').value;
@@ -213,7 +218,7 @@
     var desc        = document.getElementById('val-desc').value;
     var status      = document.getElementById('cfg-status').value || defaults.status;
     var progress    = parseInt(document.getElementById('cfg-progress').value, 10) || 0;
-    var accentColor = document.getElementById('cfg-accent-color').value || defaults.accentColor;
+    var accentColor = sanitizeColor(document.getElementById('cfg-accent-color').value, defaults.accentColor);
 
     var showProgress = ManualChart.isToggled('show-progress');
 


### PR DESCRIPTION
Potential fix for [https://github.com/grantgco/policydb/security/code-scanning/4](https://github.com/grantgco/policydb/security/code-scanning/4)

Best fix: validate and constrain `accentColor` to a strict allowlist format before using it in HTML/CSS contexts, and fall back to a known-safe default when invalid.

In this file, the minimal safe change is:
1. Add a helper function (near existing helpers in the script) to sanitize CSS color input.
2. Use that helper when assigning `accentColor` in `buildCard()`.

Specifically in `src/policydb/web/templates/charts/manual/_tpl_callout_milestone.html`:
- Update line around current `accentColor` assignment so it becomes sanitized (instead of raw `.value`).
- Add a `sanitizeColor(...)` function that only allows safe hex colors (`#RGB` or `#RRGGBB`), otherwise returns `defaults.accentColor`.

This preserves existing functionality for valid color values while preventing HTML/CSS injection through this field.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
