### PR TITLE
Roll AI-extracted exposure data up to client_exposures / locations

### DIFF
--- a/src/policydb/importer.py
+++ b/src/policydb/importer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import csv
 import sqlite3
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -201,7 +202,9 @@ class PolicyImporter:
         "company_name": "carrier",
         "writing_company": "carrier",
         "issuing_company": "carrier",
-        # Exposure fields
+        # Exposure fields (post-processed into client_exposures /
+        # policy_exposure_links after the policies INSERT; never written
+        # to the deprecated policies.exposure_* columns directly).
         "exposure_basis": "exposure_basis",
         "rating_basis": "exposure_basis",
         "exposure_type": "exposure_basis",
@@ -212,6 +215,17 @@ class PolicyImporter:
         "denominator": "exposure_denominator",
         "per": "exposure_denominator",
         "rating_unit": "exposure_denominator",
+        "exposure_unit": "exposure_unit",
+        # Exposure location fields — used to upsert a project (location).
+        "exposure_address": "exposure_address",
+        "location_address": "exposure_address",
+        "property_address": "exposure_address",
+        "exposure_city": "exposure_city",
+        "location_city": "exposure_city",
+        "exposure_state": "exposure_state",
+        "location_state": "exposure_state",
+        "exposure_zip": "exposure_zip",
+        "location_zip": "exposure_zip",
     }
 
     def __init__(self, conn: sqlite3.Connection):
@@ -392,6 +406,64 @@ class PolicyImporter:
                     _uw_email = (row.get("underwriter_contact") or "").strip() or None
                     _uw_cid = get_or_create_contact(self.conn, _uw_name, email=_uw_email)
                     assign_contact_to_policy(self.conn, _uw_cid, _pid, role="Underwriter")
+
+                # Route exposure data into client_exposures + policy_exposure_links
+                # instead of the deprecated policies.exposure_* columns.  If the
+                # row carries address fields, upsert a project (location) and
+                # attach the exposure to it.
+                _exp_basis = (row.get("exposure_basis") or "").strip()
+                _exp_amount_raw = row.get("exposure_amount")
+                try:
+                    _exp_amount = float(_parse_money(_exp_amount_raw) or 0) or None
+                except (TypeError, ValueError):
+                    _exp_amount = None
+                if _exp_basis and _exp_amount:
+                    from policydb.exposures import (
+                        find_or_create_exposure,
+                        create_exposure_link,
+                    )
+                    from policydb.queries import find_or_create_project_from_address
+
+                    try:
+                        _exp_denom = int(row.get("exposure_denominator") or 1) or 1
+                    except (TypeError, ValueError):
+                        _exp_denom = 1
+
+                    # Upsert location from address fields; re-use if one
+                    # with the same street already exists on the client.
+                    _exp_project_id = find_or_create_project_from_address(
+                        self.conn,
+                        client_id=client_id,
+                        address=row.get("exposure_address"),
+                        city=row.get("exposure_city"),
+                        state=row.get("exposure_state"),
+                        zip_code=row.get("exposure_zip"),
+                        label=row.get("project_name"),
+                    )
+                    # Stamp policies.project_id when previously unassigned.
+                    if _exp_project_id:
+                        _cur_pid = self.conn.execute(
+                            "SELECT project_id FROM policies WHERE id=?", (_pid,)
+                        ).fetchone()
+                        if not (_cur_pid and _cur_pid["project_id"]):
+                            self.conn.execute(
+                                "UPDATE policies SET project_id = ? WHERE id = ?",
+                                (_exp_project_id, _pid),
+                            )
+
+                    _year = int(eff[:4]) if eff and len(eff) >= 4 else datetime.now().year
+                    _exp_id = find_or_create_exposure(
+                        self.conn,
+                        client_id=client_id,
+                        project_id=_exp_project_id,
+                        exposure_type=_exp_basis,
+                        year=_year,
+                        amount=_exp_amount,
+                        denominator=_exp_denom,
+                    )
+                    create_exposure_link(
+                        self.conn, uid, _exp_id, is_primary=True,
+                    )
 
             if pol_number:
                 seen_policy_numbers[pol_number] = client_id

--- a/src/policydb/llm_schemas.py
+++ b/src/policydb/llm_schemas.py
@@ -393,68 +393,6 @@ POLICY_EXTRACTION_SCHEMA: dict = {
             "example": "Bob Jones",
         },
         {
-            "key": "exposure_address",
-            "label": "Property / Risk Address",
-            "type": "string",
-            "required": False,
-            "description": "Street address of the insured property or risk location",
-            "example": "123 Main St",
-        },
-        {
-            "key": "exposure_city",
-            "label": "City",
-            "type": "string",
-            "required": False,
-            "description": "City of the insured property or risk location",
-            "normalizer": "format_city",
-            "example": "Austin",
-        },
-        {
-            "key": "exposure_state",
-            "label": "State",
-            "type": "string",
-            "required": False,
-            "description": "State of the insured property or risk location",
-            "normalizer": "format_state",
-            "example": "TX",
-        },
-        {
-            "key": "exposure_zip",
-            "label": "ZIP Code",
-            "type": "string",
-            "required": False,
-            "description": "ZIP code of the insured property or risk location",
-            "normalizer": "format_zip",
-            "example": "78701",
-        },
-        {
-            "key": "exposure_basis",
-            "label": "Exposure Basis",
-            "type": "string",
-            "required": False,
-            "description": "Basis used for rating (e.g. Payroll, Revenue, Area)",
-            "config_values": "exposure_basis_options",
-            "config_mode": "prefer",
-            "example": "Payroll",
-        },
-        {
-            "key": "exposure_amount",
-            "label": "Exposure Amount",
-            "type": "number",
-            "required": False,
-            "description": "Exposure value used for premium calculation",
-            "normalizer": "parse_currency_with_magnitude",
-            "example": "12500000",
-        },
-        {
-            "key": "exposure_denominator",
-            "label": "Exposure Denominator",
-            "type": "number",
-            "required": False,
-            "description": "Rating unit denominator — the 'per X' value. For example, if the rate is 'per $100 of payroll', the denominator is 100. Common values: 1, 100, 1000.",
-            "example": "100",
-        },
-        {
             "key": "project_name",
             "label": "Location / Project Name",
             "type": "string",
@@ -504,6 +442,143 @@ POLICY_EXTRACTION_SCHEMA: dict = {
         },
     ],
     "nested_groups": {
+        "exposures": {
+            "type": "array",
+            "optional": True,
+            "description": (
+                "Exposure rating bases used to calculate premium.  Extract EVERY "
+                "rating basis the document lists, not just the primary one.  A "
+                "single policy commonly has multiple exposures — for example a "
+                "General Liability policy may be rated on both payroll and gross "
+                "sales, or a Workers Comp policy may list per-state payroll by "
+                "classification.  Create one list item per distinct rating row.  "
+                "If an exposure is tied to a specific location (building, site, "
+                "project), include the address fields so the importer can upsert "
+                "a location record and attach the exposure to it.  Mark the "
+                "principal rating basis with is_primary=true if the document "
+                "distinguishes one; otherwise the first list item becomes primary."
+            ),
+            "fields": [
+                {
+                    "key": "exposure_type",
+                    "label": "Exposure Type / Rating Basis",
+                    "type": "string",
+                    "required": True,
+                    "description": (
+                        "The rating basis this exposure uses (e.g., Payroll, "
+                        "Revenue, Gross Sales, Area, Units, TIV).  Prefer the "
+                        "configured list when applicable, but use whatever "
+                        "terminology the policy uses if it doesn't match."
+                    ),
+                    "config_values": "exposure_basis_options",
+                    "config_mode": "prefer",
+                    "example": "Payroll",
+                },
+                {
+                    "key": "amount",
+                    "label": "Exposure Amount",
+                    "type": "number",
+                    "required": True,
+                    "description": (
+                        "The exposure value used for premium calculation "
+                        "(e.g., total payroll dollars, total gross receipts, "
+                        "total square feet)."
+                    ),
+                    "normalizer": "parse_currency_with_magnitude",
+                    "example": "12500000",
+                },
+                {
+                    "key": "denominator",
+                    "label": "Rating Denominator",
+                    "type": "number",
+                    "required": False,
+                    "description": (
+                        "The 'per X' denominator used when quoting a rate. "
+                        "For example, 'per $100 of payroll' has denominator 100; "
+                        "'per $1,000 of revenue' has denominator 1000. "
+                        "Default to 1 when not specified."
+                    ),
+                    "example": "100",
+                },
+                {
+                    "key": "unit",
+                    "label": "Rating Unit Description",
+                    "type": "string",
+                    "required": False,
+                    "description": (
+                        "Human-readable rating unit string, e.g. "
+                        "'Per $100 Payroll', 'Per $1,000 Revenue', 'Flat'."
+                    ),
+                    "config_values": "exposure_unit_options",
+                    "config_mode": "prefer",
+                    "example": "Per $100 Payroll",
+                },
+                {
+                    "key": "is_primary",
+                    "label": "Is Primary Rating Basis",
+                    "type": "boolean",
+                    "required": False,
+                    "description": (
+                        "True when this is the dominant rating basis for the "
+                        "policy.  Only mark one entry primary; if unsure, leave "
+                        "all entries false and the importer will default the "
+                        "first to primary."
+                    ),
+                    "example": "true",
+                },
+                {
+                    "key": "location_label",
+                    "label": "Location / Project Name",
+                    "type": "string",
+                    "required": False,
+                    "description": (
+                        "Name of the location or project this exposure applies "
+                        "to, if the policy rates per-location (e.g., 'Main "
+                        "Office', 'Site B', 'Plant #3')."
+                    ),
+                    "example": "Main Office",
+                },
+                {
+                    "key": "address",
+                    "label": "Location Street Address",
+                    "type": "string",
+                    "required": False,
+                    "description": (
+                        "Street address of the exposure location.  When "
+                        "present, the importer will upsert a location/project "
+                        "record and attach this exposure to it."
+                    ),
+                    "example": "123 Main St",
+                },
+                {
+                    "key": "city",
+                    "label": "Location City",
+                    "type": "string",
+                    "required": False,
+                    "description": "City of the exposure location.",
+                    "normalizer": "format_city",
+                    "example": "Austin",
+                },
+                {
+                    "key": "state",
+                    "label": "Location State",
+                    "type": "string",
+                    "required": False,
+                    "description": "State abbreviation of the exposure location.",
+                    "normalizer": "format_state",
+                    "example": "TX",
+                },
+                {
+                    "key": "zip",
+                    "label": "Location ZIP",
+                    "type": "string",
+                    "required": False,
+                    "description": "ZIP code of the exposure location.",
+                    "normalizer": "format_zip",
+                    "example": "78701",
+                },
+            ],
+        },
         "locations": {
             "type": "array",
             "optional": True,

--- a/src/policydb/queries.py
+++ b/src/policydb/queries.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import sqlite3
 from datetime import date, timedelta
 from typing import Optional
@@ -12,6 +13,94 @@ logger = logging.getLogger("policydb.queries")
 from rapidfuzz import process, fuzz
 
 import policydb.config as cfg
+
+
+def _normalize_address(raw: str | None) -> str:
+    """Lowercase + collapse whitespace for address matching."""
+    if not raw:
+        return ""
+    return re.sub(r"\s+", " ", raw.strip().lower())
+
+
+def find_or_create_project_from_address(
+    conn,
+    *,
+    client_id: int,
+    address: str | None = None,
+    city: str | None = None,
+    state: str | None = None,
+    zip_code: str | None = None,
+    label: str | None = None,
+) -> int | None:
+    """Upsert a `projects` (location) row for this client.
+
+    Matches on normalized street address when one is provided, otherwise
+    on project name (case-insensitive).  Returns the project_id.  Returns
+    ``None`` when there is no usable info to identify a location (no
+    address AND no label).
+
+    This is used by the AI policy import and the CSV importer to turn
+    extracted exposure/location address fields into real `projects` rows,
+    so exposure data can be rolled up to the location/project level
+    instead of stamped onto deprecated `policies.exposure_*` columns.
+    """
+    addr = (address or "").strip()
+    lbl = (label or "").strip()
+    if not addr and not lbl:
+        return None
+
+    norm_addr = _normalize_address(addr)
+    city_clean = (city or "").strip() or None
+    state_clean = (state or "").strip() or None
+    zip_clean = (zip_code or "").strip() or None
+
+    existing_id: int | None = None
+
+    # Prefer address-match: same client, same normalized street address.
+    if norm_addr:
+        for r in conn.execute(
+            """SELECT id, address FROM projects
+               WHERE client_id = ?
+                 AND address IS NOT NULL
+                 AND TRIM(address) != ''""",
+            (client_id,),
+        ).fetchall():
+            if _normalize_address(r["address"]) == norm_addr:
+                existing_id = r["id"]
+                break
+
+    # Fall back to name-match when there's no address.
+    if existing_id is None and lbl and not addr:
+        row = conn.execute(
+            """SELECT id FROM projects
+               WHERE client_id = ?
+                 AND LOWER(TRIM(name)) = LOWER(TRIM(?))""",
+            (client_id, lbl),
+        ).fetchone()
+        if row:
+            existing_id = row["id"]
+
+    if existing_id is not None:
+        return existing_id
+
+    # Create a new project.  Name defaults to the label, else the first
+    # line of the address.  Status is Active so it shows up in the
+    # location picker immediately.
+    if lbl:
+        name = lbl[:60]
+    elif addr:
+        name = addr.split(",")[0].strip()[:60] or "Location"
+    else:
+        name = "Location"
+
+    conn.execute(
+        """INSERT INTO projects
+             (client_id, name, address, city, state, zip, status)
+           VALUES (?, ?, ?, ?, ?, ?, 'Active')""",
+        (client_id, name, addr or None, city_clean, state_clean, zip_clean),
+    )
+    conn.commit()
+    return conn.execute("SELECT last_insert_rowid()").fetchone()[0]
 
 # ─── ISSUE COVERAGE HELPERS ──────────────────────────────────────────────────
 

--- a/src/policydb/web/routes/policies.py
+++ b/src/policydb/web/routes/policies.py
@@ -1630,12 +1630,15 @@ def _ai_import_parse_inner(request: Request, conn, uid: str, result: dict):
     # Initialize warnings early so the endorsements auto-apply step can append.
     ai_warnings: list[str] = list(result.get("warnings", []))
 
-    # Merge parsed values onto existing policy, tracking changes (skip nested groups)
+    # Merge parsed values onto existing policy, tracking changes (skip nested groups).
+    # `exposures` is a nested list that's routed through client_exposures /
+    # policy_exposure_links below — never merged onto the policies row.
+    _NESTED_KEYS = ("locations", "sub_coverages", "endorsements", "exposures")
     merged = dict(policy_dict)
     import_changes: list[dict] = []
     _field_labels = {f["key"]: f["label"] for f in POLICY_EXTRACTION_SCHEMA.get("fields", [])}
     for k, v in result["parsed"].items():
-        if v is not None and k not in ("locations", "sub_coverages", "endorsements"):
+        if v is not None and k not in _NESTED_KEYS:
             old_val = policy_dict.get(k)
             if str(v).strip() != str(old_val or "").strip():
                 import_changes.append({
@@ -1688,38 +1691,94 @@ def _ai_import_parse_inner(request: Request, conn, uid: str, result: dict):
                 f"client record has {client_fein['fein']}"
             )
 
-    # ── Route exposure data through client_exposures → policy_exposure_links ──
-    exposure_basis = result["parsed"].get("exposure_basis")
-    exposure_amount = result["parsed"].get("exposure_amount")
-    exposure_denom = result["parsed"].get("exposure_denominator", 1) or 1
-    if exposure_basis and exposure_amount:
+    # ── Route exposures through client_exposures / policy_exposure_links ──
+    # Each entry in the `exposures` list becomes a row in client_exposures
+    # plus a link in policy_exposure_links.  If an entry carries address
+    # fields, we also upsert a `projects` (location) row and attach the
+    # exposure to it.  The policy's own project_id is only stamped when it
+    # was previously unassigned — we never overwrite a user-picked location.
+    exposures_parsed = result["parsed"].get("exposures") or []
+    if exposures_parsed:
         from policydb.exposures import find_or_create_exposure, create_exposure_link
+        from policydb.queries import find_or_create_project_from_address
+
         eff_date = result["parsed"].get("effective_date") or policy_dict.get("effective_date", "")
         year = int(eff_date[:4]) if eff_date and len(eff_date) >= 4 else datetime.now().year
         client_id = policy_dict["client_id"]
-        project_id = policy_dict.get("project_id")
-        exp_id = find_or_create_exposure(
-            conn,
-            client_id=client_id,
-            project_id=project_id,
-            exposure_type=exposure_basis,
-            year=year,
-            amount=float(exposure_amount),
-            denominator=int(exposure_denom),
+        policy_uid = policy_dict["policy_uid"]
+        policy_project_id = policy_dict.get("project_id")
+
+        # Normalize and filter out empty/invalid entries up front so the
+        # primary-flag decision isn't skewed by rows that would be skipped.
+        valid_exposures: list[dict] = []
+        for exp in exposures_parsed:
+            if not isinstance(exp, dict):
+                continue
+            exposure_type = (exp.get("exposure_type") or "").strip()
+            try:
+                amount = float(exp.get("amount") or 0) or None
+            except (ValueError, TypeError):
+                amount = None
+            if not exposure_type or not amount:
+                continue
+            try:
+                denominator = int(exp.get("denominator") or 1) or 1
+            except (ValueError, TypeError):
+                denominator = 1
+            valid_exposures.append({
+                **exp,
+                "exposure_type": exposure_type,
+                "amount": amount,
+                "denominator": denominator,
+            })
+
+        # Decide which valid entry is primary: first LLM-flagged one, else
+        # the first in order.
+        primary_idx = next(
+            (i for i, e in enumerate(valid_exposures) if e.get("is_primary")),
+            0 if valid_exposures else -1,
         )
-        # Check for existing link
-        existing = conn.execute(
-            "SELECT id FROM policy_exposure_links WHERE policy_uid=? AND exposure_id=?",
-            (policy_dict["policy_uid"], exp_id),
-        ).fetchone()
-        if not existing:
-            create_exposure_link(conn, policy_dict["policy_uid"], exp_id, is_primary=True)
+
+        for idx, exp in enumerate(valid_exposures):
+            # Upsert a location/project from the exposure address when present.
+            exp_project_id = find_or_create_project_from_address(
+                conn,
+                client_id=client_id,
+                address=exp.get("address"),
+                city=exp.get("city"),
+                state=exp.get("state"),
+                zip_code=exp.get("zip"),
+                label=exp.get("location_label"),
+            )
+
+            # Stamp policies.project_id only when previously unassigned.
+            if exp_project_id and not policy_project_id:
+                conn.execute(
+                    "UPDATE policies SET project_id = ? WHERE policy_uid = ?",
+                    (exp_project_id, policy_uid),
+                )
+                policy_project_id = exp_project_id
+
+            exp_id = find_or_create_exposure(
+                conn,
+                client_id=client_id,
+                project_id=exp_project_id,
+                exposure_type=exp["exposure_type"],
+                year=year,
+                amount=exp["amount"],
+                denominator=exp["denominator"],
+            )
+            create_exposure_link(
+                conn, policy_uid, exp_id, is_primary=(idx == primary_idx),
+            )
+
+        conn.commit()
 
     # ── Build policy-level diffs ──
     _field_labels = {f["key"]: f["label"] for f in POLICY_EXTRACTION_SCHEMA["fields"]}
     ai_policy_diffs: list[dict] = []
     for k, v in result["parsed"].items():
-        if k in ("locations", "sub_coverages", "endorsements") or v is None:
+        if k in _NESTED_KEYS or v is None:
             continue
         current = policy_dict.get(k)
         current_str = str(current) if current is not None else ""
@@ -3516,13 +3575,6 @@ def policy_edit_post(
     prior_premium: str = Form(""),
     notes: str = Form(""),
     project_name: str = Form(""),
-    exposure_basis: str = Form(""),
-    exposure_amount: str = Form(""),
-    exposure_unit: str = Form(""),
-    exposure_address: str = Form(""),
-    exposure_city: str = Form(""),
-    exposure_state: str = Form(""),
-    exposure_zip: str = Form(""),
     follow_up_date: str = Form(""),
     attachment_point: str = Form(""),
     participation_of: str = Form(""),
@@ -3555,10 +3607,9 @@ def policy_edit_post(
         _ensure_carrier_row(conn, carrier, "carrier")
     if access_point and access_point.strip():
         _ensure_carrier_row(conn, access_point.strip(), "wholesaler")
-    exposure_address = exposure_address.strip() if exposure_address else ""
-    exposure_city = format_city(exposure_city) if exposure_city else ""
-    exposure_state = format_state(exposure_state) if exposure_state else ""
-    exposure_zip = format_zip(exposure_zip) if exposure_zip else ""
+    # Exposure fields (exposure_basis/amount/unit/address/city/state/zip) are
+    # intentionally NOT written here — they live on client_exposures /
+    # policy_exposure_links.  Edit them via the client's Exposures grid.
     conn.execute(
         """UPDATE policies SET
            policy_type=?, carrier=?, policy_number=?,
@@ -3567,8 +3618,7 @@ def policy_edit_post(
            coverage_form=?, layer_position=?, tower_group=?,
            is_standalone=?, is_bor=?, is_opportunity=?, opportunity_status=?, target_effective_date=?,
            renewal_status=?, commission_rate=?, prior_premium=?, notes=?,
-           project_name=?, exposure_basis=?, exposure_amount=?, exposure_unit=?,
-           exposure_address=?, exposure_city=?, exposure_state=?, exposure_zip=?,
+           project_name=?,
            follow_up_date=?, attachment_point=?, participation_of=?,
            first_named_insured=?, access_point=?
            WHERE policy_uid=?""",
@@ -3583,9 +3633,6 @@ def policy_edit_post(
             renewal_status,
             _float(commission_rate), _float(prior_premium), notes or None,
             project_name or None,
-            exposure_basis or None, _float(exposure_amount), exposure_unit or None,
-            exposure_address or None, exposure_city or None,
-            exposure_state or None, exposure_zip or None,
             follow_up_date or None,
             _float(attachment_point), _float(participation_of),
             first_named_insured or None, access_point or None,
@@ -3759,9 +3806,12 @@ async def policy_cell_save(request: Request, policy_uid: str, conn=Depends(get_d
     value = body.get("value", "")
 
     # -- Field allowlists by type --
+    # Exposure fields (exposure_basis/amount/unit/address/city/state/zip) are
+    # intentionally excluded — they now live on client_exposures and are
+    # edited through the client's Exposures grid, not cell-edited on policies.
     currency_fields = {
         "premium", "limit_amount", "deductible", "attachment_point",
-        "participation_of", "prior_premium", "exposure_amount",
+        "participation_of", "prior_premium",
     }
     date_fields = {
         "effective_date", "expiration_date", "follow_up_date", "target_effective_date",
@@ -3769,13 +3819,11 @@ async def policy_cell_save(request: Request, policy_uid: str, conn=Depends(get_d
     bool_fields = {"is_bor", "is_standalone", "flagged", "policy_number_unknown"}
     text_fields = {
         "policy_number", "first_named_insured", "access_point", "description",
-        "notes", "placement_notation", "exposure_address", "exposure_basis",
-        "exposure_unit", "tower_group", "exposure_zip",
+        "notes", "placement_notation", "tower_group",
     }
     combobox_fields = {
         "policy_type", "carrier", "renewal_status", "opportunity_status",
-        "coverage_form", "layer_position", "exposure_state", "exposure_city",
-        "review_cycle",
+        "coverage_form", "layer_position", "review_cycle",
     }
     # Team name fields: writing one of these upserts a contact in the unified
     # contacts table and creates/updates the contact_policy_assignments row.

--- a/src/policydb/web/templates/policies/_tab_details.html
+++ b/src/policydb/web/templates/policies/_tab_details.html
@@ -585,96 +585,11 @@ textarea.field-inline { resize: none; }
   </div>
 </div>
 
-<!-- ── Exposure ── -->
-<div class="card mb-4">
-  <div class="px-5 py-3 border-b border-gray-100">
-    <span class="section-label">Exposure</span>
-  </div>
-  <div class="p-5 space-y-4">
-    <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
-      <div>
-        <label class="field-label">Exposure Basis</label>
-        <input type="text" data-field="exposure_basis" value="{{ policy.exposure_basis or '' }}"
-          placeholder="e.g. Payroll, Revenue, Sq Ft" class="form-input field-inline w-full"
-          list="ac-exposure_basis" autocomplete="off">
-      </div>
-      <div>
-        <label class="field-label">Exposure Amount</label>
-        <input type="text" class="form-input field-inline w-full currency-input" autocomplete="off"
-          value="{% if policy.exposure_amount %}{{ policy.exposure_amount | float | currency }}{% endif %}"
-          placeholder="0" data-currency-field="exposure_amount">
-      </div>
-      <div>
-        <label class="field-label">Exposure Unit</label>
-        <input type="text" data-field="exposure_unit" value="{{ policy.exposure_unit or '' }}"
-          placeholder="e.g. per $100, per $1,000, per unit" class="form-input field-inline w-full"
-          list="ac-exposure_unit" autocomplete="off">
-      </div>
-    </div>
-
-    <div>
-      <p class="text-xs font-medium text-gray-500 uppercase tracking-wide mb-3">Primary Exposure Address / Location</p>
-      {% if policy.project_id %}
-      {# Locked to location — read-only #}
-      <div class="mb-2">
-        <span class="text-xs text-gray-400">Address from:</span>
-        <a href="/clients/{{ policy.client_id }}/projects/{{ policy.project_id }}"
-           class="text-xs text-marsh hover:underline font-medium">{{ policy.project_name }}</a>
-        <span class="text-xs text-gray-400 ml-1">— edit location to change</span>
-      </div>
-      <div class="grid grid-cols-1 sm:grid-cols-6 gap-4">
-        <div class="sm:col-span-6">
-          <label class="field-label">Street Address</label>
-          <input type="text" value="{{ policy.exposure_address or '' }}" disabled
-            class="form-input w-full bg-gray-50 text-gray-500 cursor-not-allowed">
-        </div>
-        <div class="sm:col-span-3">
-          <label class="field-label">City</label>
-          <input type="text" value="{{ policy.exposure_city or '' }}" disabled
-            class="form-input w-full bg-gray-50 text-gray-500 cursor-not-allowed">
-        </div>
-        <div class="sm:col-span-2">
-          <label class="field-label">State</label>
-          <input type="text" value="{{ policy.exposure_state or '' }}" disabled
-            class="form-input w-full bg-gray-50 text-gray-500 cursor-not-allowed">
-        </div>
-        <div class="sm:col-span-1">
-          <label class="field-label">ZIP</label>
-          <input type="text" value="{{ policy.exposure_zip or '' }}" disabled
-            class="form-input w-full bg-gray-50 text-gray-500 cursor-not-allowed">
-        </div>
-      </div>
-      {% else %}
-      {# Editable — keep existing fields EXACTLY as they are #}
-      <div class="grid grid-cols-1 sm:grid-cols-6 gap-4">
-        <div class="sm:col-span-6 relative">
-          <label class="field-label">Street Address</label>
-          <input type="text" data-field="exposure_address" id="exposure-address-input" value="{{ policy.exposure_address or '' }}"
-            placeholder="123 Main St, Suite 100" class="form-input field-inline w-full"
-            data-1p-ignore data-lpignore="true" autocomplete="off">
-          <div id="exposure-address-suggestions" class="absolute left-0 right-0 top-full z-50 bg-white border border-gray-200 rounded-b-lg shadow-lg max-h-48 overflow-y-auto hidden"></div>
-        </div>
-        <div class="sm:col-span-3">
-          <label class="field-label">City</label>
-          <input type="text" data-field="exposure_city" value="{{ policy.exposure_city or '' }}"
-            class="form-input field-inline w-full" list="ac-exposure_city" autocomplete="off">
-        </div>
-        <div class="sm:col-span-2">
-          <label class="field-label">State</label>
-          <input type="text" data-field="exposure_state" value="{{ policy.exposure_state or '' }}"
-            class="form-input field-inline w-full" list="ac-exposure_state" autocomplete="off" placeholder="e.g. CA, NY">
-        </div>
-        <div class="sm:col-span-1">
-          <label class="field-label">ZIP</label>
-          <input type="text" data-field="exposure_zip" value="{{ policy.exposure_zip or '' }}"
-            placeholder="12345" maxlength="10" class="form-input field-inline w-full">
-        </div>
-      </div>
-      {% endif %}
-    </div>
-  </div>
-</div>
-
+{# The standalone "Exposure" input card that used to live here has been
+   retired — exposure rating data is now stored on client_exposures and
+   edited through the client's Exposures grid.  The read-only card below
+   shows whatever exposures the client has linked to this policy and
+   provides a "+ Link Exposure" button. #}
 {% include "policies/_exposure_card.html" %}
 
 <!-- ── Internal ── -->
@@ -797,19 +712,11 @@ textarea.field-inline { resize: none; }
 
 <!-- Datalists -->
 <datalist id="ac-carrier"></datalist>
-<datalist id="ac-exposure_basis"></datalist>
-<datalist id="ac-exposure_unit"></datalist>
 <datalist id="ac-project_name"></datalist>
-<datalist id="ac-exposure_city"></datalist>
 <datalist id="ac-access_point"></datalist>
 <datalist id="ac-first_named_insured"></datalist>
 <datalist id="ac-policy_type"></datalist>
 <datalist id="ac-coverage_form"></datalist>
-<datalist id="ac-exposure_state">
-  {% for abbr, name in us_states %}
-  <option value="{{ abbr }}">{{ abbr }} – {{ name }}</option>
-  {% endfor %}
-</datalist>
 
 <script>
 (function () {
@@ -934,8 +841,8 @@ textarea.field-inline { resize: none; }
   });
 
   /* ── Autocomplete loading ── */
-  var AC_FIELDS = ["carrier", "exposure_basis", "exposure_unit", "project_name", "exposure_city", "access_point", "first_named_insured", "policy_type", "coverage_form"];
-  var CLIENT_SCOPED = ["project_name", "exposure_city"];
+  var AC_FIELDS = ["carrier", "project_name", "access_point", "first_named_insured", "policy_type", "coverage_form"];
+  var CLIENT_SCOPED = ["project_name"];
 
   function loadList(field) {
     var clientParam = CLIENT_SCOPED.indexOf(field) !== -1 && CLIENT_ID ? '&client_id=' + CLIENT_ID : '';
@@ -948,60 +855,6 @@ textarea.field-inline { resize: none; }
       });
   }
   AC_FIELDS.forEach(loadList);
-
-  /* ── Google Places autocomplete for exposure address ── */
-  (function() {
-    var addrInput = document.getElementById('exposure-address-input');
-    var addrDropdown = document.getElementById('exposure-address-suggestions');
-    if (!addrInput || !addrDropdown) return;
-
-    var timer = null;
-    addrInput.addEventListener('input', function() {
-      clearTimeout(timer);
-      var q = addrInput.value.trim();
-      if (q.length < 4) { addrDropdown.classList.add('hidden'); return; }
-      timer = setTimeout(function() {
-        fetch('/api/address/autocomplete?q=' + encodeURIComponent(q))
-          .then(function(r) { return r.json(); })
-          .then(function(data) {
-            var predictions = data.predictions || [];
-            if (!predictions.length) { addrDropdown.classList.add('hidden'); return; }
-            addrDropdown.innerHTML = '';
-            predictions.forEach(function(p) {
-              var div = document.createElement('div');
-              div.className = 'px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 cursor-pointer border-b border-gray-50';
-              div.textContent = p.description;
-              div.addEventListener('mousedown', function(e) {
-                e.preventDefault();
-                addrDropdown.classList.add('hidden');
-
-                fetch('/api/address/details/' + encodeURIComponent(p.place_id))
-                  .then(function(r) { return r.json(); })
-                  .then(function(d) {
-                    if (d.error) return;
-                    addrInput.value = d.street || p.description;
-                    patchField('exposure_address', addrInput.value, addrInput);
-
-                    var cityEl = container.querySelector('[data-field="exposure_city"]');
-                    if (cityEl && d.city) { cityEl.value = d.city; patchField('exposure_city', d.city, cityEl); }
-
-                    var stateEl = container.querySelector('[data-field="exposure_state"]');
-                    if (stateEl && d.state) { stateEl.value = d.state; patchField('exposure_state', d.state, stateEl); }
-
-                    var zipEl = container.querySelector('[data-field="exposure_zip"]');
-                    if (zipEl && d.zip) { zipEl.value = d.zip; patchField('exposure_zip', d.zip, zipEl); }
-                  });
-              });
-              addrDropdown.appendChild(div);
-            });
-            addrDropdown.classList.remove('hidden');
-          }).catch(function() { addrDropdown.classList.add('hidden'); });
-      }, 400);
-    });
-    addrInput.addEventListener('blur', function() {
-      setTimeout(function() { addrDropdown.classList.add('hidden'); }, 200);
-    });
-  })();
 
   /* ── Live layer notation preview ── */
   (function () {

--- a/src/policydb/web/templates/policies/new.html
+++ b/src/policydb/web/templates/policies/new.html
@@ -250,69 +250,10 @@
     </div>
   </div>
 
-  <!-- Exposure -->
-  <div class="card-section">
-    <div class="card-header">
-      <span class="section-title">Exposure</span>
-    </div>
-    <div class="p-6 space-y-4">
-      <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
-
-        <div>
-          <label class="field-label">Exposure Basis</label>
-          <input type="text" name="exposure_basis" placeholder="e.g. Payroll, Revenue, Sq Ft" class="form-input w-full"
-            list="ac-exposure_basis" autocomplete="off">
-        </div>
-
-        <div>
-          <label class="field-label">Exposure Amount</label>
-          <input type="text" class="form-input w-full currency-input" autocomplete="off" placeholder="0">
-          <input type="hidden" name="exposure_amount" value="">
-        </div>
-
-        <div>
-          <label class="field-label">Exposure Unit</label>
-          <input type="text" name="exposure_unit" placeholder="e.g. per $100, per $1,000, per unit" class="form-input w-full"
-            list="ac-exposure_unit" autocomplete="off">
-        </div>
-
-      </div>
-
-      <!-- Primary exposure address -->
-      <div>
-        <p class="text-xs font-medium text-gray-500 uppercase tracking-wide mb-3">Primary Exposure Address / Location</p>
-        <div class="grid grid-cols-1 sm:grid-cols-6 gap-4">
-
-          <div class="sm:col-span-6">
-            <label class="field-label">Street Address</label>
-            <input type="text" name="exposure_address" placeholder="123 Main St, Suite 100" class="form-input w-full">
-          </div>
-
-          <div class="sm:col-span-3">
-            <label class="field-label">City</label>
-            <input type="text" name="exposure_city" class="form-input w-full"
-              list="ac-exposure_city" autocomplete="off">
-          </div>
-
-          <div class="sm:col-span-2">
-            <label class="field-label">State</label>
-            <select name="exposure_state" class="form-select w-full">
-              <option value="">—</option>
-              {% for abbr, name in us_states %}
-              <option value="{{ abbr }}">{{ abbr }} – {{ name }}</option>
-              {% endfor %}
-            </select>
-          </div>
-
-          <div class="sm:col-span-1">
-            <label class="field-label">ZIP</label>
-            <input type="text" name="exposure_zip" placeholder="12345" maxlength="10" class="form-input w-full">
-          </div>
-
-        </div>
-      </div>
-    </div>
-  </div>
+  {# The standalone "Exposure" input card has been retired — exposure
+     rating data is now stored on client_exposures and edited through the
+     client's Exposures grid after the policy is created.  Create the
+     policy first, then link exposures from the policy detail page. #}
 
   <!-- Internal -->
   <div class="card-section">
@@ -384,18 +325,15 @@ document.addEventListener('DOMContentLoaded', function() {
 </script>
 
 <datalist id="ac-carrier"></datalist>
-<datalist id="ac-exposure_basis"></datalist>
-<datalist id="ac-exposure_unit"></datalist>
 <datalist id="ac-project_name"></datalist>
-<datalist id="ac-exposure_city"></datalist>
 <datalist id="ac-first_named_insured"></datalist>
 <datalist id="ac-access_point"></datalist>
 
 
 <script>
 (function () {
-  const AC_FIELDS = ["carrier", "exposure_basis", "exposure_unit", "project_name", "exposure_city", "first_named_insured", "access_point"];
-  const CLIENT_SCOPED = new Set(["project_name", "exposure_city"]);
+  const AC_FIELDS = ["carrier", "project_name", "first_named_insured", "access_point"];
+  const CLIENT_SCOPED = new Set(["project_name"]);
 
   function getClientId() {
     var el = document.getElementById('new-pol-client-id');
@@ -419,37 +357,6 @@ document.addEventListener('DOMContentLoaded', function() {
   initClientAutocomplete('new-pol-client-name', 'new-pol-client-id', {
     onSelect: function() { CLIENT_SCOPED.forEach(loadAcField); }
   });
-
-  // Auto-populate location fields when a known project is selected
-  var projectInput = document.querySelector('input[name="project_name"]');
-  if (projectInput) {
-    projectInput.addEventListener('change', function () {
-      var name = this.value.trim();
-      if (!name) return;
-      var clientId = getClientId();
-      fetch('/policies/project-defaults?project_name=' + encodeURIComponent(name) + '&client_id=' + clientId)
-        .then(function (r) { return r.json(); })
-        .then(function (data) {
-          var fieldMap = {
-            exposure_address: 'input[name="exposure_address"]',
-            exposure_city:    'input[name="exposure_city"]',
-            exposure_state:   'select[name="exposure_state"]',
-            exposure_zip:     'input[name="exposure_zip"]',
-            exposure_basis:   'input[name="exposure_basis"]',
-            exposure_unit:    'input[name="exposure_unit"]'
-          };
-          Object.keys(data).forEach(function (field) {
-            if (!fieldMap[field]) return;
-            var el = document.querySelector(fieldMap[field]);
-            if (!el || el.value) return;
-            el.value = data[field];
-            el.style.transition = 'background-color 1s';
-            el.style.backgroundColor = '#fefce8';
-            setTimeout(function () { el.style.backgroundColor = ''; }, 1500);
-          });
-        });
-    });
-  }
 
   // Live tower notation preview
   (function () {

--- a/tests/test_ai_import_exposures.py
+++ b/tests/test_ai_import_exposures.py
@@ -1,0 +1,524 @@
+"""Regression tests for Bug 3 — exposure rollup from AI import + importer.
+
+Covers:
+1. `find_or_create_project_from_address()` upsert + idempotency semantics
+2. The AI import exposure chain: multi-entry, primary flag, address→project,
+   policy.project_id stamping on first-assign only
+3. Importer CSV row exposure post-processing uses the same chain
+"""
+from datetime import date
+
+import pytest
+
+import policydb.web.app  # noqa: F401 — boot FastAPI app
+
+from policydb.db import get_connection, init_db
+from policydb.exposures import (
+    create_exposure_link,
+    find_or_create_exposure,
+    get_policy_exposures,
+)
+from policydb.queries import find_or_create_project_from_address
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.sqlite"
+    monkeypatch.setattr("policydb.db.DB_PATH", db_path)
+    monkeypatch.setattr("policydb.db.DB_DIR", tmp_path)
+    monkeypatch.setattr("policydb.db.EXPORTS_DIR", tmp_path / "exports")
+    monkeypatch.setattr("policydb.db.CONFIG_PATH", tmp_path / "config.yaml")
+    init_db(path=db_path)
+    return db_path
+
+
+def _seed_client(conn, name="Acme Corp"):
+    conn.execute(
+        "INSERT INTO clients (name, industry_segment) VALUES (?, 'Construction')",
+        (name,),
+    )
+    return conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+
+def _seed_policy(conn, client_id, uid="POL-9001", project_id=None):
+    conn.execute(
+        """INSERT INTO policies
+             (policy_uid, client_id, policy_type, carrier, premium,
+              effective_date, expiration_date, project_id)
+           VALUES (?, ?, 'GL', 'Travelers', 50000, '2026-01-01', '2027-01-01', ?)""",
+        (uid, client_id, project_id),
+    )
+    return conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+
+# ── find_or_create_project_from_address ────────────────────────────────────
+
+
+def test_project_helper_returns_none_without_usable_info(tmp_db):
+    conn = get_connection()
+    cid = _seed_client(conn)
+    assert find_or_create_project_from_address(conn, client_id=cid) is None
+    assert find_or_create_project_from_address(
+        conn, client_id=cid, address="  "
+    ) is None
+
+
+def test_project_helper_creates_new_project(tmp_db):
+    conn = get_connection()
+    cid = _seed_client(conn)
+    pid = find_or_create_project_from_address(
+        conn,
+        client_id=cid,
+        address="123 Main St",
+        city="Austin",
+        state="TX",
+        zip_code="78701",
+    )
+    assert pid is not None
+
+    row = conn.execute(
+        "SELECT name, address, city, state, zip, status FROM projects WHERE id=?",
+        (pid,),
+    ).fetchone()
+    assert row["address"] == "123 Main St"
+    assert row["city"] == "Austin"
+    assert row["state"] == "TX"
+    assert row["zip"] == "78701"
+    assert row["status"] == "Active"
+    # Default name falls back to first line of address
+    assert row["name"].startswith("123 Main St")
+
+
+def test_project_helper_uses_label_as_name_when_provided(tmp_db):
+    conn = get_connection()
+    cid = _seed_client(conn)
+    pid = find_or_create_project_from_address(
+        conn,
+        client_id=cid,
+        address="500 Pine Ave",
+        label="Downtown Tower",
+    )
+    name = conn.execute("SELECT name FROM projects WHERE id=?", (pid,)).fetchone()["name"]
+    assert name == "Downtown Tower"
+
+
+def test_project_helper_reuses_existing_address(tmp_db):
+    """Same client + same normalized address → returns existing id."""
+    conn = get_connection()
+    cid = _seed_client(conn)
+    first = find_or_create_project_from_address(
+        conn, client_id=cid, address="100 Market St", city="San Francisco",
+    )
+    # Slightly different casing / whitespace should still match
+    second = find_or_create_project_from_address(
+        conn, client_id=cid, address="  100 MARKET ST  ", city="San Francisco",
+    )
+    assert first == second
+
+    count = conn.execute(
+        "SELECT COUNT(*) FROM projects WHERE client_id=?", (cid,)
+    ).fetchone()[0]
+    assert count == 1
+
+
+def test_project_helper_does_not_cross_clients(tmp_db):
+    conn = get_connection()
+    c1 = _seed_client(conn, "Client A")
+    c2 = _seed_client(conn, "Client B")
+    p1 = find_or_create_project_from_address(conn, client_id=c1, address="1 Shared St")
+    p2 = find_or_create_project_from_address(conn, client_id=c2, address="1 Shared St")
+    assert p1 != p2  # same address, different clients, two separate projects
+
+
+def test_project_helper_name_match_when_no_address(tmp_db):
+    """When the caller only provides a label (no address), reuse by name."""
+    conn = get_connection()
+    cid = _seed_client(conn)
+    first = find_or_create_project_from_address(conn, client_id=cid, label="Main Office")
+    second = find_or_create_project_from_address(conn, client_id=cid, label="main office")
+    assert first == second
+
+
+# ── AI import exposure chain ───────────────────────────────────────────────
+
+
+def _run_ai_exposure_ingest(conn, policy_uid, client_id, exposures, eff_date):
+    """Mirror the exposure loop from _ai_import_parse_inner so we can
+    exercise the same code paths without wiring a Request object.
+
+    Keep this in lock-step with the loop in
+    ``src/policydb/web/routes/policies.py::_ai_import_parse_inner``.
+    """
+    year = int(eff_date[:4])
+
+    policy_project_id = conn.execute(
+        "SELECT project_id FROM policies WHERE policy_uid=?", (policy_uid,)
+    ).fetchone()["project_id"]
+
+    # Normalize + filter up front so the primary-flag decision is made
+    # over valid entries only.
+    valid_exposures = []
+    for exp in exposures:
+        if not isinstance(exp, dict):
+            continue
+        exposure_type = (exp.get("exposure_type") or "").strip()
+        try:
+            amount = float(exp.get("amount") or 0) or None
+        except (ValueError, TypeError):
+            amount = None
+        if not exposure_type or not amount:
+            continue
+        try:
+            denominator = int(exp.get("denominator") or 1) or 1
+        except (ValueError, TypeError):
+            denominator = 1
+        valid_exposures.append({
+            **exp,
+            "exposure_type": exposure_type,
+            "amount": amount,
+            "denominator": denominator,
+        })
+
+    primary_idx = next(
+        (i for i, e in enumerate(valid_exposures) if e.get("is_primary")),
+        0 if valid_exposures else -1,
+    )
+
+    for idx, exp in enumerate(valid_exposures):
+        exp_project_id = find_or_create_project_from_address(
+            conn,
+            client_id=client_id,
+            address=exp.get("address"),
+            city=exp.get("city"),
+            state=exp.get("state"),
+            zip_code=exp.get("zip"),
+            label=exp.get("location_label"),
+        )
+
+        if exp_project_id and not policy_project_id:
+            conn.execute(
+                "UPDATE policies SET project_id = ? WHERE policy_uid = ?",
+                (exp_project_id, policy_uid),
+            )
+            policy_project_id = exp_project_id
+
+        exp_id = find_or_create_exposure(
+            conn,
+            client_id=client_id,
+            project_id=exp_project_id,
+            exposure_type=exp["exposure_type"],
+            year=year,
+            amount=exp["amount"],
+            denominator=exp["denominator"],
+        )
+        create_exposure_link(
+            conn, policy_uid, exp_id, is_primary=(idx == primary_idx),
+        )
+
+    conn.commit()
+
+
+def test_single_exposure_creates_link_not_policy_columns(tmp_db):
+    conn = get_connection()
+    cid = _seed_client(conn)
+    _seed_policy(conn, cid, "POL-5001")
+
+    _run_ai_exposure_ingest(
+        conn,
+        policy_uid="POL-5001",
+        client_id=cid,
+        exposures=[
+            {
+                "exposure_type": "Payroll",
+                "amount": 12500000,
+                "denominator": 100,
+                "unit": "Per $100 Payroll",
+            }
+        ],
+        eff_date="2026-04-01",
+    )
+
+    links = get_policy_exposures(conn, "POL-5001")
+    assert len(links) == 1
+    link = links[0]
+    assert link["exposure_type"] == "Payroll"
+    assert link["amount"] == 12500000
+    assert link["denominator"] == 100
+    assert link["year"] == 2026
+    assert link["is_primary"] == 1
+
+
+def test_multi_exposure_first_is_primary_by_default(tmp_db):
+    """A GL policy rated on both payroll and sales → two exposures, first primary."""
+    conn = get_connection()
+    cid = _seed_client(conn)
+    _seed_policy(conn, cid, "POL-5002")
+
+    _run_ai_exposure_ingest(
+        conn,
+        policy_uid="POL-5002",
+        client_id=cid,
+        exposures=[
+            {"exposure_type": "Payroll", "amount": 5000000, "denominator": 100},
+            {"exposure_type": "Gross Sales", "amount": 25000000, "denominator": 1000},
+        ],
+        eff_date="2026-04-01",
+    )
+
+    links = {l["exposure_type"]: l for l in get_policy_exposures(conn, "POL-5002")}
+    assert set(links) == {"Payroll", "Gross Sales"}
+    assert links["Payroll"]["is_primary"] == 1
+    assert links["Gross Sales"]["is_primary"] == 0
+
+
+def test_multi_exposure_honors_explicit_is_primary(tmp_db):
+    conn = get_connection()
+    cid = _seed_client(conn)
+    _seed_policy(conn, cid, "POL-5003")
+
+    _run_ai_exposure_ingest(
+        conn,
+        policy_uid="POL-5003",
+        client_id=cid,
+        exposures=[
+            {"exposure_type": "Payroll", "amount": 5000000, "denominator": 100},
+            {
+                "exposure_type": "Gross Sales",
+                "amount": 25000000,
+                "denominator": 1000,
+                "is_primary": True,
+            },
+        ],
+        eff_date="2026-04-01",
+    )
+
+    links = {l["exposure_type"]: l for l in get_policy_exposures(conn, "POL-5003")}
+    assert links["Payroll"]["is_primary"] == 0
+    assert links["Gross Sales"]["is_primary"] == 1
+
+
+def test_exposure_with_address_upserts_project_and_stamps_policy(tmp_db):
+    """Exposure address → new project + policies.project_id set when unassigned."""
+    conn = get_connection()
+    cid = _seed_client(conn)
+    _seed_policy(conn, cid, "POL-5004", project_id=None)
+
+    _run_ai_exposure_ingest(
+        conn,
+        policy_uid="POL-5004",
+        client_id=cid,
+        exposures=[
+            {
+                "exposure_type": "Building Value",
+                "amount": 10000000,
+                "denominator": 1,
+                "address": "500 Commerce St",
+                "city": "Dallas",
+                "state": "TX",
+                "zip": "75201",
+            }
+        ],
+        eff_date="2026-07-01",
+    )
+
+    # Project was created
+    project = conn.execute(
+        "SELECT id, address, city FROM projects WHERE client_id=? AND address='500 Commerce St'",
+        (cid,),
+    ).fetchone()
+    assert project is not None
+    assert project["city"] == "Dallas"
+
+    # Policy project_id was stamped
+    pol = conn.execute(
+        "SELECT project_id FROM policies WHERE policy_uid='POL-5004'"
+    ).fetchone()
+    assert pol["project_id"] == project["id"]
+
+    # Exposure linked to that project
+    links = get_policy_exposures(conn, "POL-5004")
+    assert len(links) == 1
+    assert links[0]["project_id"] == project["id"]
+
+
+def test_existing_policy_project_id_never_overwritten(tmp_db):
+    """If the policy already has project_id, AI import must not overwrite it."""
+    conn = get_connection()
+    cid = _seed_client(conn)
+    # Pre-create a project and link the policy to it
+    existing_pid = find_or_create_project_from_address(
+        conn, client_id=cid, address="1 Original St",
+    )
+    _seed_policy(conn, cid, "POL-5005", project_id=existing_pid)
+
+    # AI extracts an exposure with a different address
+    _run_ai_exposure_ingest(
+        conn,
+        policy_uid="POL-5005",
+        client_id=cid,
+        exposures=[
+            {
+                "exposure_type": "Payroll",
+                "amount": 3000000,
+                "denominator": 100,
+                "address": "99 Different Ave",
+                "city": "Austin",
+                "state": "TX",
+            }
+        ],
+        eff_date="2026-01-01",
+    )
+
+    # The new address still gets a project row (could be reused later)
+    new_project = conn.execute(
+        "SELECT id FROM projects WHERE client_id=? AND address='99 Different Ave'",
+        (cid,),
+    ).fetchone()
+    assert new_project is not None
+
+    # But the policy's project_id did NOT change
+    pol = conn.execute(
+        "SELECT project_id FROM policies WHERE policy_uid='POL-5005'"
+    ).fetchone()
+    assert pol["project_id"] == existing_pid
+
+
+def test_idempotent_address_reuses_project(tmp_db):
+    """Running AI import twice with the same address should not duplicate."""
+    conn = get_connection()
+    cid = _seed_client(conn)
+    _seed_policy(conn, cid, "POL-5006")
+
+    payload = [
+        {
+            "exposure_type": "Revenue",
+            "amount": 8000000,
+            "denominator": 1000,
+            "address": "22 Elm Rd",
+            "city": "Houston",
+            "state": "TX",
+        }
+    ]
+    _run_ai_exposure_ingest(conn, "POL-5006", cid, payload, "2026-04-01")
+    _run_ai_exposure_ingest(conn, "POL-5006", cid, payload, "2026-04-01")
+
+    project_count = conn.execute(
+        "SELECT COUNT(*) FROM projects WHERE client_id=? AND address='22 Elm Rd'",
+        (cid,),
+    ).fetchone()[0]
+    assert project_count == 1
+
+    # Only one exposure row, one link
+    exposure_count = conn.execute(
+        "SELECT COUNT(*) FROM client_exposures WHERE client_id=? AND exposure_type='Revenue'",
+        (cid,),
+    ).fetchone()[0]
+    assert exposure_count == 1
+
+    links = get_policy_exposures(conn, "POL-5006")
+    assert len(links) == 1
+
+
+def test_empty_or_invalid_exposure_entries_are_skipped(tmp_db):
+    conn = get_connection()
+    cid = _seed_client(conn)
+    _seed_policy(conn, cid, "POL-5007")
+
+    _run_ai_exposure_ingest(
+        conn,
+        policy_uid="POL-5007",
+        client_id=cid,
+        exposures=[
+            {"exposure_type": "", "amount": 1000},  # no type
+            {"exposure_type": "Payroll", "amount": 0},  # zero amount
+            {"exposure_type": "Revenue", "amount": "not a number"},  # bad amount
+            {"exposure_type": "Sales", "amount": 500000, "denominator": 1000},
+            "not a dict",  # should be skipped without error
+        ],
+        eff_date="2026-04-01",
+    )
+
+    links = get_policy_exposures(conn, "POL-5007")
+    assert len(links) == 1
+    assert links[0]["exposure_type"] == "Sales"
+    assert links[0]["is_primary"] == 1
+
+
+# ── Importer CSV rewrite ───────────────────────────────────────────────────
+
+
+def test_importer_post_inserts_exposure_via_client_exposures(tmp_db, tmp_path):
+    """PolicyImporter.import_csv routes exposure columns into client_exposures."""
+    from policydb.importer import PolicyImporter
+
+    conn = get_connection()
+    _seed_client(conn, "Importer Test Holdings LLC")
+    conn.commit()
+
+    csv_path = tmp_path / "policies.csv"
+    csv_path.write_text(
+        "client_name,policy_type,carrier,policy_number,effective_date,expiration_date,"
+        "premium,exposure_basis,exposure_amount,exposure_denominator,"
+        "exposure_address,exposure_city,exposure_state,exposure_zip\n"
+        "Importer Test Holdings LLC,General Liability,Travelers,TC-IMP-1,"
+        "2026-04-01,2027-04-01,60000,"
+        "Payroll,12500000,100,"
+        "777 Harbor Way,Seattle,WA,98101\n",
+        encoding="utf-8",
+    )
+
+    importer = PolicyImporter(conn)
+    importer.import_csv(csv_path, interactive=False)
+    assert importer.imported == 1
+    assert importer.skipped == 0
+
+    # Find the policy we just imported
+    pol = conn.execute(
+        "SELECT id, policy_uid, project_id FROM policies WHERE policy_number='TC-IMP-1'"
+    ).fetchone()
+    assert pol is not None
+
+    # Project was upserted from the address
+    project = conn.execute(
+        "SELECT id, address, city FROM projects WHERE address='777 Harbor Way'"
+    ).fetchone()
+    assert project is not None
+    assert project["city"] == "Seattle"
+    assert pol["project_id"] == project["id"]
+
+    # Exposure row lives on client_exposures, linked to the project
+    links = get_policy_exposures(conn, pol["policy_uid"])
+    assert len(links) == 1
+    link = links[0]
+    assert link["exposure_type"] == "Payroll"
+    assert link["amount"] == 12500000
+    assert link["denominator"] == 100
+    assert link["year"] == 2026
+    assert link["project_id"] == project["id"]
+    assert link["is_primary"] == 1
+
+
+def test_importer_without_exposure_columns_skips_exposure_flow(tmp_db, tmp_path):
+    """A row with no exposure columns imports cleanly without creating exposures."""
+    from policydb.importer import PolicyImporter
+
+    conn = get_connection()
+    _seed_client(conn, "Bare Import Holdings LLC")
+    conn.commit()
+
+    csv_path = tmp_path / "bare.csv"
+    csv_path.write_text(
+        "client_name,policy_type,carrier,policy_number,effective_date,expiration_date,premium\n"
+        "Bare Import Holdings LLC,Auto,Progressive,TC-BARE-1,2026-04-01,2027-04-01,10000\n",
+        encoding="utf-8",
+    )
+
+    importer = PolicyImporter(conn)
+    importer.import_csv(csv_path, interactive=False)
+    assert importer.imported == 1
+
+    pol = conn.execute(
+        "SELECT policy_uid FROM policies WHERE policy_number='TC-BARE-1'"
+    ).fetchone()
+    assert pol is not None
+    assert get_policy_exposures(conn, pol["policy_uid"]) == []

--- a/tests/test_llm_schemas.py
+++ b/tests/test_llm_schemas.py
@@ -285,8 +285,7 @@ def test_parse_llm_json_normalizes_fields():
         "expiration_date": "April 1, 2027",
         "premium": "45k",
         "limit_amount": "1m",
-        "deductible": "$5,000",
-        "exposure_state": "texas"
+        "deductible": "$5,000"
     }'''
     result = parse_llm_json(raw, POLICY_EXTRACTION_SCHEMA)
     assert result["ok"] is True
@@ -296,7 +295,6 @@ def test_parse_llm_json_normalizes_fields():
     assert p["deductible"] == 5000.0
     assert p["effective_date"] == "2026-04-01"
     assert p["expiration_date"] == "2027-04-01"
-    assert p["exposure_state"] == "TX"
     assert p["policy_number"] == "TC-001"
 
 

--- a/tests/test_tabbed_pages.py
+++ b/tests/test_tabbed_pages.py
@@ -125,10 +125,13 @@ class TestPolicyCellPatch:
         assert r.status_code == 200
         assert r.json()["formatted"] == "Internal note here"
 
-    def test_text_field_exposure_address(self, app_client):
+    def test_exposure_fields_rejected(self, app_client):
+        # Exposure fields were retired from the policy cell PATCH endpoint —
+        # they now live on client_exposures and are edited via the client's
+        # Exposures grid.  Attempting to PATCH them should fail fast.
         r = self._patch(app_client, "exposure_address", "123 Main St")
-        assert r.status_code == 200
-        assert r.json()["formatted"] == "123 Main St"
+        assert r.status_code == 400
+        assert "Invalid field" in r.json().get("error", "")
 
     def test_combobox_renewal_status(self, app_client):
         r = self._patch(app_client, "renewal_status", "In Progress")


### PR DESCRIPTION
## Summary

Retires the dual-write of exposure data to `policies.exposure_*` columns.  The AI policy import and CSV importer now route exposure rating data through `client_exposures` + `policy_exposure_links` exclusively, and an extracted address upserts a `projects` (location) row so exposures roll up to the right location instead of being stamped on the policy.

**Why now:** A real policy commonly has more than one exposure (GL rated on payroll + sales; Workers Comp with per-state payroll), but the old flat fields could only hold one.  The columns also drifted out of sync with the normalized `client_exposures` table because both paths were being written.  Per the planning discussion, we're stopping the policy-column writes entirely, dropping any pre-existing data (no backfill), and relying on new imports to rebuild the normalized table from here forward.

## What changed

- **`llm_schemas.py`** — dropped the seven flat exposure fields from `POLICY_EXTRACTION_SCHEMA.fields`; added `exposures` to `nested_groups` as an array with `exposure_type`, `amount`, `denominator`, `unit`, `is_primary`, `location_label`, `address`, `city`, `state`, `zip`.  Prompt tells the LLM to extract every rating basis it finds.
- **`queries.py::find_or_create_project_from_address()`** — new helper. Upserts a `projects` row by normalized street address (case/whitespace insensitive) with a label-only fallback.  Idempotent; never cross-matches clients.
- **`_ai_import_parse_inner()`** — normalizes + filters the extracted exposures list, picks the primary (LLM-flagged > first valid), upserts a project per entry when an address is present, calls `find_or_create_exposure` + `create_exposure_link`, and stamps `policies.project_id` only when previously unassigned.  Year derives from the policy's effective date.
- **`PolicyImporter.import_csv()`** — post-processes the exposure columns after the policy `INSERT` through the same chain.  Previously the alias map pointed these at deprecated columns that were never actually inserted, so CSV import was silently dropping exposure data — this fixes that while wiring the rollup.
- **Form handler / cell PATCH** — `/policies/{uid}/edit` POST and `/policies/{uid}/cell` PATCH stopped accepting the seven exposure fields.
- **Edit templates** — `policies/_tab_details.html` and `policies/new.html` no longer render the exposure input card.  The existing read-only `_exposure_card.html` (which already rendered from `policy_exposure_links`) continues to show exposures on the policy detail page, and the "+ Link Exposure" button remains the way to attach new rows.

## What's NOT in this PR (follow-up)

- Migration to drop the `policies.exposure_*` columns — they stay on the schema, unused
- Audit of remaining READ sites that still query `policies.exposure_*` (prompt builder, exports, templates) — tracked for a separate audit PR

## Test plan

- [x] `tests/test_ai_import_exposures.py` — 15 new tests covering:
  - `find_or_create_project_from_address`: none-without-info, create-new, label-as-name, reuse-by-address, never-cross-client, label-only match
  - AI exposure ingest: single, multi with default primary, explicit `is_primary` override, address upserts project + stamps `policies.project_id` when unassigned, never overwrites existing project_id, idempotent duplicate addresses, skips empty/invalid entries
  - CSV importer: post-inserts exposure via `client_exposures`, bare rows skip cleanly
- [x] `tests/test_llm_schemas.py::test_parse_llm_json_normalizes_fields` updated — dropped the `exposure_state` assertion (field no longer exists in the schema)
- [x] `tests/test_tabbed_pages.py::test_text_field_exposure_address` → `test_exposure_fields_rejected` — now asserts the cell PATCH returns `400 Invalid field` when an old exposure field is submitted
- [x] Full suite: 502 passing, same 8 pre-existing main failures (timeline_engine, compliance, llm_schemas metadata, open_tasks sync, tabbed_pages commission/persistence) untouched
- [x] App boots clean, 754 routes registered post-rebase
- [ ] Manual: run an AI import on a multi-exposure policy and confirm both rows land in `client_exposures` with the first marked primary
- [ ] Manual: CSV-import a policies file that includes `exposure_basis`, `exposure_amount`, and `exposure_address` columns; verify a `projects` row is created and the exposure is linked
- [ ] Manual: open an existing policy's edit tab and confirm the Exposure input card is gone but the read-only `_exposure_card.html` still shows linked exposures

🤖 Generated with [Claude Code](https://claude.com/claude-code)