### PR TITLE
Don't leak exception details in prompt builder error panel

### DIFF
--- a/src/policydb/web/routes/prompt_builder.py
+++ b/src/policydb/web/routes/prompt_builder.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import html
 import json
 import logging
-import traceback
 
 from fastapi import APIRouter, Depends, Form, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
@@ -192,13 +192,18 @@ def preview_prompt(
 
     try:
         result = assemble_prompt(conn, template, record_type, record_id)
-    except Exception as exc:
-        log.exception("Prompt assembly failed: template=%s record=%s/%s", template_id, record_type, record_id)
-        tb = traceback.format_exc()
+    except Exception:
+        # Log the full traceback server-side; show the user a generic error
+        # without leaking exception details or stack frames into the HTML.
+        log.exception(
+            "Prompt assembly failed: template=%s record=%s/%s",
+            template_id, record_type, record_id,
+        )
+        safe_name = html.escape(template.get("name") or "")
         return HTMLResponse(
             "<div class='rounded border border-red-300 bg-red-50 p-3 text-sm text-red-800'>"
-            f"<p class='font-semibold'>Failed to assemble prompt: {type(exc).__name__}: {exc}</p>"
-            f"<pre class='mt-2 overflow-auto text-xs text-red-700'>{tb}</pre>"
+            "<p class='font-semibold'>Failed to assemble prompt.</p>"
+            f"<p class='mt-1'>Template: {safe_name}. See server log for details.</p>"
             "</div>",
             status_code=200,
         )


### PR DESCRIPTION
## Summary
CodeQL flagged the error handler added in #237 for exposing stack traces to the user (information exposure through an exception). The traceback was rendered in the HTML response so the user could see what went wrong, but that leaks absolute paths, library versions, and internal structure.

Move to log-only: log the full exception server-side via `log.exception` and render a generic error panel with just the template name (HTML-escaped). Users still know something failed and which template, and operators still have the full traceback in the server log.

## Before → After

**Before** (flagged by CodeQL):
```html
<p>Failed to assemble prompt: RuntimeError: secret path /Users/foo/bar.py ...</p>
<pre>Traceback (most recent call last):
  File "/Users/grantgreeson/.../prompt_assembler.py", line 1520 ...
</pre>
```

**After:**
```html
<p>Failed to assemble prompt.</p>
<p>Template: Client Status &amp; Next Steps. See server log for details.</p>
```

## Test plan
- [x] Monkey-patched `assemble_prompt` to raise `RuntimeError("secret path /Users/foo/bar.py leaks if tb included")` and called `preview_prompt()` directly
- [x] Verified the response body contains no exception message, no exception type, and no `/Users/` path
- [x] Verified the template name is HTML-escaped
- [x] Confirmed the full traceback still lands in the server log via `log.exception`

🤖 Generated with [Claude Code](https://claude.com/claude-code)