### PR TITLE
Fix prompt builder hang on Client Status & Next Steps

### DIFF
--- a/src/policydb/prompt_assembler.py
+++ b/src/policydb/prompt_assembler.py
@@ -849,7 +849,7 @@ def assemble_contacts(conn: sqlite3.Connection, record_id: int, depth: int = DEP
     """Assemble contacts. record_id is client_id. Pass policy_id=N for policy contacts."""
     policy_id = kwargs.get("policy_id")
     if policy_id:
-        rows = conn.execute(
+        raw_rows = conn.execute(
             """SELECT co.name, co.email, co.phone, cpa.role, cpa.is_placement_colleague
                FROM contact_policy_assignments cpa
                JOIN contacts co ON cpa.contact_id = co.id
@@ -857,7 +857,7 @@ def assemble_contacts(conn: sqlite3.Connection, record_id: int, depth: int = DEP
             (policy_id,),
         ).fetchall()
     else:
-        rows = conn.execute(
+        raw_rows = conn.execute(
             """SELECT co.name, co.email, co.phone, cca.role, cca.contact_type, cca.is_primary
                FROM contact_client_assignments cca
                JOIN contacts co ON cca.contact_id = co.id
@@ -866,29 +866,34 @@ def assemble_contacts(conn: sqlite3.Connection, record_id: int, depth: int = DEP
             (record_id,),
         ).fetchall()
 
-    if not rows:
+    if not raw_rows:
         return ""
+
+    # Convert to dicts so .get() works and missing columns (which differ between
+    # the two branches above) return None instead of raising KeyError on Row.
+    rows = [dict(r) for r in raw_rows]
 
     lines = ["## Contacts\n"]
 
     if len(rows) <= 5:
         for c in rows:
-            role = c["role"] or ("Placement Colleague" if c.get("is_placement_colleague") else "Contact")
+            role = c.get("role") or ("Placement Colleague" if c.get("is_placement_colleague") else "Contact")
             line = f"- **{c['name']}** — {role}"
-            if c["email"]:
+            if c.get("email"):
                 line += f" ({c['email']})"
             lines.append(line + "\n")
     else:
         # Primary at tier 2, rest at tier 3
         primary = [c for c in rows if c.get("is_primary") or c.get("is_placement_colleague")]
-        others = [c for c in rows if c not in primary]
+        primary_ids = {id(c) for c in primary}
+        others = [c for c in rows if id(c) not in primary_ids]
         for c in primary:
-            role = c["role"] or "Primary Contact"
+            role = c.get("role") or "Primary Contact"
             line = f"- **{c['name']}** — {role}"
-            if c["email"]:
+            if c.get("email"):
                 line += f" ({c['email']})"
             lines.append(line + "\n")
-        ref_items = [f"- {c['name']} — {c['role'] or 'Contact'}\n" for c in others]
+        ref_items = [f"- {c['name']} — {c.get('role') or 'Contact'}\n" for c in others]
         ref_items = _truncated_list(ref_items, 5, "contacts")
         for item in ref_items:
             lines.append(item)

--- a/src/policydb/web/routes/prompt_builder.py
+++ b/src/policydb/web/routes/prompt_builder.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 import json
+import logging
+import traceback
 
 from fastapi import APIRouter, Depends, Form, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+
+log = logging.getLogger(__name__)
 
 from policydb.prompt_assembler import (
     PRIMARY_RECORD_TYPES,
@@ -186,7 +190,18 @@ def preview_prompt(
     if not template:
         return HTMLResponse("<p class='text-red-500'>Template not found.</p>")
 
-    result = assemble_prompt(conn, template, record_type, record_id)
+    try:
+        result = assemble_prompt(conn, template, record_type, record_id)
+    except Exception as exc:
+        log.exception("Prompt assembly failed: template=%s record=%s/%s", template_id, record_type, record_id)
+        tb = traceback.format_exc()
+        return HTMLResponse(
+            "<div class='rounded border border-red-300 bg-red-50 p-3 text-sm text-red-800'>"
+            f"<p class='font-semibold'>Failed to assemble prompt: {type(exc).__name__}: {exc}</p>"
+            f"<pre class='mt-2 overflow-auto text-xs text-red-700'>{tb}</pre>"
+            "</div>",
+            status_code=200,
+        )
 
     return templates.TemplateResponse("prompt_builder/_preview.html", {
         "request": request,


### PR DESCRIPTION
## Summary
- `assemble_contacts()` called `.get()` on `sqlite3.Row` objects, raising `AttributeError`. FastAPI returned 500 and HTMX left the `"Assembling prompt…"` placeholder in place — the reported hang on the **Client Status & Next Steps** template.
- Latent since the function was written; no template exercised it until migration 145 added `"contacts"` to Client Status & Next Steps (PR #214). Other briefing templates don't list `"contacts"` so they were unaffected.
- Added a safety net around `assemble_prompt()` in `/prompt-builder/preview` so future latent bugs render an error panel instead of hanging silently.

## Root cause
```
File ".../prompt_assembler.py", line 883, in assemble_contacts
    primary = [c for c in rows if c.get("is_primary") or c.get("is_placement_colleague")]
AttributeError: 'sqlite3.Row' object has no attribute 'get'
```
Secondary correctness issue: the two SQL branches return different column sets (`is_placement_colleague` only at policy scope, `is_primary` only at client scope), so direct Row column access would also have `KeyError`'d on the missing column.

## Fixes
- **`src/policydb/prompt_assembler.py`** — `assemble_contacts` now materializes rows into dicts before reading fields; missing columns return `None` instead of raising. Replaced `c not in primary` membership with an id-based set to avoid falsely deduping contacts with identical field values.
- **`src/policydb/web/routes/prompt_builder.py`** — wrapped `assemble_prompt()` in a `try/except` that logs the exception and returns a 200 HTML error block with traceback. Future latent assembler bugs now surface in the preview panel.

## Test plan
- [x] Repro on live server confirmed the exact traceback in `~/.policydb/server.log`
- [x] Ran all 11 builtin templates against real data — every one assembles cleanly:
  - `Client Status & Next Steps` (client=1) → 4273 chars
  - `Policy Status & Next Steps` (policy=3) → 2477 chars
  - `Renewal Status & Next Steps` (renewal=3) → 2582 chars
  - `Issue Status & Next Steps` (issue=208) → 1248 chars
  - Plus the 7 original builtins (Renewal Status Email, Open Items Call Agenda, Stewardship Report Shell, Submission Cover Note, Client Coverage Narrative, Issue Escalation Memo, New Business Prospect Brief)
- [x] Swept every `.get(` call in `prompt_assembler.py` — lines 876/883 were the only Row-vs-dict violations; all other `.get()` calls are on dicts from `_row_to_dict()`, `kwargs`, `keys`, or `template`.
- [ ] After merge, restart `policydb serve` and click **Generate Prompt** on Client Status & Next Steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)