### PR TITLE
feat: loss run request automation + carriers directory

### DIFF
--- a/src/policydb/config.py
+++ b/src/policydb/config.py
@@ -690,6 +690,7 @@ _DEFAULTS: dict[str, Any] = {
     "service_model_options": ["Standard", "High-touch", "White-glove"],
     "daily_followup_target": 5,
     "pin_renewal_days": 14,
+    "loss_run_follow_up_days": 7,
     "backup_retention_count": 30,
     "migration_backup_retention_count": 10,
     "log_level": "INFO",

--- a/src/policydb/db.py
+++ b/src/policydb/db.py
@@ -364,7 +364,7 @@ def _init_db_inner(conn: sqlite3.Connection, db_path: Path) -> None:
     # Back up the database once before running any pending migrations.
     # This gives a clean restore point regardless of which migration fails.
 
-    _KNOWN_MIGRATIONS = set(range(1, 147))  # update upper bound when adding new migrations
+    _KNOWN_MIGRATIONS = set(range(1, 150))  # update upper bound when adding new migrations
 
     if _KNOWN_MIGRATIONS - applied:
         _backup_db(conn, db_path)
@@ -1930,6 +1930,67 @@ def _init_db_inner(conn: sqlite3.Connection, db_path: Path) -> None:
         )
         conn.commit()
         logger.info("Migration 148: added outlook_contact_id column")
+
+    if 149 not in applied:
+        conn.executescript((_MIGRATIONS_DIR / "149_carriers_table.sql").read_text())
+        # Add email_templates.purpose if not already present. SQLite lacks
+        # `ADD COLUMN IF NOT EXISTS`, so we guard with pragma_table_info.
+        _et_cols = {r[1] for r in conn.execute("PRAGMA table_info(email_templates)").fetchall()}
+        if "purpose" not in _et_cols:
+            conn.execute(
+                "ALTER TABLE email_templates ADD COLUMN purpose TEXT NOT NULL DEFAULT ''"
+            )
+        conn.execute(
+            "INSERT INTO schema_version (version, description) VALUES (?, ?)",
+            (149, "Carriers table + email_templates.purpose column for loss run request automation"),
+        )
+        # Seed carriers table from the existing config list (one-time). Names only —
+        # the user fills in loss-run email addresses via /carriers or inline from
+        # the compose slideover's "Save destination" checkbox.
+        from policydb import config as _cfg_seed
+        existing_count = conn.execute("SELECT COUNT(*) FROM carriers").fetchone()[0]
+        if existing_count == 0:
+            for _name in _cfg_seed.get("carriers", []) or []:
+                _name = (_name or "").strip()
+                if not _name:
+                    continue
+                conn.execute(
+                    "INSERT OR IGNORE INTO carriers (name, type) VALUES (?, 'carrier')",
+                    (_name,),
+                )
+        # Seed the Loss Run Request email template if absent. Uses existing
+        # policy_context() tokens — no new token plumbing needed.
+        already_tpl = conn.execute(
+            "SELECT COUNT(*) FROM email_templates WHERE purpose='loss_run_request'"
+        ).fetchone()[0]
+        if already_tpl == 0:
+            conn.execute(
+                """INSERT INTO email_templates
+                   (name, context, description, subject_template, body_template, purpose)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (
+                    "Loss Run Request",
+                    "policy",
+                    "Loss run request to carrier or wholesaler — 5 years of claim history.",
+                    "Loss Run Request — {{first_named_insured}} — {{policy_number}}",
+                    (
+                        "Hello,\n\n"
+                        "Please provide a current loss run for the policy below, including "
+                        "5 years of history.\n\n"
+                        "- Named Insured: {{first_named_insured}}\n"
+                        "- Policy Number: {{policy_number}}\n"
+                        "- Coverage Line: {{policy_type}}\n"
+                        "- Effective Date: {{effective_date}}\n"
+                        "- Expiration Date: {{expiration_date}}\n\n"
+                        "Please reply all with the loss run attached. Let me know if you need "
+                        "any additional information.\n\n"
+                        "Thank you"
+                    ),
+                    "loss_run_request",
+                ),
+            )
+        conn.commit()
+        logger.info("Migration 149: added carriers table + email_templates.purpose + seeded loss run template")
 
     # Data hygiene: fix 'None' string corruption in text fields (runs every startup, fast no-op if clean)
     conn.execute("UPDATE clients SET cn_number = NULL WHERE cn_number = 'None'")

--- a/src/policydb/importer.py
+++ b/src/policydb/importer.py
@@ -292,6 +292,13 @@ class PolicyImporter:
                 self.warnings.append(f"Row {i}: missing policy_type or carrier, skipping")
                 self.skipped += 1
                 continue
+            # Touch-once: imported carriers/wholesalers auto-land in the directory
+            # so the loss-run email directory stays comprehensive.
+            from policydb.web.routes.carriers import ensure_carrier_row as _ensure_carrier_row
+            _ensure_carrier_row(self.conn, carrier, "carrier")
+            _ap = (row.get("access_point") or "").strip()
+            if _ap:
+                _ensure_carrier_row(self.conn, _ap, "wholesaler")
 
             eff = _parse_date(row.get("effective_date", ""))
             exp = _parse_date(row.get("expiration_date", ""))

--- a/src/policydb/migrations/149_carriers_table.sql
+++ b/src/policydb/migrations/149_carriers_table.sql
@@ -1,0 +1,30 @@
+-- Carriers & wholesalers directory for loss run request automation
+-- Promotes the previous config-list `carriers` entry to a first-class table
+-- with loss-run email addresses. Wholesalers live in the same table with
+-- type='wholesaler' so the same lookup works for direct-to-carrier and
+-- direct-to-wholesaler loss run requests.
+CREATE TABLE IF NOT EXISTS carriers (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    name           TEXT NOT NULL,
+    type           TEXT NOT NULL DEFAULT 'carrier',    -- 'carrier' | 'wholesaler'
+    loss_run_email TEXT NOT NULL DEFAULT '',
+    loss_run_cc    TEXT NOT NULL DEFAULT '',
+    notes          TEXT NOT NULL DEFAULT '',
+    created_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (name COLLATE NOCASE, type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_carriers_name_nocase ON carriers (name COLLATE NOCASE);
+CREATE INDEX IF NOT EXISTS idx_carriers_type ON carriers (type);
+
+CREATE TRIGGER IF NOT EXISTS carriers_updated_at
+AFTER UPDATE ON carriers
+BEGIN
+    UPDATE carriers SET updated_at = CURRENT_TIMESTAMP WHERE id = NEW.id;
+END;
+
+-- Note: the `email_templates.purpose` column is added by the Python wire in
+-- db.py (migration 149 block) rather than here, with a pragma_table_info()
+-- guard so the migration is safely idempotent across dev machines that may
+-- have applied an earlier variant of the column out-of-band.

--- a/src/policydb/utils.py
+++ b/src/policydb/utils.py
@@ -49,12 +49,17 @@ _BASE_CARRIER_ALIASES: dict[str, str] = {}  # populated on first rebuild_carrier
 
 
 def rebuild_carrier_aliases() -> None:
-    """Rebuild _CARRIER_ALIASES from config with snapshot-then-merge pattern.
+    """Rebuild _CARRIER_ALIASES from config + the carriers directory table.
 
     Merge order (later overrides earlier):
     1. Base carrier aliases from config carrier_aliases (snapshotted on first call)
-    2. carriers config list — each entry self-references as canonical
-    3. carrier_aliases config — user-learned mappings layered on top
+    2. carriers config list — each entry self-references as canonical (legacy seed)
+    3. carriers directory table — source of truth for canonical carrier/wholesaler names
+    4. carrier_aliases config — user-learned mappings layered on top
+
+    The directory table becomes authoritative once migration 148 runs. Before that
+    (or during early test setup when the DB hasn't been initialized), the table
+    read fails silently and we fall back to the config-only behavior.
     """
     global _CARRIER_ALIASES, _BASE_CARRIER_ALIASES
     from policydb import config as cfg
@@ -72,6 +77,24 @@ def rebuild_carrier_aliases() -> None:
     # Layer carriers config list as self-referencing canonicals
     for entry in cfg.get("carriers", []):
         merged[entry.strip().lower()] = entry.strip()
+    # Layer directory table rows (carriers and wholesalers) on top of config seed
+    try:
+        from policydb.db import get_connection
+        _conn = get_connection()
+        try:
+            _rows = _conn.execute(
+                "SELECT name FROM carriers WHERE TRIM(name) != ''"
+            ).fetchall()
+            for _r in _rows:
+                _name = (_r["name"] or "").strip()
+                if _name:
+                    merged[_name.lower()] = _name
+        finally:
+            _conn.close()
+    except Exception:
+        # Table doesn't exist yet (pre-migration) or DB not initialized —
+        # fall through to config-only behavior.
+        pass
     # Layer user-learned aliases on top
     for canonical, variations in aliases.items():
         merged[canonical.lower()] = canonical

--- a/src/policydb/web/app.py
+++ b/src/policydb/web/app.py
@@ -327,7 +327,7 @@ def get_db() -> Generator[sqlite3.Connection, None, None]:
 
 
 # ── Register routers ──────────────────────────────────────────────────────────
-from policydb.web.routes import dashboard, clients, policies, activities, settings, reconcile, templates as tpl_routes, contacts, review, briefing, inbox, ref_lookup, compliance, action_center, logs, compose, import_history, geocoder as geocoder_routes, charts as charts_routes, programs as programs_routes, exports as exports_routes, issues as issues_routes, data_health as data_health_routes, anomalies as anomalies_routes, kb as kb_routes, attachments as attachments_routes, pinned_notes as pinned_notes_routes, outlook_routes, prompt_builder as prompt_builder_routes, bind_order as bind_order_routes, recurring_events as recurring_events_routes, open_tasks as open_tasks_routes  # noqa: E402
+from policydb.web.routes import dashboard, clients, policies, activities, settings, reconcile, templates as tpl_routes, contacts, review, briefing, inbox, ref_lookup, compliance, action_center, logs, compose, import_history, geocoder as geocoder_routes, charts as charts_routes, programs as programs_routes, exports as exports_routes, issues as issues_routes, data_health as data_health_routes, anomalies as anomalies_routes, kb as kb_routes, attachments as attachments_routes, pinned_notes as pinned_notes_routes, outlook_routes, prompt_builder as prompt_builder_routes, bind_order as bind_order_routes, recurring_events as recurring_events_routes, open_tasks as open_tasks_routes, carriers as carriers_routes  # noqa: E402
 
 app.include_router(dashboard.router)
 app.include_router(clients.router)
@@ -361,6 +361,7 @@ app.include_router(prompt_builder_routes.router)
 app.include_router(bind_order_routes.router)
 app.include_router(recurring_events_routes.router)
 app.include_router(open_tasks_routes.router)
+app.include_router(carriers_routes.router)
 
 # Static files (charts JS/CSS assets)
 STATIC_DIR = Path(__file__).parent / "static"

--- a/src/policydb/web/routes/carriers.py
+++ b/src/policydb/web/routes/carriers.py
@@ -1,0 +1,349 @@
+"""Carrier & wholesaler directory — loss run email addresses + metadata.
+
+First-class table promoted from the legacy `carriers` config list. Used by
+the loss run request automation to look up where to send requests, and by
+the importer to ensure every referenced carrier has a row.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+
+from fastapi import APIRouter, Depends, Form, Query, Request
+from fastapi.responses import HTMLResponse, JSONResponse
+
+from policydb.utils import clean_email, normalize_carrier
+from policydb.web.app import get_db, templates
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/carriers", tags=["carriers"])
+
+VALID_TYPES = {"carrier", "wholesaler"}
+EDITABLE_FIELDS = {"name", "type", "loss_run_email", "loss_run_cc", "notes"}
+
+
+# ── Lookup helpers used by other modules ─────────────────────────────────────
+
+
+FUZZY_MATCH_THRESHOLD = 85  # rapidfuzz WRatio — mirrors reconciler carrier threshold
+
+
+def _fuzzy_lookup(conn: sqlite3.Connection, query: str, type_: str) -> dict | None:
+    """Fuzzy-match `query` against directory rows of the given type.
+
+    Uses rapidfuzz.WRatio (same scorer the reconciler uses for carrier pairing).
+    Returns the best row above FUZZY_MATCH_THRESHOLD, or None.
+    """
+    query = (query or "").strip()
+    if not query:
+        return None
+    try:
+        from rapidfuzz import process, fuzz
+    except ImportError:
+        return None
+    rows = conn.execute(
+        "SELECT * FROM carriers WHERE type = ? AND TRIM(name) != ''",
+        (type_,),
+    ).fetchall()
+    if not rows:
+        return None
+    choices = {r["name"]: dict(r) for r in rows}
+    match = process.extractOne(
+        query,
+        list(choices.keys()),
+        scorer=fuzz.WRatio,
+        score_cutoff=FUZZY_MATCH_THRESHOLD,
+    )
+    if match:
+        return choices[match[0]]
+    return None
+
+
+def lookup_destination(
+    conn: sqlite3.Connection,
+    *,
+    carrier_name: str = "",
+    wholesaler_name: str = "",
+) -> dict | None:
+    """Return the preferred loss-run destination for a policy.
+
+    Wholesaler wins when present — mirrors real business flow where the
+    intermediary owns the carrier relationship. Falls back to the carrier
+    row when no wholesaler is set. Returns None if neither matches.
+
+    Lookup chain per candidate:
+        1. Exact normalized name (via normalize_carrier + carrier_aliases)
+        2. Exact raw name (case-insensitive) — covers rows not yet in aliases
+        3. Fuzzy WRatio >= 85 (same threshold the reconciler uses for carriers)
+    """
+    wholesaler_name = (wholesaler_name or "").strip()
+    if wholesaler_name:
+        row = conn.execute(
+            "SELECT * FROM carriers WHERE name = ? COLLATE NOCASE AND type = 'wholesaler' LIMIT 1",
+            (wholesaler_name,),
+        ).fetchone()
+        if row:
+            return dict(row)
+        fuzzy = _fuzzy_lookup(conn, wholesaler_name, "wholesaler")
+        if fuzzy:
+            return fuzzy
+
+    carrier_name = (carrier_name or "").strip()
+    if carrier_name:
+        canonical = normalize_carrier(carrier_name)
+        row = conn.execute(
+            "SELECT * FROM carriers WHERE name = ? COLLATE NOCASE AND type = 'carrier' LIMIT 1",
+            (canonical or carrier_name,),
+        ).fetchone()
+        if row:
+            return dict(row)
+        if canonical and canonical.lower() != carrier_name.lower():
+            row = conn.execute(
+                "SELECT * FROM carriers WHERE name = ? COLLATE NOCASE AND type = 'carrier' LIMIT 1",
+                (carrier_name,),
+            ).fetchone()
+            if row:
+                return dict(row)
+        # Fuzzy fallback — catches typos and minor variants
+        fuzzy = _fuzzy_lookup(conn, canonical or carrier_name, "carrier")
+        if fuzzy:
+            return fuzzy
+    return None
+
+
+def ensure_carrier_row(conn: sqlite3.Connection, name: str, type_: str = "carrier") -> None:
+    """Insert a blank carriers row if the name isn't already present.
+
+    Called by the importer and by the compose "Save destination" flow so
+    the directory stays comprehensive without the user having to manually
+    pre-populate it. Idempotent — safe to call repeatedly.
+    """
+    name = (name or "").strip()
+    if not name:
+        return
+    if type_ not in VALID_TYPES:
+        type_ = "carrier"
+    conn.execute(
+        "INSERT OR IGNORE INTO carriers (name, type) VALUES (?, ?)",
+        (name, type_),
+    )
+
+
+def upsert_loss_run_email(
+    conn: sqlite3.Connection,
+    *,
+    name: str,
+    type_: str,
+    email: str,
+    cc: str = "",
+) -> None:
+    """Insert-or-update the loss run destination for a carrier/wholesaler.
+
+    Used by the compose "Save destination" checkbox so the directory
+    compiles itself as the user works.
+    """
+    name = (name or "").strip()
+    email = clean_email(email) or (email or "").strip()
+    if not name or not email:
+        return
+    if type_ not in VALID_TYPES:
+        type_ = "carrier"
+    row = conn.execute(
+        "SELECT id FROM carriers WHERE name = ? COLLATE NOCASE AND type = ? LIMIT 1",
+        (name, type_),
+    ).fetchone()
+    if row:
+        conn.execute(
+            "UPDATE carriers SET loss_run_email = ?, loss_run_cc = ? WHERE id = ?",
+            (email, cc or "", row["id"]),
+        )
+    else:
+        conn.execute(
+            "INSERT INTO carriers (name, type, loss_run_email, loss_run_cc) VALUES (?, ?, ?, ?)",
+            (name, type_, email, cc or ""),
+        )
+
+
+# ── Routes ───────────────────────────────────────────────────────────────────
+
+
+@router.get("", response_class=HTMLResponse)
+def carriers_index(
+    request: Request,
+    conn: sqlite3.Connection = Depends(get_db),
+    q: str = Query(""),
+    type_filter: str = Query("all", alias="type"),
+):
+    """Directory page — contenteditable table with search + type filter."""
+    sql = "SELECT * FROM carriers"
+    where = []
+    params: list = []
+    if q.strip():
+        where.append("(name LIKE ? OR loss_run_email LIKE ? OR notes LIKE ?)")
+        needle = f"%{q.strip()}%"
+        params.extend([needle, needle, needle])
+    if type_filter in VALID_TYPES:
+        where.append("type = ?")
+        params.append(type_filter)
+    if where:
+        sql += " WHERE " + " AND ".join(where)
+    sql += " ORDER BY type DESC, name COLLATE NOCASE"
+    rows = [dict(r) for r in conn.execute(sql, params).fetchall()]
+
+    counts = conn.execute(
+        "SELECT type, COUNT(*) AS c FROM carriers GROUP BY type"
+    ).fetchall()
+    count_by_type = {r["type"]: r["c"] for r in counts}
+    count_by_type.setdefault("carrier", 0)
+    count_by_type.setdefault("wholesaler", 0)
+    count_with_email = conn.execute(
+        "SELECT COUNT(*) FROM carriers WHERE TRIM(loss_run_email) != ''"
+    ).fetchone()[0]
+
+    return templates.TemplateResponse("carriers/index.html", {
+        "request": request,
+        "active": "carriers",
+        "carriers": rows,
+        "q": q,
+        "type_filter": type_filter if type_filter in VALID_TYPES else "all",
+        "count_by_type": count_by_type,
+        "count_with_email": count_with_email,
+        "count_total": sum(count_by_type.values()),
+    })
+
+
+@router.post("", response_class=HTMLResponse)
+def carriers_create(
+    request: Request,
+    name: str = Form(""),
+    type_: str = Form("carrier", alias="type"),
+    loss_run_email: str = Form(""),
+    loss_run_cc: str = Form(""),
+    notes: str = Form(""),
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    """Insert a new row from the `+ Add row` affordance. Returns the new row."""
+    name = (name or "").strip() or "New carrier"
+    if type_ not in VALID_TYPES:
+        type_ = "carrier"
+    email_clean = clean_email(loss_run_email) if loss_run_email else ""
+    cc_clean = clean_email(loss_run_cc) if loss_run_cc else ""
+    try:
+        cur = conn.execute(
+            """INSERT INTO carriers (name, type, loss_run_email, loss_run_cc, notes)
+               VALUES (?, ?, ?, ?, ?)""",
+            (name, type_, email_clean, cc_clean, (notes or "").strip()),
+        )
+        conn.commit()
+        new_id = cur.lastrowid
+    except sqlite3.IntegrityError:
+        # Duplicate name+type — return existing row so the UI can surface it
+        row = conn.execute(
+            "SELECT id FROM carriers WHERE name = ? COLLATE NOCASE AND type = ? LIMIT 1",
+            (name, type_),
+        ).fetchone()
+        new_id = row["id"] if row else None
+    if not new_id:
+        return HTMLResponse("", status_code=400)
+    row = conn.execute("SELECT * FROM carriers WHERE id = ?", (new_id,)).fetchone()
+    return templates.TemplateResponse("carriers/_row.html", {
+        "request": request,
+        "c": dict(row),
+    })
+
+
+@router.patch("/{carrier_id}")
+def carriers_patch(
+    carrier_id: int,
+    field: str = Form(...),
+    value: str = Form(""),
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    """Cell-save PATCH — contenteditable blur handler.
+
+    Returns `{"ok": true, "formatted": ...}` per the standard PolicyDB PATCH
+    contract so the JS callback can flash the cell.
+
+    Renames cascade: when `field='name'`, matching policies.carrier (or
+    access_point for wholesalers) are updated in the same transaction and
+    the in-memory alias map is rebuilt so subsequent normalize_carrier()
+    calls see the new canonical.
+    """
+    if field not in EDITABLE_FIELDS:
+        return JSONResponse({"ok": False, "error": f"unknown field: {field}"}, status_code=400)
+    row = conn.execute("SELECT * FROM carriers WHERE id = ?", (carrier_id,)).fetchone()
+    if not row:
+        return JSONResponse({"ok": False, "error": "not found"}, status_code=404)
+
+    raw = (value or "").strip()
+    formatted = raw
+    old_name = row["name"]
+    row_type = row["type"]
+
+    if field == "type":
+        if raw not in VALID_TYPES:
+            return JSONResponse({"ok": False, "error": "type must be carrier or wholesaler"}, status_code=400)
+    elif field in ("loss_run_email", "loss_run_cc"):
+        if raw:
+            cleaned = clean_email(raw)
+            if not cleaned:
+                return JSONResponse({"ok": False, "error": "invalid email"}, status_code=400)
+            formatted = cleaned
+        else:
+            formatted = ""
+    elif field == "name":
+        if not raw:
+            return JSONResponse({"ok": False, "error": "name required"}, status_code=400)
+
+    try:
+        conn.execute(
+            f"UPDATE carriers SET {field} = ? WHERE id = ?",
+            (formatted, carrier_id),
+        )
+        # Rename cascade: propagate the new name to policies in the same transaction
+        cascaded = 0
+        if field == "name" and formatted and formatted.lower() != (old_name or "").lower():
+            if row_type == "carrier":
+                cur = conn.execute(
+                    "UPDATE policies SET carrier = ? WHERE carrier = ? COLLATE NOCASE",
+                    (formatted, old_name),
+                )
+                cascaded = cur.rowcount or 0
+            elif row_type == "wholesaler":
+                cur = conn.execute(
+                    "UPDATE policies SET access_point = ? WHERE access_point = ? COLLATE NOCASE",
+                    (formatted, old_name),
+                )
+                cascaded = cur.rowcount or 0
+        conn.commit()
+        if field == "name":
+            # Refresh the in-memory alias map so normalize_carrier() picks up the rename.
+            try:
+                from policydb.utils import rebuild_carrier_aliases
+                rebuild_carrier_aliases()
+            except Exception:
+                pass
+            if cascaded:
+                logger.info(
+                    "Carrier rename cascaded: %r → %r across %d policies (type=%s)",
+                    old_name, formatted, cascaded, row_type,
+                )
+    except sqlite3.IntegrityError:
+        return JSONResponse({"ok": False, "error": "duplicate name+type"}, status_code=409)
+
+    response: dict = {"ok": True, "formatted": formatted}
+    if field == "name":
+        response["cascaded"] = cascaded
+    return JSONResponse(response)
+
+
+@router.delete("/{carrier_id}")
+def carriers_delete(
+    carrier_id: int,
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    conn.execute("DELETE FROM carriers WHERE id = ?", (carrier_id,))
+    conn.commit()
+    return HTMLResponse("")

--- a/src/policydb/web/routes/compose.py
+++ b/src/policydb/web/routes/compose.py
@@ -239,11 +239,55 @@ def compose_panel(
     template_id: int = Query(0),
     issue_uid: str = Query(""),
     program_uid: str = Query(""),
+    purpose: str = Query(""),
 ):
     """Return the compose slideover HTML partial."""
 
     # ── Build rendering context based on params ──────────────────────────
     ctx: dict = {}
+
+    # ── Loss-run purpose pre-resolution ──────────────────────────────────
+    # When opened via "Request Loss Run" button on a policy, look up the
+    # carrier/wholesaler in the directory, auto-select the seeded template,
+    # and enable the "Save destination" checkbox so unknown destinations
+    # compile the directory on send.
+    loss_run_mode = (purpose == "loss_run_request")
+    loss_run_hint = ""
+    loss_run_destination = {"name": "", "type": "carrier"}
+    if loss_run_mode and policy_uid:
+        from policydb.web.routes.carriers import lookup_destination
+        _pol = conn.execute(
+            "SELECT carrier, access_point FROM policies WHERE policy_uid = ?",
+            (policy_uid.upper(),),
+        ).fetchone()
+        if _pol:
+            _carrier = (_pol["carrier"] or "").strip()
+            _wholesaler = (_pol["access_point"] or "").strip()
+            # Wholesaler wins when present (matches lookup_destination precedence)
+            if _wholesaler:
+                loss_run_destination = {"name": _wholesaler, "type": "wholesaler"}
+            elif _carrier:
+                loss_run_destination = {"name": _carrier, "type": "carrier"}
+            _dest = lookup_destination(conn, carrier_name=_carrier, wholesaler_name=_wholesaler)
+            if _dest and _dest.get("loss_run_email"):
+                to_email = _dest["loss_run_email"]
+                # Use the canonical directory name for save-destination upsert
+                loss_run_destination = {
+                    "name": _dest["name"],
+                    "type": _dest["type"],
+                }
+            else:
+                loss_run_hint = (
+                    f"No loss run email on file for {loss_run_destination['name'] or 'this policy'}. "
+                    "Fill in the To field — leave 'Save destination' checked and it'll be added to the directory."
+                )
+        # Auto-select the loss-run template if one isn't already requested
+        if not template_id:
+            _tpl_row = conn.execute(
+                "SELECT id FROM email_templates WHERE purpose = 'loss_run_request' ORDER BY id LIMIT 1"
+            ).fetchone()
+            if _tpl_row:
+                template_id = _tpl_row["id"]
 
     if issue_uid:
         ctx = issue_context(conn, issue_uid)
@@ -323,12 +367,17 @@ def compose_panel(
     primary_to = {}
     if to_email:
         # Explicit To address passed from per-contact email button
+        # or from loss-run directory lookup
         for r in recipients:
             if r["email"].strip().lower() == to_email.strip().lower():
                 primary_to = r
                 break
         if not primary_to:
             primary_to = {"name": "", "email": to_email, "role": "", "badge": "", "source": "manual"}
+    elif loss_run_mode:
+        # Loss run with no directory match — leave To blank so the user
+        # types the carrier's email. Never default to a client contact.
+        primary_to = {}
     elif mode != "rfi_notify":
         # Default: first CLIENT badge contact only — never default to
         # placement colleagues or underwriters in the To field
@@ -418,21 +467,24 @@ def compose_panel(
             body = rendered_body
 
     # ── Load available templates for dropdown ────────────────────────────
+    # Exclude purpose-tagged templates (e.g. loss_run_request) — those only
+    # surface via their dedicated flows, not the generic template picker.
+    _purpose_filter = "(purpose IS NULL OR purpose = '')"
     if program_uid:
         tpl_rows = conn.execute(
-            "SELECT * FROM email_templates WHERE context IN ('policy','general') ORDER BY context, name"
+            f"SELECT * FROM email_templates WHERE context IN ('policy','general') AND {_purpose_filter} ORDER BY context, name"
         ).fetchall()
     elif policy_uid or project_name:
         tpl_rows = conn.execute(
-            "SELECT * FROM email_templates WHERE context IN ('policy','general') ORDER BY context, name"
+            f"SELECT * FROM email_templates WHERE context IN ('policy','general') AND {_purpose_filter} ORDER BY context, name"
         ).fetchall()
     elif client_id:
         tpl_rows = conn.execute(
-            "SELECT * FROM email_templates WHERE context IN ('client','general') ORDER BY context, name"
+            f"SELECT * FROM email_templates WHERE context IN ('client','general') AND {_purpose_filter} ORDER BY context, name"
         ).fetchall()
     else:
         tpl_rows = conn.execute(
-            "SELECT * FROM email_templates WHERE context='general' ORDER BY name"
+            f"SELECT * FROM email_templates WHERE context='general' AND {_purpose_filter} ORDER BY name"
         ).fetchall()
     available_templates = [dict(r) for r in tpl_rows]
 
@@ -455,6 +507,10 @@ def compose_panel(
         "available_templates": available_templates,
         "template_id": template_id,
         "ctx": ctx,
+        "purpose": purpose,
+        "loss_run_mode": loss_run_mode,
+        "loss_run_hint": loss_run_hint,
+        "loss_run_destination": loss_run_destination,
     })
 
 

--- a/src/policydb/web/routes/outlook_routes.py
+++ b/src/policydb/web/routes/outlook_routes.py
@@ -42,6 +42,14 @@ class ComposeRequest(BaseModel):
     project_name: str = ""
     include_policy_table: bool = False
     formal_format: bool = False
+    # Optional purpose tag for downstream tracking / attachment auto-categorization
+    purpose: str = ""
+    # Loss-run-request specific flags — only set by the loss-run flow
+    auto_log_activity: bool = False
+    follow_up_days: int | None = None
+    save_destination: bool = False
+    destination_name: str = ""
+    destination_type: str = ""
 
 
 @router.get("/status")
@@ -157,6 +165,69 @@ def outlook_compose(req: ComposeRequest, conn=Depends(get_db)):
         subject=subject,
         html_body=html_body,
     )
+
+    # ── Optional post-send side effects (loss-run flow) ──────────────────
+    # Only runs when the draft was actually created in Outlook. If the
+    # AppleScript bridge failed, skip the activity write and directory
+    # upsert so we don't leave orphan tracking rows for an email the user
+    # never saw.
+    if result.get("ok") and (req.auto_log_activity or req.save_destination):
+        from datetime import date, timedelta
+
+        policy_id = None
+        client_id = req.client_id or 0
+        if req.policy_uid:
+            _pol = conn.execute(
+                "SELECT id, client_id FROM policies WHERE policy_uid = ?",
+                (req.policy_uid.upper(),),
+            ).fetchone()
+            if _pol:
+                policy_id = _pol["id"]
+                if not client_id:
+                    client_id = _pol["client_id"] or 0
+
+        if req.auto_log_activity and (policy_id or client_id):
+            days = req.follow_up_days if req.follow_up_days is not None else int(
+                cfg.get("loss_run_follow_up_days", 7) or 7
+            )
+            follow_up_date = (date.today() + timedelta(days=days)).isoformat() if days else None
+            dest_label = (req.destination_name or req.to or "carrier").strip()
+            subject_note = subject or f"Loss Run Request — {req.policy_uid or ''}"
+            details_note = f"Loss run request sent to {dest_label} ({req.to})."
+            account_exec = cfg.get("default_account_exec", "Grant")
+            conn.execute(
+                """INSERT INTO activity_log
+                   (client_id, policy_id, activity_type, subject, details,
+                    activity_date, follow_up_date, account_exec, disposition,
+                    email_direction)
+                   VALUES (?, ?, 'Email', ?, ?, date('now'), ?, ?, 'Waiting on Carrier', 'outbound')""",
+                (
+                    client_id or None,
+                    policy_id,
+                    subject_note,
+                    details_note,
+                    follow_up_date,
+                    account_exec,
+                ),
+            )
+
+        if req.save_destination and req.destination_name and req.to:
+            from policydb.web.routes.carriers import upsert_loss_run_email
+            upsert_loss_run_email(
+                conn,
+                name=req.destination_name,
+                type_=(req.destination_type or "carrier"),
+                email=req.to,
+                cc=", ".join(req.cc) if req.cc else "",
+            )
+            # Refresh the alias map so normalize_carrier() picks up any new name.
+            try:
+                from policydb.utils import rebuild_carrier_aliases
+                rebuild_carrier_aliases()
+            except Exception:
+                pass
+
+        conn.commit()
 
     return JSONResponse(result)
 

--- a/src/policydb/web/routes/policies.py
+++ b/src/policydb/web/routes/policies.py
@@ -523,6 +523,12 @@ def policy_new_post(
     policy_type = normalize_coverage_type(policy_type)
     carrier = normalize_carrier(carrier) if carrier else ""
     policy_number = normalize_policy_number(policy_number) if policy_number else ""
+    # Touch-once: new carriers / wholesalers auto-land in the directory.
+    from policydb.web.routes.carriers import ensure_carrier_row as _ensure_carrier_row
+    if carrier:
+        _ensure_carrier_row(conn, carrier, "carrier")
+    if access_point and access_point.strip():
+        _ensure_carrier_row(conn, access_point.strip(), "wholesaler")
     # Parse currency shorthand (e.g., "$5M" → 5000000)
     premium = str(_parse_money(premium) or 0) if premium else premium
     limit_amount = str(_parse_money(limit_amount) or '') if limit_amount else limit_amount
@@ -3500,6 +3506,12 @@ def policy_edit_post(
     policy_type = normalize_coverage_type(policy_type)
     carrier = normalize_carrier(carrier) if carrier else ""
     policy_number = normalize_policy_number(policy_number) if policy_number else ""
+    # Touch-once: edited carriers / wholesalers auto-land in the directory.
+    from policydb.web.routes.carriers import ensure_carrier_row as _ensure_carrier_row
+    if carrier:
+        _ensure_carrier_row(conn, carrier, "carrier")
+    if access_point and access_point.strip():
+        _ensure_carrier_row(conn, access_point.strip(), "wholesaler")
     exposure_address = exposure_address.strip() if exposure_address else ""
     exposure_city = format_city(exposure_city) if exposure_city else ""
     exposure_state = format_state(exposure_state) if exposure_state else ""
@@ -3772,6 +3784,17 @@ async def policy_cell_save(request: Request, policy_uid: str, conn=Depends(get_d
     elif field == "carrier":
         formatted = normalize_carrier(value)
         conn.execute("UPDATE policies SET carrier = ? WHERE policy_uid = ?", (formatted or None, uid))
+        if formatted:
+            # Touch-once: carrier typed on any policy lands in the directory.
+            from policydb.web.routes.carriers import ensure_carrier_row
+            ensure_carrier_row(conn, formatted, "carrier")
+    elif field == "access_point":
+        formatted = value.strip()
+        conn.execute("UPDATE policies SET access_point = ? WHERE policy_uid = ?", (formatted or None, uid))
+        if formatted:
+            # Touch-once: wholesaler typed in access_point lands in the directory.
+            from policydb.web.routes.carriers import ensure_carrier_row
+            ensure_carrier_row(conn, formatted, "wholesaler")
     elif field == "renewal_status":
         val = value.strip()
         # Capture prior status for revert

--- a/src/policydb/web/routes/templates.py
+++ b/src/policydb/web/routes/templates.py
@@ -53,15 +53,16 @@ def template_create(
     description: str = Form(""),
     subject_template: str = Form(""),
     body_template: str = Form(""),
+    purpose: str = Form(""),
     conn=Depends(get_db),
 ):
     from fastapi.responses import RedirectResponse
     context = context if context in _CONTEXT_LABELS else "policy"
     conn.execute(
-        """INSERT INTO email_templates (name, context, description, subject_template, body_template)
-           VALUES (?, ?, ?, ?, ?)""",
+        """INSERT INTO email_templates (name, context, description, subject_template, body_template, purpose)
+           VALUES (?, ?, ?, ?, ?, ?)""",
         (name.strip(), context, description.strip() or None,
-         subject_template, body_template),
+         subject_template, body_template, (purpose or "").strip()),
     )
     conn.commit()
     return RedirectResponse("/templates", status_code=303)
@@ -112,16 +113,17 @@ def template_edit_save(
     description: str = Form(""),
     subject_template: str = Form(""),
     body_template: str = Form(""),
+    purpose: str = Form(""),
     conn=Depends(get_db),
 ):
     context = context if context in _CONTEXT_LABELS else "policy"
     conn.execute(
         """UPDATE email_templates
            SET name=?, context=?, description=?, subject_template=?, body_template=?,
-               updated_at=CURRENT_TIMESTAMP
+               purpose=?, updated_at=CURRENT_TIMESTAMP
            WHERE id=?""",
         (name.strip(), context, description.strip() or None,
-         subject_template, body_template, template_id),
+         subject_template, body_template, (purpose or "").strip(), template_id),
     )
     conn.commit()
     row = conn.execute(

--- a/src/policydb/web/templates/_compose_slideover.html
+++ b/src/policydb/web/templates/_compose_slideover.html
@@ -31,7 +31,8 @@
 
     {# ── Context label ── #}
     {% set _ctx_label %}
-      {% if mode == 'rfi_notify' %}RFI Notification
+      {% if loss_run_mode %}Loss Run Request: {{ loss_run_destination.name or ctx.get('policy_uid', policy_uid) }}
+      {% elif mode == 'rfi_notify' %}RFI Notification
       {% elif policy_uid %}Policy: {{ ctx.get('policy_uid', policy_uid) }}
       {% elif project_name %}Location: {{ project_name }}
       {% elif client_id %}Client: {{ ctx.get('client_name', '') }}
@@ -39,13 +40,33 @@
       {% endif %}
     {% endset %}
     <div>
-      <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-600">
+      <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium {% if loss_run_mode %}bg-blue-100 text-blue-700{% else %}bg-gray-100 text-gray-600{% endif %}">
         {{ _ctx_label | trim }}
       </span>
     </div>
 
+    {% if loss_run_mode and loss_run_hint %}
+    <div class="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+      {{ loss_run_hint }}
+    </div>
+    {% endif %}
+
     {# ── Recipient picker ── #}
     {% include "_recipient_picker.html" %}
+
+    {% if loss_run_mode and loss_run_destination.name %}
+    <label class="flex items-start gap-2 cursor-pointer text-xs text-gray-600 -mt-1">
+      <input type="checkbox" id="compose-save-destination"
+             class="rounded border-gray-300 mt-0.5" checked>
+      <span>
+        Save the To address as
+        <span class="font-semibold">{{ loss_run_destination.name }}</span>'s
+        loss run email in the
+        <span class="italic">{{ loss_run_destination.type }}s</span>
+        directory on send.
+      </span>
+    </label>
+    {% endif %}
 
     {# ── Separator ── #}
     <hr class="border-gray-100">
@@ -150,7 +171,11 @@
     bundle_id: {{ bundle_id | tojson }},
     mode: {{ mode | tojson }},
     ref_tag: {{ ref_tag | tojson }},
-    issue_uid: {{ (issue_uid | default('')) | tojson }}
+    issue_uid: {{ (issue_uid | default('')) | tojson }},
+    purpose: {{ (purpose | default('')) | tojson }},
+    loss_run_mode: {{ (loss_run_mode | default(false)) | tojson }},
+    destination_name: {{ (loss_run_destination.name if loss_run_destination else '') | tojson }},
+    destination_type: {{ (loss_run_destination.type if loss_run_destination else '') | tojson }}
   };
 
   window.markComposeEdited = function() {
@@ -359,21 +384,37 @@
     var formalCheck = document.getElementById('compose-formal');
     if (formalCheck) formalFormat = formalCheck.checked;
 
+    var saveDestination = false;
+    var saveCheck = document.getElementById('compose-save-destination');
+    if (saveCheck) saveDestination = saveCheck.checked;
+
+    var requestBody = {
+      to: toEmail,
+      cc: ccEmails,
+      subject: subject,
+      body: body,
+      policy_uid: composeParams.policy_uid,
+      client_id: composeParams.client_id,
+      project_name: composeParams.project_name,
+      issue_uid: composeParams.issue_uid || '',
+      include_policy_table: includeTable,
+      formal_format: formalFormat,
+      purpose: composeParams.purpose || ''
+    };
+    // Loss-run-specific flags — auto-log activity, schedule follow-up,
+    // and optionally compile the destination directory.
+    if (composeParams.loss_run_mode) {
+      requestBody.auto_log_activity = true;
+      requestBody.follow_up_days = 7;
+      requestBody.save_destination = saveDestination;
+      requestBody.destination_name = composeParams.destination_name || '';
+      requestBody.destination_type = composeParams.destination_type || 'carrier';
+    }
+
     fetch('/outlook/compose', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({
-        to: toEmail,
-        cc: ccEmails,
-        subject: subject,
-        body: body,
-        policy_uid: composeParams.policy_uid,
-        client_id: composeParams.client_id,
-        project_name: composeParams.project_name,
-        issue_uid: composeParams.issue_uid || '',
-        include_policy_table: includeTable,
-        formal_format: formalFormat
-      })
+      body: JSON.stringify(requestBody)
     })
     .then(function(r) { return r.json(); })
     .then(function(data) {

--- a/src/policydb/web/templates/base.html
+++ b/src/policydb/web/templates/base.html
@@ -564,7 +564,7 @@
 
             <!-- Tools dropdown -->
             <div class="relative" onmouseenter="openNavDrop(this)" onmouseleave="closeNavDrop(this)">
-              <button class="nav-link flex items-center gap-1 {% if active in ['briefing','reconcile','templates','settings','ref-lookup','review','charts','manual-charts','exports','kb','prompt-builder'] %}bg-marsh-light border-b-2 border-[#c8a96e]{% endif %}">
+              <button class="nav-link flex items-center gap-1 {% if active in ['briefing','reconcile','templates','settings','ref-lookup','review','charts','manual-charts','exports','kb','prompt-builder','carriers'] %}bg-marsh-light border-b-2 border-[#c8a96e]{% endif %}">
                 Tools
                 <svg class="w-3 h-3 opacity-60" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
               </button>
@@ -575,6 +575,7 @@
                 <a href="/briefing" class="block px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-100 {% if active == 'briefing' %}font-semibold text-marsh{% endif %}">Briefing</a>
                 <a href="/reconcile" class="block px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-100 {% if active == 'reconcile' %}font-semibold text-marsh{% endif %}">Reconcile</a>
                 <a href="/templates" class="block px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-100 {% if active == 'templates' %}font-semibold text-marsh{% endif %}">Templates</a>
+                <a href="/carriers" class="block px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-100 {% if active == 'carriers' %}font-semibold text-marsh{% endif %}">Carriers</a>
                 <a href="/prompt-builder" class="block px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-100 {% if active == 'prompt-builder' %}font-semibold text-marsh{% endif %}">Prompt Builder</a>
                 <a href="/kb?source=bookmark" class="block px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-100 {% if active == 'kb' %}font-semibold text-marsh{% endif %}">Bookmarks</a>
                 <a href="/kb" class="block px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-100 {% if active == 'kb' %}font-semibold text-marsh{% endif %}">Knowledge Base</a>

--- a/src/policydb/web/templates/carriers/_row.html
+++ b/src/policydb/web/templates/carriers/_row.html
@@ -1,0 +1,48 @@
+{#
+  Single carrier row for the directory table. Used as the initial render
+  target by POST /carriers (new row) and by PATCH /carriers/{id} after
+  cell saves. Fields blur-save via JS in carriers/index.html.
+#}
+<tr data-carrier-id="{{ c.id }}" class="border-t border-gray-100 hover:bg-gray-50/60">
+  <td class="px-3 py-2">
+    <span contenteditable="true"
+          class="carrier-cell font-medium text-gray-800"
+          data-field="name"
+          data-id="{{ c.id }}"
+          data-placeholder="Carrier name">{{ c.name }}</span>
+  </td>
+  <td class="px-3 py-2 text-xs">
+    <select class="carrier-type-select text-xs border border-gray-200 rounded px-2 py-1 bg-white"
+            data-id="{{ c.id }}">
+      <option value="carrier" {% if c.type == 'carrier' %}selected{% endif %}>Carrier</option>
+      <option value="wholesaler" {% if c.type == 'wholesaler' %}selected{% endif %}>Wholesaler</option>
+    </select>
+  </td>
+  <td class="px-3 py-2">
+    <span contenteditable="true"
+          class="carrier-cell text-gray-700 font-mono text-xs"
+          data-field="loss_run_email"
+          data-id="{{ c.id }}"
+          data-placeholder="lossruns@…">{{ c.loss_run_email }}</span>
+  </td>
+  <td class="px-3 py-2">
+    <span contenteditable="true"
+          class="carrier-cell text-gray-500 font-mono text-xs"
+          data-field="loss_run_cc"
+          data-id="{{ c.id }}"
+          data-placeholder="(optional cc)">{{ c.loss_run_cc }}</span>
+  </td>
+  <td class="px-3 py-2">
+    <span contenteditable="true"
+          class="carrier-cell text-gray-500 text-xs"
+          data-field="notes"
+          data-id="{{ c.id }}"
+          data-placeholder="Notes">{{ c.notes }}</span>
+  </td>
+  <td class="px-3 py-2 whitespace-nowrap text-right no-print">
+    <button type="button"
+            onclick="carrierDelete({{ c.id }}, this)"
+            class="text-xs text-gray-300 hover:text-red-500"
+            title="Delete">&times;</button>
+  </td>
+</tr>

--- a/src/policydb/web/templates/carriers/index.html
+++ b/src/policydb/web/templates/carriers/index.html
@@ -1,0 +1,180 @@
+{% extends "base.html" %}
+{% block title %}Carriers & Wholesalers — PolicyDB{% endblock %}
+{% block content %}
+
+<style>
+  [contenteditable]:empty:before { content: attr(data-placeholder); color: #cbd5e1; pointer-events: none; }
+  .carrier-cell:focus { outline: none; border-bottom: 2px solid var(--color-marsh, #000F47); margin-bottom: -2px; }
+  .carrier-type-select:focus { outline: none; border-color: #000F47; box-shadow: 0 0 0 1px #000F47; }
+  .chip { display: inline-flex; align-items: center; gap: 4px; padding: 3px 10px; border-radius: 9999px; font-size: 11px; font-weight: 600; }
+  .chip-active { background: #000F47; color: white; }
+  .chip-inactive { background: #f3f4f6; color: #6b7280; }
+  .chip-inactive:hover { background: #e5e7eb; }
+</style>
+
+<div class="mb-5">
+  <div class="flex items-center justify-between">
+    <div>
+      <h1 class="text-2xl font-bold text-gray-900">Carriers & Wholesalers</h1>
+      <p class="text-sm text-gray-400 mt-0.5">
+        {{ count_total }} total ·
+        {{ count_by_type.carrier }} carrier{{ 's' if count_by_type.carrier != 1 }} ·
+        {{ count_by_type.wholesaler }} wholesaler{{ 's' if count_by_type.wholesaler != 1 }} ·
+        <span class="text-gray-600">{{ count_with_email }} with loss-run email on file</span>
+      </p>
+    </div>
+  </div>
+
+  <div class="mt-4 flex items-center gap-3 flex-wrap">
+    <form method="get" action="/carriers" class="flex items-center gap-2">
+      <input type="search" name="q" value="{{ q }}" placeholder="Search name, email, notes…"
+             class="border border-gray-300 rounded-lg px-3 py-1.5 text-sm w-64 focus:outline-none focus:ring-2 focus:ring-marsh">
+      {% if type_filter != 'all' %}<input type="hidden" name="type" value="{{ type_filter }}">{% endif %}
+      <button type="submit" class="text-xs text-gray-500 hover:text-marsh">Search</button>
+      {% if q %}<a href="/carriers{% if type_filter != 'all' %}?type={{ type_filter }}{% endif %}" class="text-xs text-gray-400 hover:text-red-500">clear</a>{% endif %}
+    </form>
+
+    <div class="flex items-center gap-1.5 ml-auto">
+      <a href="/carriers{% if q %}?q={{ q }}{% endif %}" class="chip {% if type_filter == 'all' %}chip-active{% else %}chip-inactive{% endif %}">All</a>
+      <a href="/carriers?type=carrier{% if q %}&q={{ q }}{% endif %}" class="chip {% if type_filter == 'carrier' %}chip-active{% else %}chip-inactive{% endif %}">Carriers</a>
+      <a href="/carriers?type=wholesaler{% if q %}&q={{ q }}{% endif %}" class="chip {% if type_filter == 'wholesaler' %}chip-active{% else %}chip-inactive{% endif %}">Wholesalers</a>
+    </div>
+  </div>
+</div>
+
+<div class="card overflow-hidden">
+  <table class="w-full text-sm">
+    <thead class="bg-gray-50 text-xs font-semibold uppercase tracking-wide text-gray-500">
+      <tr>
+        <th class="px-3 py-2 text-left w-[22%]">Name</th>
+        <th class="px-3 py-2 text-left w-[12%]">Type</th>
+        <th class="px-3 py-2 text-left w-[25%]">Loss Run Email</th>
+        <th class="px-3 py-2 text-left w-[18%]">CC</th>
+        <th class="px-3 py-2 text-left">Notes</th>
+        <th class="px-3 py-2 w-10 no-print"></th>
+      </tr>
+    </thead>
+    <tbody id="carriers-tbody">
+      {% for c in carriers %}
+        {% include "carriers/_row.html" %}
+      {% else %}
+      <tr><td colspan="6" class="px-3 py-8 text-center text-sm text-gray-400 italic">
+        No carriers match. {% if q %}Try clearing the search,{% endif %} or add a new row below.
+      </td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+<div class="mt-3 flex items-center gap-2">
+  <button type="button" onclick="carrierAddRow()"
+          class="text-xs text-marsh hover:underline font-medium">+ Add carrier / wholesaler</button>
+  <span class="text-xs text-gray-400">Click any cell to edit — blur to save. Changes flow to every policy lookup.</span>
+</div>
+
+<script>
+(function() {
+  function postPatch(id, field, value) {
+    var fd = new FormData();
+    fd.append('field', field);
+    fd.append('value', value);
+    return fetch('/carriers/' + id, { method: 'PATCH', body: fd })
+      .then(function(r) { return r.json().then(function(j) { return { ok: r.ok, body: j }; }); });
+  }
+
+  // Cell blur save
+  document.addEventListener('blur', function(e) {
+    var el = e.target;
+    if (!el.classList || !el.classList.contains('carrier-cell')) return;
+    var id = el.getAttribute('data-id');
+    var field = el.getAttribute('data-field');
+    if (!id || !field) return;
+    var val = (el.textContent || '').trim();
+    postPatch(id, field, val).then(function(res) {
+      if (res.ok && res.body && res.body.ok) {
+        if (res.body.formatted !== undefined && res.body.formatted !== val) {
+          el.textContent = res.body.formatted;
+        }
+        if (window.flashCell) window.flashCell(el);
+      } else {
+        el.style.backgroundColor = '#fee2e2';
+        setTimeout(function() { el.style.backgroundColor = ''; }, 1200);
+        if (res.body && res.body.error) {
+          console.warn('Carrier save failed:', res.body.error);
+        }
+      }
+    });
+  }, true);
+
+  // Type select save
+  document.addEventListener('change', function(e) {
+    var el = e.target;
+    if (!el.classList || !el.classList.contains('carrier-type-select')) return;
+    var id = el.getAttribute('data-id');
+    if (!id) return;
+    postPatch(id, 'type', el.value).then(function(res) {
+      if (res.ok && res.body && res.body.ok) {
+        if (window.flashCell) window.flashCell(el);
+      }
+    });
+  });
+
+  // Keyboard: Enter commits, Escape cancels
+  document.addEventListener('keydown', function(e) {
+    var el = e.target;
+    if (!el.classList || !el.classList.contains('carrier-cell')) return;
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      el.blur();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      el.blur();
+    }
+  });
+
+  window.carrierAddRow = function() {
+    var fd = new FormData();
+    fd.append('name', 'New carrier');
+    fd.append('type', 'carrier');
+    fetch('/carriers', { method: 'POST', body: fd })
+      .then(function(r) { return r.text(); })
+      .then(function(html) {
+        var tbody = document.getElementById('carriers-tbody');
+        // Remove the empty-state row if present
+        var onlyRow = tbody.querySelector('tr td[colspan]');
+        if (onlyRow) onlyRow.parentElement.remove();
+        tbody.insertAdjacentHTML('afterbegin', html);
+        var firstCell = tbody.querySelector('.carrier-cell[data-field="name"]');
+        if (firstCell) {
+          firstCell.focus();
+          var range = document.createRange();
+          range.selectNodeContents(firstCell);
+          var sel = window.getSelection();
+          sel.removeAllRanges();
+          sel.addRange(range);
+        }
+      });
+  };
+
+  window.carrierDelete = function(id, btn) {
+    if (btn.dataset.confirming === '1') {
+      fetch('/carriers/' + id, { method: 'DELETE' }).then(function() {
+        var row = btn.closest('tr');
+        if (row) row.remove();
+      });
+      return;
+    }
+    btn.dataset.confirming = '1';
+    var origText = btn.textContent;
+    btn.textContent = 'confirm?';
+    btn.classList.add('text-red-500');
+    setTimeout(function() {
+      btn.dataset.confirming = '';
+      btn.textContent = origText;
+      btn.classList.remove('text-red-500');
+    }, 2500);
+  };
+})();
+</script>
+
+{% endblock %}

--- a/src/policydb/web/templates/policies/_policy_row.html
+++ b/src/policydb/web/templates/policies/_policy_row.html
@@ -64,6 +64,10 @@
       hx-target="#row-{{ p.policy_uid }}"
       hx-swap="outerHTML"
       class="text-xs text-amber-600 hover:underline no-print ml-1" title="Log activity">Log</button>
+    <button type="button"
+      hx-get="/compose?policy_uid={{ p.policy_uid }}&purpose=loss_run_request"
+      hx-target="body" hx-swap="beforeend"
+      class="text-xs text-blue-600 hover:underline no-print ml-1" title="Request loss run from carrier / wholesaler">LR</button>
     <button type="button" onclick="copyRefTag(this, '{{ build_ref_tag(cn_number=p.cn_number|default(''), client_id=p.client_id, policy_uid=p.policy_uid, project_id=p.project_id|default(0)) }}')"
       class="text-gray-300 hover:text-marsh text-xs no-print ml-1" title="Copy ref tag">&#10697;</button>
   </td>

--- a/src/policydb/web/templates/policies/edit.html
+++ b/src/policydb/web/templates/policies/edit.html
@@ -41,13 +41,19 @@
           title="More actions">
           <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20"><circle cx="10" cy="4" r="1.5"/><circle cx="10" cy="10" r="1.5"/><circle cx="10" cy="16" r="1.5"/></svg>
         </button>
-        <div id="more-actions-menu" class="hidden absolute right-0 top-full mt-1 w-48 bg-white border border-gray-200 rounded-lg shadow-lg z-50 py-1">
+        <div id="more-actions-menu" class="hidden absolute right-0 top-full mt-1 w-56 bg-white border border-gray-200 rounded-lg shadow-lg z-50 py-1">
           <form method="post" action="/policies/{{ policy.policy_uid }}/renew">
             <button type="button" onclick="confirmAction(this, 'Renew this policy?')"
               class="w-full text-left px-4 py-2 text-sm text-blue-600 hover:bg-blue-50 transition-colors">
               Renew Policy
             </button>
           </form>
+          <button type="button"
+            hx-get="/compose?policy_uid={{ policy.policy_uid }}&purpose=loss_run_request"
+            hx-target="body" hx-swap="beforeend"
+            class="w-full text-left px-4 py-2 text-sm text-blue-600 hover:bg-blue-50 transition-colors">
+            Request Loss Run
+          </button>
           <div class="border-t border-gray-100 my-1"></div>
           <form method="post" action="/policies/{{ policy.policy_uid }}/archive">
             <button type="button" onclick="confirmAction(this, 'Archive this policy?')"


### PR DESCRIPTION
## Summary

- New `/carriers` page (Tools → Carriers) promotes the legacy `carriers` config list to a first-class table with loss-run email directory, housing both carriers and wholesalers with type filter + search + contenteditable cell-save.
- One-click **Request Loss Run** on every policy (row toolbar + detail More menu): auto-resolves the destination via the new directory, opens the compose slideover pre-filled with the seeded template, auto-logs an Email activity with a 7-day "Waiting on Carrier" follow-up, and compiles the directory as a side effect via a "Save destination" checkbox.
- Five-part touch-once wire keeps the new directory, `policies.carrier` / `access_point`, and the reconcile-style `normalize_carrier()` pipeline in sync: alias-map reads from the table, rename cascades to policies, fuzzy WRatio ≥85 fallback, and every policy save path auto-ensures a directory row.

## Migration

- `149_carriers_table.sql` — new `carriers` table (id, name, type, loss_run_email, loss_run_cc, notes), seeded with 22 carriers from the config list. Adds `email_templates.purpose` column (Python-wired with a `pragma_table_info` guard so it's safely idempotent). Seeds a "Loss Run Request" template using existing `policy_context()` tokens — no new tokens needed.

## Files

- **New**: `src/policydb/web/routes/carriers.py`, `src/policydb/web/templates/carriers/{index,_row}.html`, `src/policydb/migrations/149_carriers_table.sql`
- **Modified**: `db.py`, `utils.py`, `config.py`, `app.py`, `base.html`, `importer.py`, `compose.py`, `outlook_routes.py`, `policies.py` (+ row templates + edit.html), `templates.py`, `_compose_slideover.html`

## Test plan
- [x] Migration 149 applies cleanly + seeds 22 carriers + Loss Run Request template
- [x] `/carriers` renders with type filter + search + contenteditable cells
- [x] PATCH cell-save returns `{ok, formatted}` and validates email via `clean_email`
- [x] `/compose?policy_uid=X&purpose=loss_run_request` pre-fills To from directory when known, shows hint + Save box when unknown
- [x] Wholesaler precedence: policy with `access_point=RSG` selects RSG over carrier
- [x] Fuzzy lookup: policy carrier `Trvelers` resolves to `Travelers` → `claims@travelers.com`
- [x] Rename cascade: renaming a carrier in `/carriers` updates matching `policies.carrier` in the same transaction (`cascaded: N` in response)
- [x] Auto-ensure on policy cell save: typing a new carrier name lands a directory row automatically
- [x] End-to-end side effects: activity_log row created with `disposition='Waiting on Carrier'`, `follow_up_date = today + 7`, `email_direction='outbound'`
- [x] Purpose-tagged templates are excluded from the normal compose picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)