### PR TITLE
fix: RFI attachments at policy level, snooze math, bind order rollover

### DIFF
--- a/src/policydb/bind_order.py
+++ b/src/policydb/bind_order.py
@@ -4,9 +4,11 @@ This module provides the pure-logic core for the Bind Order action:
 
     Subject (program OR standalone policy)
             │
-            ├── For each CHECKED child:
-            │     - if needs_renew: renew_policy() → new term row
-            │     - then mark Bound (set bound_date, log activity, complete
+            ├── For each CHECKED child (not already bound):
+            │     - renew_policy() → archive old term, create new term row
+            │       with the panel-provided dates/premium
+            │     - generate renewal timeline milestones on the new row
+            │     - mark Bound (set bound_date, log activity, complete
             │       milestones, close follow-ups, cascade to program)
             │
             ├── For each UNCHECKED child with a disposition:
@@ -19,6 +21,11 @@ This module provides the pure-logic core for the Bind Order action:
             │     (program-scoped if program; policy-scoped if standalone)
             │
             └── auto_resolve_renewal_issue() for the subject
+
+Every bind commits a new policy term: the old row is archived and a new row
+is created regardless of whether the old row's expiration date has lapsed.
+This keeps one row per term, preserves historical term data on the archived
+row, and lets the new term start its own renewal cycle cleanly.
 
 The module is FastAPI-free. Routes live in web/routes/bind_order.py.
 """
@@ -153,26 +160,21 @@ class BindOrderResult:
 
 
 def resolve_child_state(conn: sqlite3.Connection, policy_uid: str) -> ChildState:
-    """Decide whether a policy needs to be renewed before binding, is ready to
-    bind directly, or has already been bound for its current term.
+    """Classify a policy for the bind panel UI.
 
     Logic:
-      - already_bound: bound_date IS NOT NULL on the current row (this term has
-        already had its bind event recorded)
-      - ready_to_bind: bound_date IS NULL AND there's no successor row (no
-        prior_policy_uid pointing to this row) — i.e., this row IS the new term
-        we want to bind. Either the user pre-renewed proactively, or this is the
-        natural in-place state if the row's expiration hasn't been rolled.
-      - needs_renew: bound_date IS NULL AND the row's expiration_date is in the
-        past or the user has explicitly asked us to renew it. In practice we
-        treat any non-bound row with no successor as ready_to_bind UNLESS the
-        expiration_date has already passed (meaning the row is the *expired*
-        term and we need to roll forward).
+      - already_bound: bound_date IS NOT NULL, row is archived, or a successor
+        row already points back at it. In all three cases binding this row
+        would be a double-bind, so the panel disables the checkbox.
+      - needs_renew: bound_date IS NULL and expiration_date has already lapsed.
+        The row is a stale/expired term that must be rolled forward.
+      - ready_to_bind: bound_date IS NULL and expiration_date is still in the
+        future. Normal unbound row ready to receive this bind event.
 
-    The needs_renew vs ready_to_bind distinction at panel-load time is
-    informational — the panel shows the user which rows will be touched by
-    renew_policy() before bind. Final routing happens in execute_bind_order()
-    so the user can change their mind by editing dates in the panel.
+    NOTE: This state is only a label used by the panel UI — execute_bind_order
+    always calls renew_policy() on every checked, non-already-bound child,
+    regardless of whether the label is needs_renew or ready_to_bind. Every
+    bind creates a new term row.
     """
     row = conn.execute(
         """SELECT policy_uid, bound_date, expiration_date, archived
@@ -672,60 +674,73 @@ def execute_bind_order(
                     all_terminal = False
                 continue
 
-            # CHECKED path — bind it (renewing first if needed)
+            # CHECKED path — always create a new term row, archive the old.
+            # Every bind commits a new policy term: the old row is snapshotted
+            # and archived, the new row receives the bound dates/premium and
+            # kicks off its own renewal timeline.
             state = resolve_child_state(conn, old_uid)
-            renewed_inline = 0
-            new_uid = old_uid
-
-            if state == "needs_renew":
-                old_row = conn.execute(
-                    "SELECT id FROM policies WHERE policy_uid = ?", (old_uid,)
-                ).fetchone()
-                old_id = old_row["id"] if old_row else None
-                new_uid = renew_policy(
-                    conn,
+            if state == "already_bound":
+                # Defensive: the panel UI should disable already-bound rows,
+                # but if one slips through we log and skip rather than
+                # double-bind or silently duplicate.
+                logger.warning(
+                    "Skipping bind for %s: already bound or superseded",
                     old_uid,
-                    new_effective=sp.new_effective,
-                    new_expiration=sp.new_expiration,
-                    new_premium=ch.new_premium,
                 )
-                renewed_inline = 1
-                result.renewed_inline_count += 1
+                continue
 
-                # Re-link the new row to its program (renew_policy doesn't copy program_id)
-                if program:
-                    new_row = conn.execute(
-                        "SELECT id, schematic_column FROM policies WHERE policy_uid = ?",
-                        (new_uid,),
-                    ).fetchone()
-                    if new_row:
-                        # Look up the OLD row's program metadata to preserve schematic_column
-                        old_meta = conn.execute(
-                            """SELECT tower_group, schematic_column
-                               FROM policies WHERE id = ?""",
-                            (old_id,),
-                        ).fetchone() if old_id else None
-                        conn.execute(
-                            """UPDATE policies
-                               SET program_id = ?,
-                                   tower_group = ?,
-                                   schematic_column = ?
-                               WHERE id = ?""",
-                            (
-                                program["id"],
-                                program.get("name"),
-                                old_meta["schematic_column"] if old_meta else None,
-                                new_row["id"],
-                            ),
-                        )
-                        if old_id:
-                            old_to_new_id[old_id] = new_row["id"]
-                        _sync_policy_to_program_location(conn, new_uid, program)
-            elif ch.new_premium is not None:
-                # ready_to_bind but user edited premium in the panel — apply the override
-                conn.execute(
-                    "UPDATE policies SET premium = ? WHERE policy_uid = ?",
-                    (ch.new_premium, old_uid),
+            old_row = conn.execute(
+                "SELECT id FROM policies WHERE policy_uid = ?", (old_uid,)
+            ).fetchone()
+            old_id = old_row["id"] if old_row else None
+            new_uid = renew_policy(
+                conn,
+                old_uid,
+                new_effective=sp.new_effective,
+                new_expiration=sp.new_expiration,
+                new_premium=ch.new_premium,
+            )
+            renewed_inline = 1
+            result.renewed_inline_count += 1
+
+            # Re-link the new row to its program (renew_policy doesn't copy program_id)
+            if program:
+                new_row = conn.execute(
+                    "SELECT id, schematic_column FROM policies WHERE policy_uid = ?",
+                    (new_uid,),
+                ).fetchone()
+                if new_row:
+                    old_meta = conn.execute(
+                        """SELECT tower_group, schematic_column
+                           FROM policies WHERE id = ?""",
+                        (old_id,),
+                    ).fetchone() if old_id else None
+                    conn.execute(
+                        """UPDATE policies
+                           SET program_id = ?,
+                               tower_group = ?,
+                               schematic_column = ?
+                           WHERE id = ?""",
+                        (
+                            program["id"],
+                            program.get("name"),
+                            old_meta["schematic_column"] if old_meta else None,
+                            new_row["id"],
+                        ),
+                    )
+                    if old_id:
+                        old_to_new_id[old_id] = new_row["id"]
+                    _sync_policy_to_program_location(conn, new_uid, program)
+
+            # Generate a fresh renewal timeline on the new term so the
+            # next-cycle milestones (submission, quote, binder, etc.) are
+            # materialized and visible in the Action Center immediately.
+            try:
+                from policydb.timeline_engine import generate_policy_timelines
+                generate_policy_timelines(conn, new_uid)
+            except Exception as e:
+                logger.warning(
+                    "Failed to generate timeline for new term %s: %s", new_uid, e
                 )
 
             # Mark bound (single choke point)

--- a/src/policydb/web/routes/activities.py
+++ b/src/policydb/web/routes/activities.py
@@ -777,14 +777,17 @@ def activity_snooze(request: Request, activity_id: int, days: int = 7, conn=Depe
     row = conn.execute(
         "SELECT follow_up_date, policy_id FROM activity_log WHERE id=?", (activity_id,)
     ).fetchone()
+    today = date.today()
     if row and row["follow_up_date"]:
         try:
             old_date = date.fromisoformat(row["follow_up_date"])
         except (ValueError, TypeError):
-            old_date = date.today()
+            old_date = today
     else:
-        old_date = date.today()
-    new_date = (old_date + timedelta(days=days)).isoformat()
+        old_date = today
+    # Overdue tasks snooze from today; future tasks snooze from their own date.
+    base = max(today, old_date)
+    new_date = (base + timedelta(days=days)).isoformat()
     # Cap against policy expiration
     exp_date = _lookup_expiration(conn, "activity", str(activity_id))
     if exp_date:

--- a/src/policydb/web/routes/clients.py
+++ b/src/policydb/web/routes/clients.py
@@ -5453,6 +5453,7 @@ def request_program_view(request: Request, client_id: int, program_uid: str = ""
                 f"SELECT * FROM client_request_items WHERE bundle_id=? AND policy_uid IN ({placeholders}) ORDER BY received ASC, sort_order ASC, id ASC",
                 [bundle_id] + child_uids,
             ).fetchall()])
+            _attach_item_attachment_counts(conn, items)
 
     client = conn.execute("SELECT id, name FROM clients WHERE id=?", (client_id,)).fetchone()
     return templates.TemplateResponse("clients/_request_policy_view.html", {
@@ -5482,6 +5483,7 @@ def request_policy_view(request: Request, client_id: int, policy_uid: str = "", 
             "SELECT * FROM client_request_items WHERE bundle_id=? AND policy_uid=? ORDER BY received ASC, sort_order ASC, id ASC",
             (bundle_id, policy_uid),
         ).fetchall()])
+        _attach_item_attachment_counts(conn, items)
 
     client = conn.execute("SELECT id, name FROM clients WHERE id=?", (client_id,)).fetchone()
     return templates.TemplateResponse("clients/_request_policy_view.html", {
@@ -5529,6 +5531,7 @@ def get_request_bundle(
         "SELECT * FROM client_request_items WHERE bundle_id=? ORDER BY received ASC, sort_order ASC, id ASC",
         (bundle_id,),
     ).fetchall()])
+    _attach_item_attachment_counts(conn, items)
     client = conn.execute("SELECT id, name FROM clients WHERE id=?", (client_id,)).fetchone()
     policies = [dict(r) for r in conn.execute(
         "SELECT policy_uid, policy_type, carrier, project_name, effective_date FROM policies WHERE client_id=? AND archived=0 ORDER BY policy_type, effective_date DESC",

--- a/src/policydb/web/routes/open_tasks.py
+++ b/src/policydb/web/routes/open_tasks.py
@@ -244,10 +244,14 @@ def action_snooze(
             return new_date
         if not days:
             return current
+        today = date.today()
         try:
-            base = date.fromisoformat(current) if current else date.today()
+            current_date = date.fromisoformat(current) if current else today
         except (ValueError, TypeError):
-            base = date.today()
+            current_date = today
+        # Overdue or undated tasks snooze from today; future-dated tasks snooze
+        # from their scheduled date so a "+3d" on a task 10 days out becomes +13d.
+        base = max(today, current_date)
         return (base + timedelta(days=days)).isoformat()
 
     _kind, rid = _parse_activity_id(activity_id)

--- a/src/policydb/web/routes/policies.py
+++ b/src/policydb/web/routes/policies.py
@@ -4586,14 +4586,17 @@ def policy_snooze_followup(
            FROM policies p WHERE p.policy_uid = ?""",
         (uid,),
     ).fetchone()
+    today = _date.today()
     if pol and pol["follow_up_date"]:
         try:
             old_date = _date.fromisoformat(pol["follow_up_date"])
         except (ValueError, TypeError):
-            old_date = _date.today()
+            old_date = today
     else:
-        old_date = _date.today()
-    new_date = (old_date + _td(days=days)).isoformat()
+        old_date = today
+    # Overdue tasks snooze from today; future tasks snooze from their own date.
+    base = max(today, old_date)
+    new_date = (base + _td(days=days)).isoformat()
     # Cap against expiration
     if pol and pol["expiration_date"]:
         buffer = cfg.get("followup_expiration_buffer_days", 3)

--- a/src/policydb/web/templates/clients/_request_bundle.html
+++ b/src/policydb/web/templates/clients/_request_bundle.html
@@ -140,48 +140,9 @@
 
 </div>
 
+{% include "clients/_request_item_attachments_js.html" %}
+
 <script>
-/* Global: toggle the lazy-loaded attachment panel under an RFI item.
-   Always re-fetches on open so the panel stays fresh after detaches made
-   elsewhere, and so a failed first-load naturally retries on the next click. */
-if (typeof window.toggleItemAttachments !== 'function') {
-  window.toggleItemAttachments = function(itemId) {
-    var host = document.getElementById('item-att-' + itemId);
-    if (!host) return;
-    var willShow = host.classList.contains('hidden');
-    host.classList.toggle('hidden');
-    if (willShow && window.htmx) {
-      window.htmx.ajax(
-        'GET',
-        '/api/attachments/panel?record_type=rfi_item&record_id=' + itemId,
-        {target: '#item-att-' + itemId, swap: 'innerHTML'}
-      );
-    }
-  };
-}
-
-/* Keep each item's paperclip count badge in sync with its panel after any
-   HTMX swap inside that item's attachment container. Handles both first
-   load (target = #item-att-N) and subsequent panel refreshes after
-   attach/detach (target = #attachments-panel-rfi_item-N). Installed once. */
-if (!window.__rfiItemBadgeListenerInstalled) {
-  window.__rfiItemBadgeListenerInstalled = true;
-  document.body.addEventListener('htmx:afterSwap', function(evt) {
-    var target = evt.detail && evt.detail.target;
-    if (!target) return;
-    var container = (target.id && target.id.indexOf('item-att-') === 0)
-      ? target
-      : (target.closest && target.closest('[id^="item-att-"]'));
-    if (!container || !container.id) return;
-    var itemId = container.id.replace('item-att-', '');
-    var count = container.querySelectorAll('[id^="att-card-"]').length;
-    var badge = document.getElementById('item-att-count-' + itemId);
-    if (badge) {
-      badge.textContent = count > 0 ? count : 'Attach';
-    }
-  });
-}
-
 (function() {
   var BID = "{{ bundle.id }}";
   var CID = "{{ client.id }}";

--- a/src/policydb/web/templates/clients/_request_item_attachments_js.html
+++ b/src/policydb/web/templates/clients/_request_item_attachments_js.html
@@ -1,0 +1,46 @@
+{# Shared JS for RFI item attachment toggling and badge sync.
+   Included from both _request_bundle.html (client view) and
+   _request_policy_view.html (policy view). Guarded so it is safe to
+   load multiple times per page. #}
+<script>
+/* Global: toggle the lazy-loaded attachment panel under an RFI item.
+   Always re-fetches on open so the panel stays fresh after detaches made
+   elsewhere, and so a failed first-load naturally retries on the next click. */
+if (typeof window.toggleItemAttachments !== 'function') {
+  window.toggleItemAttachments = function(itemId) {
+    var host = document.getElementById('item-att-' + itemId);
+    if (!host) return;
+    var willShow = host.classList.contains('hidden');
+    host.classList.toggle('hidden');
+    if (willShow && window.htmx) {
+      window.htmx.ajax(
+        'GET',
+        '/api/attachments/panel?record_type=rfi_item&record_id=' + itemId,
+        {target: '#item-att-' + itemId, swap: 'innerHTML'}
+      );
+    }
+  };
+}
+
+/* Keep each item's paperclip count badge in sync with its panel after any
+   HTMX swap inside that item's attachment container. Handles both first
+   load (target = #item-att-N) and subsequent panel refreshes after
+   attach/detach (target = #attachments-panel-rfi_item-N). Installed once. */
+if (!window.__rfiItemBadgeListenerInstalled) {
+  window.__rfiItemBadgeListenerInstalled = true;
+  document.body.addEventListener('htmx:afterSwap', function(evt) {
+    var target = evt.detail && evt.detail.target;
+    if (!target) return;
+    var container = (target.id && target.id.indexOf('item-att-') === 0)
+      ? target
+      : (target.closest && target.closest('[id^="item-att-"]'));
+    if (!container || !container.id) return;
+    var itemId = container.id.replace('item-att-', '');
+    var count = container.querySelectorAll('[id^="att-card-"]').length;
+    var badge = document.getElementById('item-att-count-' + itemId);
+    if (badge) {
+      badge.textContent = count > 0 ? count : 'Attach';
+    }
+  });
+}
+</script>

--- a/src/policydb/web/templates/clients/_request_policy_view.html
+++ b/src/policydb/web/templates/clients/_request_policy_view.html
@@ -71,6 +71,8 @@
   <a href="/clients/{{ client.id }}" class="text-[10px] text-marsh hover:underline mt-2 inline-block">View full request list on client page &rarr;</a>
 </div>
 
+{% include "clients/_request_item_attachments_js.html" %}
+
 {# Contenteditable save handler for item cards #}
 <script>
 (function() {


### PR DESCRIPTION
## Summary

Three bug fixes reported in a single session. All verified live against the local dev DB.

### Bug 1 — RFI attachments at policy level
Attaching a file or DevonThink link to an RFI item from the client page appeared to succeed, but the same item on the policy tab showed no attachment count AND its paperclip button did nothing when clicked.

- **Root cause A (silent no-op):** `toggleItemAttachments()` was defined inline in `_request_bundle.html` only, but the policy tab renders `_request_policy_view.html`, which includes `_request_item.html` (the button) without ever loading the function.
- **Root cause B (missing count):** the three policy/program/bundle-page render routes skipped `_attach_item_attachment_counts()`, so `attachment_count` was absent and the badge always rendered "Attach" even when attachments existed.

**Fix:** extract the attachment JS (toggle + badge sync listener, both idempotency-guarded) into a new shared partial `clients/_request_item_attachments_js.html`, included from both the bundle view and the policy-view partial. Add the missing `_attach_item_attachment_counts()` calls in `clients.py`.

### Bug 2 — Snooze math on overdue tasks
Snoozing an overdue task added the delta to the original follow-up date, so a task 10 days overdue "+3d" was still overdue. Three separate handlers had the bug; the bulk-snooze handler already did it right and is used as the reference.

**Fix:** in `activity_snooze`, `policy_snooze_followup`, and `open_tasks.action_snooze`, compute `base = max(today, old_date)` before adding the delta. Overdue and undated tasks snooze forward from today; future-dated tasks still snooze from their scheduled date.

### Bug 3 — Bind order must always create a new term row (big bug)
Completing a bind order on three policies tied to a location left the old policies visible and never created new policy records. Root cause: `execute_bind_order` only called `renew_policy()` for rows whose `expiration_date` had already lapsed. For any row with a future expiration (the normal pre-expiration bind case), it silently stamped `bound_date` on the existing row and ignored the panel's `new_effective` / `new_expiration` entirely — no archive, no new term row, no next-cycle renewal timeline.

**Fix:** every checked child now runs through `renew_policy()` unconditionally (skipping only `already_bound` rows defensively), which archives the old row, creates a new policy row with the panel-provided dates and premium, and carries forward project_id, project_name, contacts, and exposure fields. After each rollover we call `generate_policy_timelines(new_uid)` so the next renewal cycle's milestones materialize as soon as they enter the 180-day horizon window. Module and `resolve_child_state` docstrings updated to reflect the new "every bind commits a new term" semantics.

## Files changed

- `src/policydb/bind_order.py` — always-renew execution path, new docstring, defensive already_bound skip, timeline generation on new term row
- `src/policydb/web/routes/open_tasks.py` — snooze date math uses `max(today, old)`
- `src/policydb/web/routes/activities.py` — same snooze fix
- `src/policydb/web/routes/policies.py` — same snooze fix
- `src/policydb/web/routes/clients.py` — call `_attach_item_attachment_counts()` in `request_policy_view`, `request_program_view`, and `get_request_bundle`
- `src/policydb/web/templates/clients/_request_item_attachments_js.html` — **new** shared partial
- `src/policydb/web/templates/clients/_request_bundle.html` — replace inline attachment JS with include
- `src/policydb/web/templates/clients/_request_policy_view.html` — include the shared attachment JS

## Test plan

- [x] Bug 1: load `/policies/POL-010/edit`, click Workflow tab → HTMX loads RFI partial → confirm `window.toggleItemAttachments` is a function, badge listener installed, paperclip click opens the attachment panel with upload + DevonThink UI.
- [x] Bug 2: POST `/activities/123/snooze?days=3` on a row originally due 2026-03-25 (21 days overdue as of 2026-04-15) → new `follow_up_date = 2026-04-18` (today + 3), not 2026-03-28.
- [x] Bug 2: confirm future-dated rows still snooze from their own date.
- [x] Bug 3: call `execute_bind_order` on POL-009 (unbound, expiration 2026-06-01, ready_to_bind) with panel dates 2026-06-01 / 2027-06-01 and premium $39,500 → old POL-009 `archived=1`, new POL-054 created with `prior_policy_uid=POL-009`, `bound_date=2026-04-15`, correct term dates and premium, project_id carried forward, post-bind follow-ups and "renewal term created" kickoff logged. Test state cleaned up after verification.

## Reviewer notes

- **Always-renew tradeoff:** if a user manually renewed a policy via the existing `/policies/{uid}/renew` path and then opened bind order on the fresh new row, this change will create a second new row and archive the manually-renewed one (double rollover). The panel UX doesn't yet distinguish this case. The user explicitly confirmed this tradeoff is acceptable given how much worse the current silent-overwrite behavior is, and we can add a guard later if it ever becomes a real issue.
- `generate_policy_timelines()` is called on the new term row immediately after renewal. The new row's milestones are typically outside the 180-day horizon so this is a no-op today, but it's the right place for the call so the next run will populate correctly without a separate sweep.
- The RFI attachment badge still renders "Attach" for items with no existing attachments — only items that already have attachments show a numeric count. That matches existing client-view behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)