### PR TITLE
Open Tasks panel: row context + hover tooltips

### DIFF
--- a/src/policydb/queries.py
+++ b/src/policydb/queries.py
@@ -1210,6 +1210,26 @@ def filter_thread_for_history(rows: list) -> list:
 # Open Tasks panel — aggregated follow-up rollup for issue/client/program/policy
 # ─────────────────────────────────────────────────────────────────────────────
 
+# Shared SELECT projection used by every _open_tasks_for_* query.
+# The helper _open_task_row_from_activity() expects these column aliases.
+_OPEN_TASK_SELECT = """a.id, a.subject, a.activity_type, a.follow_up_date,
+    a.disposition, a.policy_id, a.client_id, a.issue_id, a.program_id, a.details,
+    p.policy_uid, p.policy_type, p.carrier,
+    c.name AS client_name,
+    iss.issue_uid AS issue_uid_joined,
+    iss.subject AS issue_subject_joined,
+    proj.id AS project_id_joined,
+    proj.name AS project_name_joined,
+    pg.program_uid AS program_uid_joined,
+    pg.name AS program_name_joined"""
+
+_OPEN_TASK_JOINS = """LEFT JOIN policies p ON p.id = a.policy_id
+    LEFT JOIN clients c ON c.id = a.client_id
+    LEFT JOIN activity_log iss ON iss.id = a.issue_id AND iss.item_kind = 'issue'
+    LEFT JOIN projects proj ON proj.id = COALESCE(a.project_id, p.project_id)
+    LEFT JOIN programs pg ON pg.id = COALESCE(a.program_id, p.program_id)"""
+
+
 def _open_task_row_from_activity(r) -> dict:
     """Convert a sqlite row from activity_log (+ policy/client joins) into the
     panel's TaskRow shape. Helper shared across scopes."""
@@ -1232,6 +1252,9 @@ def _open_task_row_from_activity(r) -> dict:
             accountability = d.get("accountability", "my_action")
             break
 
+    details_raw = (r["details"] or "") if "details" in keys else ""
+    details_preview = " ".join(details_raw.split())[:160] if details_raw else ""
+
     return {
         "activity_id": str(r["id"]),
         "subject": r["subject"] or r["activity_type"] or "Follow-up",
@@ -1243,9 +1266,19 @@ def _open_task_row_from_activity(r) -> dict:
         "policy_id": r["policy_id"] if "policy_id" in keys else None,
         "policy_uid": r["policy_uid"] if "policy_uid" in keys else None,
         "policy_type": r["policy_type"] if "policy_type" in keys else None,
+        "carrier": r["carrier"] if "carrier" in keys else None,
         "client_id": r["client_id"],
         "client_name": r["client_name"] if "client_name" in keys else "",
         "source": "activity",
+        "details_preview": details_preview,
+        "issue_id": r["issue_id"] if "issue_id" in keys else None,
+        "issue_uid": r["issue_uid_joined"] if "issue_uid_joined" in keys else None,
+        "issue_subject": r["issue_subject_joined"] if "issue_subject_joined" in keys else None,
+        "project_id": r["project_id_joined"] if "project_id_joined" in keys else None,
+        "project_name": r["project_name_joined"] if "project_name_joined" in keys else None,
+        "program_id": r["program_id"] if "program_id" in keys else None,
+        "program_uid": r["program_uid_joined"] if "program_uid_joined" in keys else None,
+        "program_name": r["program_name_joined"] if "program_name_joined" in keys else None,
         "is_on_issue": False,          # caller sets
         "linked_to_other_issue": None, # caller sets
         "attach_target_issue_id": None, # caller sets
@@ -1296,17 +1329,13 @@ def _open_tasks_for_issue(conn, issue_id: int) -> dict:
     # On-issue: all open follow-ups linked to this issue (may include rows on
     # non-covered policies too, e.g. client-level activities)
     on_issue_raw = conn.execute(
-        """SELECT a.id, a.subject, a.activity_type, a.follow_up_date,
-                  a.disposition, a.policy_id, a.client_id, a.issue_id,
-                  p.policy_uid, p.policy_type,
-                  c.name AS client_name
+        f"""SELECT {_OPEN_TASK_SELECT}
            FROM activity_log a
-           LEFT JOIN policies p ON p.id = a.policy_id
-           LEFT JOIN clients c ON c.id = a.client_id
+           {_OPEN_TASK_JOINS}
            WHERE a.issue_id = ?
              AND a.follow_up_done = 0
              AND a.follow_up_date IS NOT NULL
-             AND (a.item_kind = 'followup' OR a.item_kind IS NULL)""",
+             AND (a.item_kind = 'followup' OR a.item_kind IS NULL)""",  # noqa: S608
         (issue_id,),
     ).fetchall()
     for r in on_issue_raw:
@@ -1324,15 +1353,9 @@ def _open_tasks_for_issue(conn, issue_id: int) -> dict:
     if policy_ids:
         placeholders = ",".join("?" * len(policy_ids))
         loose_raw = conn.execute(
-            f"""SELECT a.id, a.subject, a.activity_type, a.follow_up_date,
-                       a.disposition, a.policy_id, a.client_id, a.issue_id,
-                       p.policy_uid, p.policy_type,
-                       c.name AS client_name,
-                       other.issue_uid AS other_issue_uid
+            f"""SELECT {_OPEN_TASK_SELECT}
                 FROM activity_log a
-                JOIN policies p ON p.id = a.policy_id
-                LEFT JOIN clients c ON c.id = a.client_id
-                LEFT JOIN activity_log other ON other.id = a.issue_id AND other.item_kind = 'issue'
+                {_OPEN_TASK_JOINS}
                 WHERE a.policy_id IN ({placeholders})
                   AND a.follow_up_done = 0
                   AND a.follow_up_date IS NOT NULL
@@ -1343,7 +1366,7 @@ def _open_tasks_for_issue(conn, issue_id: int) -> dict:
         for r in loose_raw:
             row = _open_task_row_from_activity(r)
             row["is_on_issue"] = False
-            row["linked_to_other_issue"] = r["other_issue_uid"]
+            row["linked_to_other_issue"] = row["issue_uid"]
             loose_rows.append(row)
             total += 1
             if row["days_overdue"] > 0:
@@ -1424,16 +1447,14 @@ def _open_tasks_for_client(conn, client_id: int) -> dict:
     # ── Group 1: direct_client
     direct_rows: list[dict] = []
     for r in conn.execute(
-        """SELECT a.id, a.subject, a.activity_type, a.follow_up_date,
-                  a.disposition, a.policy_id, a.client_id, a.issue_id,
-                  c.name AS client_name
+        f"""SELECT {_OPEN_TASK_SELECT}
            FROM activity_log a
-           JOIN clients c ON c.id = a.client_id
+           {_OPEN_TASK_JOINS}
            WHERE a.client_id = ?
              AND a.policy_id IS NULL
              AND a.follow_up_done = 0
              AND a.follow_up_date IS NOT NULL
-             AND (a.item_kind = 'followup' OR a.item_kind IS NULL)""",
+             AND (a.item_kind = 'followup' OR a.item_kind IS NULL)""",  # noqa: S608
         (client_id,),
     ).fetchall():
         row = _open_task_row_from_activity(r)
@@ -1478,17 +1499,13 @@ def _open_tasks_for_client(conn, client_id: int) -> dict:
         iss_id = iss["issue_id"]
         iss_rows: list[dict] = []
         for r in conn.execute(
-            """SELECT a.id, a.subject, a.activity_type, a.follow_up_date,
-                      a.disposition, a.policy_id, a.client_id, a.issue_id,
-                      p.policy_uid, p.policy_type,
-                      c.name AS client_name
+            f"""SELECT {_OPEN_TASK_SELECT}
                FROM activity_log a
-               LEFT JOIN policies p ON p.id = a.policy_id
-               LEFT JOIN clients c ON c.id = a.client_id
+               {_OPEN_TASK_JOINS}
                WHERE a.issue_id = ?
                  AND a.follow_up_done = 0
                  AND a.follow_up_date IS NOT NULL
-                 AND (a.item_kind = 'followup' OR a.item_kind IS NULL)""",
+                 AND (a.item_kind = 'followup' OR a.item_kind IS NULL)""",  # noqa: S608
             (iss_id,),
         ).fetchall():
             row = _open_task_row_from_activity(r)
@@ -1515,13 +1532,9 @@ def _open_tasks_for_client(conn, client_id: int) -> dict:
     if uncovered:
         ph = ",".join("?" * len(uncovered))
         for r in conn.execute(
-            f"""SELECT a.id, a.subject, a.activity_type, a.follow_up_date,
-                       a.disposition, a.policy_id, a.client_id, a.issue_id,
-                       p.policy_uid, p.policy_type,
-                       c.name AS client_name
+            f"""SELECT {_OPEN_TASK_SELECT}
                 FROM activity_log a
-                JOIN policies p ON p.id = a.policy_id
-                LEFT JOIN clients c ON c.id = a.client_id
+                {_OPEN_TASK_JOINS}
                 WHERE a.policy_id IN ({ph})
                   AND a.follow_up_done = 0
                   AND a.follow_up_date IS NOT NULL
@@ -1598,13 +1611,9 @@ def _open_tasks_for_program(conn, program_id: int) -> dict:
     if issue_ids:
         ph = ",".join("?" * len(issue_ids))
         for r in conn.execute(
-            f"""SELECT a.id, a.subject, a.activity_type, a.follow_up_date,
-                       a.disposition, a.policy_id, a.client_id, a.issue_id,
-                       p.policy_uid, p.policy_type,
-                       c.name AS client_name
+            f"""SELECT {_OPEN_TASK_SELECT}
                 FROM activity_log a
-                LEFT JOIN policies p ON p.id = a.policy_id
-                LEFT JOIN clients c ON c.id = a.client_id
+                {_OPEN_TASK_JOINS}
                 WHERE a.issue_id IN ({ph})
                   AND a.follow_up_done = 0
                   AND a.follow_up_date IS NOT NULL
@@ -1628,15 +1637,9 @@ def _open_tasks_for_program(conn, program_id: int) -> dict:
         else:
             exclude_clause = " AND a.issue_id IS NULL"
         for r in conn.execute(
-            f"""SELECT a.id, a.subject, a.activity_type, a.follow_up_date,
-                       a.disposition, a.policy_id, a.client_id, a.issue_id,
-                       p.policy_uid, p.policy_type,
-                       c.name AS client_name,
-                       other.issue_uid AS other_issue_uid
+            f"""SELECT {_OPEN_TASK_SELECT}
                 FROM activity_log a
-                JOIN policies p ON p.id = a.policy_id
-                LEFT JOIN clients c ON c.id = a.client_id
-                LEFT JOIN activity_log other ON other.id = a.issue_id AND other.item_kind = 'issue'
+                {_OPEN_TASK_JOINS}
                 WHERE a.policy_id IN ({ph})
                   AND a.follow_up_done = 0
                   AND a.follow_up_date IS NOT NULL
@@ -1644,7 +1647,7 @@ def _open_tasks_for_program(conn, program_id: int) -> dict:
             params,
         ).fetchall():
             row = _open_task_row_from_activity(r)
-            row["linked_to_other_issue"] = r["other_issue_uid"]
+            row["linked_to_other_issue"] = row["issue_uid"]
             if issue_ids and not row["linked_to_other_issue"]:
                 row["attach_target_issue_id"] = issue_ids[0] if len(issue_ids) == 1 else None
             loose_rows.append(row)
@@ -1676,23 +1679,17 @@ def _open_tasks_for_policy(conn, policy_id: int) -> dict:
     waiting = 0
 
     for r in conn.execute(
-        """SELECT a.id, a.subject, a.activity_type, a.follow_up_date,
-                  a.disposition, a.policy_id, a.client_id, a.issue_id,
-                  p.policy_uid, p.policy_type,
-                  c.name AS client_name,
-                  other.issue_uid AS other_issue_uid
+        f"""SELECT {_OPEN_TASK_SELECT}
            FROM activity_log a
-           JOIN policies p ON p.id = a.policy_id
-           LEFT JOIN clients c ON c.id = a.client_id
-           LEFT JOIN activity_log other ON other.id = a.issue_id AND other.item_kind = 'issue'
+           {_OPEN_TASK_JOINS}
            WHERE a.policy_id = ?
              AND a.follow_up_done = 0
              AND a.follow_up_date IS NOT NULL
-             AND (a.item_kind = 'followup' OR a.item_kind IS NULL)""",
+             AND (a.item_kind = 'followup' OR a.item_kind IS NULL)""",  # noqa: S608
         (policy_id,),
     ).fetchall():
         row = _open_task_row_from_activity(r)
-        row["linked_to_other_issue"] = r["other_issue_uid"]
+        row["linked_to_other_issue"] = row["issue_uid"]
 
         # Attach target: policy's single open renewal issue if unique
         tgt = conn.execute(

--- a/src/policydb/web/templates/_open_tasks_row.html
+++ b/src/policydb/web/templates/_open_tasks_row.html
@@ -3,7 +3,10 @@
    Expected context: row (a TaskRow dict), scope_type, scope_id.
 #}
 {% set grayed = row.linked_to_other_issue and not row.is_on_issue %}
-<div class="group flex items-start gap-2 px-3 py-2 border-b border-gray-100 hover:bg-gray-50 {% if grayed %}opacity-60{% endif %}"
+{# Suppress issue/program pills when they'd just repeat the group header. #}
+{% set show_issue_pill = row.issue_uid and scope_type != 'issue' %}
+{% set show_program_pill = row.program_uid and scope_type != 'program' %}
+<div class="group/row flex items-start gap-2 px-3 py-2 border-b border-gray-100 hover:bg-gray-50 {% if grayed %}opacity-60{% endif %}"
      data-activity-id="{{ row.activity_id }}">
 
   {# Policy UID pill #}
@@ -18,11 +21,52 @@
     {% endif %}
   </div>
 
-  {# Subject + meta #}
+  {# Subject + details preview + context pills + meta #}
   <div class="flex-1 min-w-0">
-    <div class="text-sm text-gray-800 truncate">{{ row.subject }}</div>
+    <div class="text-sm text-gray-800 truncate font-medium">{{ row.subject }}</div>
+
+    {% if row.details_preview %}
+    <div class="text-[11px] text-gray-500 italic mt-0.5 truncate group-hover/row:whitespace-normal group-hover/row:overflow-visible"
+         title="{{ row.details_preview }}">
+      {{ row.details_preview }}
+    </div>
+    {% endif %}
+
+    {# Context pills — issue, location/project, program #}
+    {% if show_issue_pill or row.project_name or show_program_pill %}
+    <div class="flex flex-wrap items-center gap-1 mt-1">
+      {% if show_issue_pill %}
+      <a href="/issues/{{ row.issue_id }}"
+         class="inline-flex items-center gap-1 text-[10px] font-mono text-amber-700 bg-amber-50 border border-amber-200 hover:bg-amber-100 px-1.5 py-0.5 rounded"
+         title="Linked issue: {{ row.issue_subject or '' }}">
+        <span>⚑</span>
+        <span>{{ row.issue_uid }}</span>
+        {% if row.issue_subject %}<span class="font-sans text-amber-900/70 truncate max-w-[14rem]">· {{ row.issue_subject }}</span>{% endif %}
+      </a>
+      {% endif %}
+
+      {% if row.project_name %}
+      <a href="/clients/{{ row.client_id }}/locations/{{ row.project_id }}"
+         class="inline-flex items-center gap-1 text-[10px] text-emerald-800 bg-emerald-50 border border-emerald-200 hover:bg-emerald-100 px-1.5 py-0.5 rounded"
+         title="Location / Project">
+        <span>📍</span>
+        <span class="truncate max-w-[12rem]">{{ row.project_name }}</span>
+      </a>
+      {% endif %}
+
+      {% if show_program_pill %}
+      <a href="/programs/{{ row.program_uid }}"
+         class="inline-flex items-center gap-1 text-[10px] font-mono text-indigo-800 bg-indigo-50 border border-indigo-200 hover:bg-indigo-100 px-1.5 py-0.5 rounded"
+         title="Program: {{ row.program_name or '' }}">
+        <span>◱</span>
+        <span>{{ row.program_uid }}</span>
+      </a>
+      {% endif %}
+    </div>
+    {% endif %}
+
     <div class="text-[10px] text-gray-400 mt-0.5 truncate">
-      {{ row.policy_type or '—' }} &middot; {{ row.client_name }}{% if row.activity_type %} &middot; {{ row.activity_type }}{% endif %}
+      {{ row.policy_type or '—' }}{% if row.carrier %} · {{ row.carrier }}{% endif %} &middot; {{ row.client_name }}{% if row.activity_type %} &middot; {{ row.activity_type }}{% endif %}
     </div>
   </div>
 
@@ -36,21 +80,50 @@
 
   {# Action buttons — always visible to avoid hover-discoverability problem #}
   <div class="shrink-0 flex items-center gap-1 pt-0.5">
-    {# Mark done #}
-    <button type="button"
-            title="Mark done"
-            hx-post="/open-tasks/{{ row.activity_id }}/done"
-            hx-vals='{"return_scope_type": "{{ scope_type }}", "return_scope_id": {{ scope_id }}}'
-            hx-target="#open-tasks-panel-{{ scope_type }}-{{ scope_id }}"
-            hx-swap="outerHTML"
-            class="text-green-600 hover:bg-green-50 rounded p-1 text-xs">✓</button>
+    {#-
+      Tooltip pattern: wrap button in a relative/group container so the tooltip
+      bubble can absolutely-position above the button and fade in on hover.
+      The native `title=""` is kept alongside for keyboard/screen-reader users.
+    -#}
+    {% macro task_btn(emoji, label, color_classes, extra_attrs='', wrapper_id='') %}
+    <div class="relative group/btn{% if wrapper_id %} {{ wrapper_id }}{% endif %}">
+      <button type="button"
+              title="{{ label }}"
+              aria-label="{{ label }}"
+              {{ extra_attrs | safe }}
+              class="{{ color_classes }} rounded p-1 text-xs">{{ emoji }}</button>
+      <span class="pointer-events-none absolute bottom-full right-0 mb-1 whitespace-nowrap
+                   rounded bg-gray-900 text-white text-[10px] font-medium px-2 py-1 shadow-lg
+                   opacity-0 group-hover/btn:opacity-100 transition z-30">
+        {{ label }}
+      </span>
+    </div>
+    {% endmacro %}
 
-    {# Snooze #}
-    <div class="relative">
-      <button type="button" title="Snooze"
-              onclick="this.nextElementSibling.classList.toggle('hidden')"
+    {# Mark done #}
+    {{ task_btn(
+      '✓',
+      'Mark done — closes this follow-up, no new activity logged',
+      'text-green-600 hover:bg-green-50',
+      'hx-post="/open-tasks/' ~ row.activity_id ~ '/done" ' ~
+      'hx-vals=\'{"return_scope_type": "' ~ scope_type ~ '", "return_scope_id": ' ~ scope_id ~ '}\' ' ~
+      'hx-target="#open-tasks-panel-' ~ scope_type ~ '-' ~ scope_id ~ '" ' ~
+      'hx-swap="outerHTML"'
+    ) }}
+
+    {# Snooze — dropdown #}
+    <div class="relative group/btn">
+      <button type="button"
+              title="Snooze — push the due date out 1/3/7/14 days"
+              aria-label="Snooze"
+              onclick="this.nextElementSibling.nextElementSibling.classList.toggle('hidden')"
               class="text-blue-600 hover:bg-blue-50 rounded p-1 text-xs">💤</button>
-      <div class="hidden absolute right-0 top-full mt-1 bg-white border border-gray-200 rounded shadow-lg z-10 text-xs">
+      <span class="pointer-events-none absolute bottom-full right-0 mb-1 whitespace-nowrap
+                   rounded bg-gray-900 text-white text-[10px] font-medium px-2 py-1 shadow-lg
+                   opacity-0 group-hover/btn:opacity-100 transition z-30">
+        Snooze — push the due date out
+      </span>
+      <div class="hidden absolute right-0 top-full mt-1 bg-white border border-gray-200 rounded shadow-lg z-20 text-xs">
         {% for d in [1, 3, 7, 14] %}
         <button type="button"
                 hx-post="/open-tasks/{{ row.activity_id }}/snooze"
@@ -65,50 +138,75 @@
     {# Waiting toggle #}
     {% if row.source == 'activity' %}
     {% set next_move = "my" if row.accountability == "waiting_external" else "waiting" %}
-    <button type="button"
-            title="Toggle My Move / Waiting"
-            hx-post="/open-tasks/{{ row.activity_id }}/disposition"
-            hx-vals='{"move": "{{ next_move }}", "return_scope_type": "{{ scope_type }}", "return_scope_id": {{ scope_id }}}'
-            hx-target="#open-tasks-panel-{{ scope_type }}-{{ scope_id }}"
-            hx-swap="outerHTML"
-            class="rounded p-1 text-xs {% if row.accountability == 'waiting_external' %}text-amber-600 hover:bg-amber-50{% else %}text-gray-500 hover:bg-gray-100{% endif %}">
-      {% if row.accountability == 'waiting_external' %}⏳{% else %}🏃{% endif %}
-    </button>
+    {% if row.accountability == "waiting_external" %}
+      {{ task_btn(
+        '⏳',
+        'Take back — switches accountability back to you',
+        'text-amber-600 hover:bg-amber-50',
+        'hx-post="/open-tasks/' ~ row.activity_id ~ '/disposition" ' ~
+        'hx-vals=\'{"move": "' ~ next_move ~ '", "return_scope_type": "' ~ scope_type ~ '", "return_scope_id": ' ~ scope_id ~ '}\' ' ~
+        'hx-target="#open-tasks-panel-' ~ scope_type ~ '-' ~ scope_id ~ '" ' ~
+        'hx-swap="outerHTML"'
+      ) }}
+    {% else %}
+      {{ task_btn(
+        '🏃',
+        'Mark as Waiting — switches accountability to the other party',
+        'text-gray-500 hover:bg-gray-100',
+        'hx-post="/open-tasks/' ~ row.activity_id ~ '/disposition" ' ~
+        'hx-vals=\'{"move": "' ~ next_move ~ '", "return_scope_type": "' ~ scope_type ~ '", "return_scope_id": ' ~ scope_id ~ '}\' ' ~
+        'hx-target="#open-tasks-panel-' ~ scope_type ~ '-' ~ scope_id ~ '" ' ~
+        'hx-swap="outerHTML"'
+      ) }}
+    {% endif %}
     {% endif %}
 
     {# Log & close — activity-source only, on-issue rows only #}
     {% if row.source == 'activity' and row.is_on_issue %}
-    <button type="button"
-            title="Log & close (no follow-up)"
-            hx-post="/open-tasks/{{ row.activity_id }}/log-close"
-            hx-vals='{"return_scope_type": "{{ scope_type }}", "return_scope_id": {{ scope_id }}}'
-            hx-target="#open-tasks-panel-{{ scope_type }}-{{ scope_id }}"
-            hx-swap="outerHTML"
-            class="text-gray-500 hover:bg-gray-100 rounded p-1 text-xs">⊗</button>
+    {{ task_btn(
+      '⊗',
+      'Log & close — log the activity and close it without a new follow-up',
+      'text-gray-500 hover:bg-gray-100',
+      'hx-post="/open-tasks/' ~ row.activity_id ~ '/log-close" ' ~
+      'hx-vals=\'{"return_scope_type": "' ~ scope_type ~ '", "return_scope_id": ' ~ scope_id ~ '}\' ' ~
+      'hx-target="#open-tasks-panel-' ~ scope_type ~ '-' ~ scope_id ~ '" ' ~
+      'hx-swap="outerHTML"'
+    ) }}
     {% endif %}
 
     {# Attach / linked-to-other-issue #}
     {% if row.source == 'activity' and not row.is_on_issue %}
       {% if grayed %}
       <a href="/issues/{{ row.linked_to_other_issue }}"
-         class="text-[10px] text-marsh hover:underline px-1">{{ row.linked_to_other_issue }}</a>
+         class="text-[10px] text-marsh hover:underline px-1"
+         title="Linked to {{ row.linked_to_other_issue }}">{{ row.linked_to_other_issue }}</a>
       {% elif row.attach_target_issue_id %}
-      <button type="button"
-              title="Attach to this issue"
-              hx-post="/open-tasks/{{ row.activity_id }}/attach"
-              hx-vals='{"target_issue_id": {{ row.attach_target_issue_id }}, "return_scope_type": "{{ scope_type }}", "return_scope_id": {{ scope_id }}}'
-              hx-target="#open-tasks-panel-{{ scope_type }}-{{ scope_id }}"
-              hx-swap="outerHTML"
-              class="text-marsh hover:bg-blue-50 rounded p-1 text-xs">🔗</button>
+      {{ task_btn(
+        '🔗',
+        'Attach to this issue — link this loose task to the open renewal issue',
+        'text-marsh hover:bg-blue-50',
+        'hx-post="/open-tasks/' ~ row.activity_id ~ '/attach" ' ~
+        'hx-vals=\'{"target_issue_id": ' ~ row.attach_target_issue_id ~ ', "return_scope_type": "' ~ scope_type ~ '", "return_scope_id": ' ~ scope_id ~ '}\' ' ~
+        'hx-target="#open-tasks-panel-' ~ scope_type ~ '-' ~ scope_id ~ '" ' ~
+        'hx-swap="outerHTML"'
+      ) }}
       {% endif %}
     {% endif %}
 
     {# Note #}
     {% if row.source == 'activity' %}
-    <button type="button"
-            title="Add note"
-            onclick="const box = this.parentElement.parentElement.nextElementSibling; box.classList.toggle('hidden'); if (!box.classList.contains('hidden')) box.querySelector('textarea').focus();"
-            class="text-gray-500 hover:bg-gray-100 rounded p-1 text-xs">💬</button>
+    <div class="relative group/btn">
+      <button type="button"
+              title="Add note — append a quick note to the task (saved as activity)"
+              aria-label="Add note"
+              onclick="const box = this.parentElement.parentElement.parentElement.nextElementSibling; box.classList.toggle('hidden'); if (!box.classList.contains('hidden')) box.querySelector('textarea').focus();"
+              class="text-gray-500 hover:bg-gray-100 rounded p-1 text-xs">💬</button>
+      <span class="pointer-events-none absolute bottom-full right-0 mb-1 whitespace-nowrap
+                   rounded bg-gray-900 text-white text-[10px] font-medium px-2 py-1 shadow-lg
+                   opacity-0 group-hover/btn:opacity-100 transition z-30">
+        Add note — append a quick note
+      </span>
+    </div>
     {% endif %}
   </div>
 </div>


### PR DESCRIPTION
## Summary

- Every Open Tasks row now shows the task's **details preview**, and color-coded **issue / location / program pills** so users can triage without opening the source record.
- Emoji action buttons get **plain-English hover tooltips** via a reusable Jinja macro, replacing the slow browser `title=` bubble.
- Backend SELECTs are unified behind shared `_OPEN_TASK_SELECT` / `_OPEN_TASK_JOINS` constants so all four scopes (issue / client / program / policy) pull the same enriched projection.

## Why

On a client page, a row like "Email to Placement" under issue "2026 GL Renewal — Client XYZ" used to show nothing about what the task was or what had happened — forcing a drill-down into the issue or policy every time. The user asked for tooltips on the emoji buttons and richer context on each row, specifically calling out that **location / project** data is needed too.

## What changed

### Backend — `src/policydb/queries.py`
- New `_OPEN_TASK_SELECT` / `_OPEN_TASK_JOINS` constants shared across all 7 SELECTs in `_open_tasks_for_issue/_client/_program/_policy`.
- Joins add: `activity_log iss` (parent issue), `projects proj` (location), `programs pg` (via `COALESCE(a.program_id, p.program_id)` so program tasks inherit from the policy).
- Projection now includes: `a.details`, `p.carrier`, `iss.issue_uid/subject`, `proj.id/name`, `pg.program_uid/name`.
- `_open_task_row_from_activity()` exposes `details_preview` (whitespace-normalized, 160-char trim), `issue_uid/subject/id`, `project_id/name`, `program_uid/name`, and `carrier` on every TaskRow.
- `linked_to_other_issue` now reads from the unified `issue_uid` field (same semantics, one less column alias).

### Template — `src/policydb/web/templates/_open_tasks_row.html`
- New **details preview** line under the subject — italic gray, single-line truncate, expands full on row hover via `group/row` + `group-hover/row:whitespace-normal`.
- New **context pills** row: ⚑ amber issue pill (suppressed when `scope_type == 'issue'`), 📍 emerald location/project pill, ◱ indigo program pill (suppressed when `scope_type == 'program'`).
- New **`task_btn` Jinja macro** renders each emoji button inside a `group/btn` wrapper with an absolutely-positioned tooltip bubble that fades in on hover. Native `title=` and `aria-label=` remain for screen readers.
- Tooltip copy describes **what each button does** in plain English:
  - ✓ "Mark done — closes this follow-up, no new activity logged"
  - 💤 "Snooze — push the due date out 1/3/7/14 days"
  - 🏃 "Mark as Waiting — switches accountability to the other party"
  - ⏳ "Take back — switches accountability back to you"
  - ⊗ "Log & close — log the activity and close it without a new follow-up"
  - 🔗 "Attach to this issue — link this loose task to the open renewal issue"
  - 💬 "Add note — append a quick note to the task (saved as activity)"

## Test plan

- [x] Client scope (Skyline): row shows subject, italic `Called` preview, amber `⚑ 48EB81A3 · Issue: NEW FANCY ISSUE` pill
- [x] Policy scope (POL-015): row shows `📍 Main Street Location` pill
- [x] Issue scope (48EB81A3): issue pill correctly suppressed (group header already names the issue)
- [x] Tooltip bubble renders with full descriptive text on each action button
- [x] Snooze dropdown still opens and fires `hx-post` correctly
- [x] Add-note 💬 toggle reveals the note form against the new deeper nesting
- [x] HTMX attributes (`hx-post`, `hx-vals`, `hx-target`, `hx-swap`) populated correctly on all action buttons
- [x] No migrations, no schema changes, no new routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)