### PR TITLE
fix(reconcile): template regressions + hoist initClientAutocomplete + post-merge cleanup

### DIFF
--- a/src/policydb/web/routes/policies.py
+++ b/src/policydb/web/routes/policies.py
@@ -3813,8 +3813,12 @@ async def policy_cell_save(request: Request, policy_uid: str, conn=Depends(get_d
         "premium", "limit_amount", "deductible", "attachment_point",
         "participation_of", "prior_premium",
     }
+    # Note: follow_up_date is NOT editable via /cell. Migration 150 dropped
+    # policies.follow_up_date and made activity_log the sole source. Callers
+    # that need to write a follow-up date should PATCH /{uid}/followup-field,
+    # which routes through create_followup_activity / activity_log updates.
     date_fields = {
-        "effective_date", "expiration_date", "follow_up_date", "target_effective_date",
+        "effective_date", "expiration_date", "target_effective_date",
     }
     bool_fields = {"is_bor", "is_standalone", "flagged", "policy_number_unknown"}
     text_fields = {

--- a/src/policydb/web/templates/_issue_create_slideover.html
+++ b/src/policydb/web/templates/_issue_create_slideover.html
@@ -377,18 +377,9 @@
   };
 
   // Wire up client autocomplete for the editable (non-locked) case.
-  // initClientAutocomplete is defined in base.html's footer script block, which
-  // renders AFTER this include, so wait for the DOM to finish parsing.
-  function _wireIssueCreateClientAutocomplete() {
-    if (typeof initClientAutocomplete === 'function') {
-      initClientAutocomplete('issue-create-client-search', 'issue-create-client-select');
-    }
-  }
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', _wireIssueCreateClientAutocomplete);
-  } else {
-    _wireIssueCreateClientAutocomplete();
-  }
+  // initClientAutocomplete is defined in base.html's early-body script block
+  // (near <body class="h-full">), so it's always available at parse time.
+  initClientAutocomplete('issue-create-client-search', 'issue-create-client-select');
 
 })();
 </script>

--- a/src/policydb/web/templates/base.html
+++ b/src/policydb/web/templates/base.html
@@ -522,6 +522,69 @@
 </head>
 <body class="h-full">
 
+{# Early page helpers — defined at the top of body so inline scripts inside
+   child templates' content block can call them at parse time. Pure functions
+   only: nothing here may touch DOM elements at definition time, because body
+   content has not rendered yet. #}
+<script>
+/* Shared client autocomplete — replaces <select> dropdowns.
+   Usage: initClientAutocomplete(inputId, hiddenId, { onSelect: fn, min: 0 })
+     inputId  — visible text input element ID
+     hiddenId — hidden input (name="client_id") element ID
+     opts.onSelect(item) — callback after selection (for cascading)
+     opts.min — minimum chars before searching (default 0 = show all on focus)
+*/
+function initClientAutocomplete(inputId, hiddenId, opts) {
+  opts = opts || {};
+  var input = document.getElementById(inputId);
+  if (!input) return;
+  var dropdown = null, debounce = null;
+  var minChars = opts.min || 0;
+
+  input.addEventListener('input', function() {
+    clearTimeout(debounce);
+    document.getElementById(hiddenId).value = '0';
+    var q = input.value.trim();
+    if (q.length < minChars) { rmDD(); return; }
+    debounce = setTimeout(function() { doSearch(q); }, 200);
+  });
+  input.addEventListener('focus', function() {
+    if (minChars === 0 && !dropdown) doSearch(input.value.trim());
+  });
+  input.addEventListener('blur', function() { setTimeout(rmDD, 150); });
+
+  function doSearch(q) {
+    fetch('/api/client-search?q=' + encodeURIComponent(q))
+      .then(function(r) { return r.json(); })
+      .then(function(results) {
+        rmDD();
+        if (!results.length) return;
+        dropdown = document.createElement('div');
+        dropdown.className = 'absolute z-50 bg-white border border-gray-200 rounded shadow-lg mt-1 max-h-48 overflow-y-auto';
+        dropdown.style.minWidth = input.offsetWidth + 'px';
+        dropdown.style.maxWidth = '420px';
+        results.forEach(function(item) {
+          var row = document.createElement('div');
+          row.className = 'px-3 py-1.5 text-sm hover:bg-blue-50 cursor-pointer truncate';
+          row.textContent = item.name;
+          row.addEventListener('mousedown', function(e) {
+            e.preventDefault();
+            input.value = item.name;
+            document.getElementById(hiddenId).value = item.id;
+            rmDD();
+            if (opts.onSelect) opts.onSelect(item);
+          });
+          dropdown.appendChild(row);
+        });
+        input.parentNode.style.position = 'relative';
+        input.parentNode.appendChild(dropdown);
+      });
+  }
+  function rmDD() { if (dropdown && dropdown.parentNode) dropdown.parentNode.removeChild(dropdown); dropdown = null; }
+}
+window.initClientAutocomplete = initClientAutocomplete;
+</script>
+
 <div class="min-h-full">
   <!-- Nav -->
   <nav class="bg-marsh border-b border-marsh-light">
@@ -1477,63 +1540,9 @@ document.addEventListener('keydown', function(e) {
   }
   window.showToast = showToast;
 
-  /**
-   * Shared client autocomplete — replaces <select> dropdowns.
-   * Usage: initClientAutocomplete(inputId, hiddenId, { onSelect: fn, min: 0 })
-   *   inputId  — visible text input element ID
-   *   hiddenId — hidden input (name="client_id") element ID
-   *   opts.onSelect(item) — callback after selection (for cascading)
-   *   opts.min — minimum chars before searching (default 0 = show all on focus)
-   */
-  function initClientAutocomplete(inputId, hiddenId, opts) {
-    opts = opts || {};
-    var input = document.getElementById(inputId);
-    if (!input) return;
-    var dropdown = null, debounce = null;
-    var minChars = opts.min || 0;
-
-    input.addEventListener('input', function() {
-      clearTimeout(debounce);
-      document.getElementById(hiddenId).value = '0';
-      var q = input.value.trim();
-      if (q.length < minChars) { rmDD(); return; }
-      debounce = setTimeout(function() { doSearch(q); }, 200);
-    });
-    input.addEventListener('focus', function() {
-      if (minChars === 0 && !dropdown) doSearch(input.value.trim());
-    });
-    input.addEventListener('blur', function() { setTimeout(rmDD, 150); });
-
-    function doSearch(q) {
-      fetch('/api/client-search?q=' + encodeURIComponent(q))
-        .then(function(r) { return r.json(); })
-        .then(function(results) {
-          rmDD();
-          if (!results.length) return;
-          dropdown = document.createElement('div');
-          dropdown.className = 'absolute z-50 bg-white border border-gray-200 rounded shadow-lg mt-1 max-h-48 overflow-y-auto';
-          dropdown.style.minWidth = input.offsetWidth + 'px';
-          dropdown.style.maxWidth = '420px';
-          results.forEach(function(item) {
-            var row = document.createElement('div');
-            row.className = 'px-3 py-1.5 text-sm hover:bg-blue-50 cursor-pointer truncate';
-            row.textContent = item.name;
-            row.addEventListener('mousedown', function(e) {
-              e.preventDefault();
-              input.value = item.name;
-              document.getElementById(hiddenId).value = item.id;
-              rmDD();
-              if (opts.onSelect) opts.onSelect(item);
-            });
-            dropdown.appendChild(row);
-          });
-          input.parentNode.style.position = 'relative';
-          input.parentNode.appendChild(dropdown);
-        });
-    }
-    function rmDD() { if (dropdown && dropdown.parentNode) dropdown.parentNode.removeChild(dropdown); dropdown = null; }
-  }
-  window.initClientAutocomplete = initClientAutocomplete;
+  // Note: initClientAutocomplete was moved to an early-body script near
+  // line 525 so inline scripts inside child templates' content block can
+  // call it at parse time. See the script block right after the body tag.
 
   // Listen for server-sent toast messages via HX-Trigger
   document.body.addEventListener('activityLogged', function(e) {

--- a/src/policydb/web/templates/reconcile/_pairing_board.html
+++ b/src/policydb/web/templates/reconcile/_pairing_board.html
@@ -56,25 +56,10 @@
     <span class="text-xs text-green-600 font-medium">All program matches confirmed</span>
     {% endif %}
   </div>
-  <div class="space-y-2">
-    {% for uid, pgm in program_summary.items() %}
-    <div class="flex items-center gap-3 text-xs">
-      <span class="font-medium text-blue-900">{{ pgm.policy_type or 'Program' }}</span>
-      <span class="text-blue-500">&middot;</span>
-      <span class="text-blue-700">{{ pgm.matched_count }}/{{ pgm.carrier_count }} carriers matched</span>
-      <span class="text-blue-500">&middot;</span>
-      <span class="tabular-nums {% if pgm.fully_reconciled %}text-green-700{% else %}text-amber-700{% endif %}">
-        {{ pgm.matched_premium | currency }} of {{ pgm.total_premium | currency }}
-      </span>
-      {% if pgm.fully_reconciled %}
-      <span class="text-green-600 font-medium">&#10003; Reconciled</span>
-      {% elif pgm.new_carriers %}
-      <span class="text-amber-600 font-medium">{{ pgm.new_carriers | length }} new carrier{{ 's' if pgm.new_carriers | length != 1 else '' }}</span>
-      {% endif %}
-      <a href="/policies/{{ uid }}/edit" class="text-blue-500 hover:underline ml-auto font-mono">{{ uid }}</a>
-    </div>
-    {% endfor %}
-  </div>
+  {# Per-program stats loop removed in 8e59fc8e's simplification pass — child
+     policies are now ordinary 1:1 matches and appear as regular rows in the
+     pairing board. The "Okay All Program Matches" button above still bulk-
+     confirms every PAIRED row whose db.program_id is set. #}
 </div>
 {% endif %}
 

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -225,7 +225,14 @@ def test_suggest_no_location_project_id_uses_corporate():
 # ── Summary computation ─────────────────────────────────────────────────────
 
 def test_compliance_summary():
-    """Summary computes correct totals and percentages."""
+    """Summary computes correct totals and percentages.
+
+    compute_compliance_summary excludes Needs Review / Waived / N/A /
+    Pending Info from the denominator (see compliance.py:289 — they
+    don't represent decided coverage states), so the denominator here
+    is 3 applicable requirements (GL, Umbrella, Property) with 2
+    satisfied → 67%.
+    """
     governing = {
         "GL": {"compliance_status": "Compliant", "coverage_line": "GL"},
         "Umbrella": {"compliance_status": "Compliant", "coverage_line": "Umbrella"},
@@ -237,7 +244,7 @@ def test_compliance_summary():
     assert summary["compliant"] == 2
     assert summary["gap"] == 1
     assert summary["needs_review"] == 1
-    assert summary["compliance_pct"] == 50  # 2/4 * 100
+    assert summary["compliance_pct"] == 67  # 2 / (4 - 1 needs_review) * 100, rounded
 
 
 def test_compliance_summary_empty():
@@ -259,7 +266,11 @@ def test_compliance_summary_all_compliant():
 
 
 def test_compliance_summary_waived_and_na():
-    """Waived and N/A statuses are tracked but not counted as compliant."""
+    """Waived and N/A statuses are tracked but excluded from the denominator.
+
+    With 1 Compliant, 1 Waived, 1 N/A, 1 Partial, the applicable denominator
+    is 2 (Compliant + Partial), and satisfied is 1 → 50%.
+    """
     governing = {
         "GL": {"compliance_status": "Compliant"},
         "D&O": {"compliance_status": "Waived"},
@@ -272,7 +283,7 @@ def test_compliance_summary_waived_and_na():
     assert summary["waived"] == 1
     assert summary["na"] == 1
     assert summary["partial"] == 1
-    assert summary["compliance_pct"] == 25
+    assert summary["compliance_pct"] == 50  # 1 / (4 - 1 waived - 1 na) * 100
 
 
 def test_compliance_summary_none_status_treated_as_needs_review():
@@ -416,7 +427,12 @@ def _make_db() -> sqlite3.Connection:
             program_id    INTEGER,
             expiration_date DATE,
             is_program    INTEGER DEFAULT 0,
-            is_opportunity INTEGER DEFAULT 0
+            is_opportunity INTEGER DEFAULT 0,
+            -- Added in migration 147 (compliance review UX redesign):
+            -- endorsements is the policy-side source of truth for Waiver of
+            -- Subrogation / Additional Insured / Primary & Non-contributory
+            -- and feeds the compliance matching in compliance.py:726.
+            endorsements  TEXT DEFAULT '[]'
         );
         CREATE TABLE client_risks (
             id        INTEGER PRIMARY KEY,

--- a/tests/test_llm_schemas.py
+++ b/tests/test_llm_schemas.py
@@ -38,12 +38,15 @@ def test_policy_schema_has_required_metadata():
     from policydb.llm_schemas import POLICY_EXTRACTION_SCHEMA
 
     assert POLICY_EXTRACTION_SCHEMA["name"] == "policy_extraction"
-    assert POLICY_EXTRACTION_SCHEMA["version"] == 1
+    # Schema was bumped to version 2 when follow_up_date / exposure fields
+    # were factored out to client_exposures and activity_log (PRs #244 / #248).
+    assert POLICY_EXTRACTION_SCHEMA["version"] == 2
     assert "description" in POLICY_EXTRACTION_SCHEMA
     assert POLICY_EXTRACTION_SCHEMA["context_fields"] == ["client_name", "industry"]
     assert "fields" in POLICY_EXTRACTION_SCHEMA
     assert isinstance(POLICY_EXTRACTION_SCHEMA["fields"], list)
-    assert len(POLICY_EXTRACTION_SCHEMA["fields"]) == 28
+    # Field count dropped from 28 → 25 after factoring out deprecated columns.
+    assert len(POLICY_EXTRACTION_SCHEMA["fields"]) == 25
 
 
 def test_policy_schema_date_fields_have_no_normalizer():

--- a/tests/test_open_tasks.py
+++ b/tests/test_open_tasks.py
@@ -42,127 +42,12 @@ def _insert_followup(conn, client_id, policy_id, subject, fu_date, done=0):
     return conn.execute("SELECT last_insert_rowid()").fetchone()[0]
 
 
-# ── sync_policy_follow_up_date ────────────────────────────────────────────────
-
-def test_sync_policy_fu_date_sets_earliest_open(tmp_db):
-    from policydb.queries import sync_policy_follow_up_date
-    conn = get_connection()
-    cid = _seed_client(conn)
-    pid = _seed_policy(conn, cid)
-    _insert_followup(conn, cid, pid, "later", "2026-05-10")
-    _insert_followup(conn, cid, pid, "earlier", "2026-05-01")
-    conn.commit()
-
-    sync_policy_follow_up_date(conn, pid)
-    conn.commit()
-
-    row = conn.execute("SELECT follow_up_date FROM policies WHERE id=?", (pid,)).fetchone()
-    assert row["follow_up_date"] == "2026-05-01"
-
-
-def test_sync_policy_fu_date_clears_when_no_open(tmp_db):
-    from policydb.queries import sync_policy_follow_up_date
-    conn = get_connection()
-    cid = _seed_client(conn)
-    pid = _seed_policy(conn, cid)
-    _insert_followup(conn, cid, pid, "done", "2026-05-01", done=1)
-    conn.execute("UPDATE policies SET follow_up_date='2026-05-01' WHERE id=?", (pid,))
-    conn.commit()
-
-    sync_policy_follow_up_date(conn, pid)
-    conn.commit()
-
-    row = conn.execute("SELECT follow_up_date FROM policies WHERE id=?", (pid,)).fetchone()
-    assert row["follow_up_date"] is None
-
-
-def test_sync_client_fu_date_sets_earliest_open(tmp_db):
-    from policydb.queries import sync_client_follow_up_date
-    conn = get_connection()
-    cid = _seed_client(conn)
-    # Client-level follow-ups have policy_id = NULL
-    conn.execute(
-        "INSERT INTO activity_log (activity_date, client_id, policy_id, activity_type, "
-        "subject, follow_up_date, follow_up_done, item_kind, account_exec) "
-        "VALUES (?, ?, NULL, 'Call', 'direct1', '2026-06-10', 0, 'followup', 'Grant')",
-        (date.today().isoformat(), cid),
-    )
-    conn.execute(
-        "INSERT INTO activity_log (activity_date, client_id, policy_id, activity_type, "
-        "subject, follow_up_date, follow_up_done, item_kind, account_exec) "
-        "VALUES (?, ?, NULL, 'Call', 'direct2', '2026-06-01', 0, 'followup', 'Grant')",
-        (date.today().isoformat(), cid),
-    )
-    conn.commit()
-
-    sync_client_follow_up_date(conn, cid)
-    conn.commit()
-
-    row = conn.execute("SELECT follow_up_date FROM clients WHERE id=?", (cid,)).fetchone()
-    assert row["follow_up_date"] == "2026-06-01"
-
-
-def test_sync_policy_fu_date_ignores_done_rows(tmp_db):
-    """Core invariant: a done row must not be picked as the earliest date
-    when an open row exists with a later date."""
-    from policydb.queries import sync_policy_follow_up_date
-    conn = get_connection()
-    cid = _seed_client(conn)
-    pid = _seed_policy(conn, cid)
-    _insert_followup(conn, cid, pid, "closed earlier", "2026-05-01", done=1)
-    _insert_followup(conn, cid, pid, "still open", "2026-05-10")
-    conn.commit()
-
-    sync_policy_follow_up_date(conn, pid)
-    conn.commit()
-
-    row = conn.execute("SELECT follow_up_date FROM policies WHERE id=?", (pid,)).fetchone()
-    assert row["follow_up_date"] == "2026-05-10"
-
-
-def test_sync_policy_fu_date_picks_up_null_item_kind(tmp_db):
-    """Pre-migration rows with item_kind IS NULL must still be synced.
-    Migration 104 added item_kind with DEFAULT 'followup' but did not
-    backfill existing rows — the helper must accept both forms."""
-    from policydb.queries import sync_policy_follow_up_date
-    conn = get_connection()
-    cid = _seed_client(conn)
-    pid = _seed_policy(conn, cid)
-    conn.execute(
-        "INSERT INTO activity_log (activity_date, client_id, policy_id, activity_type, "
-        "subject, follow_up_date, follow_up_done, item_kind, account_exec) "
-        "VALUES (?, ?, ?, 'Call', 'legacy row', '2026-04-15', 0, NULL, 'Grant')",
-        (date.today().isoformat(), cid, pid),
-    )
-    conn.commit()
-
-    sync_policy_follow_up_date(conn, pid)
-    conn.commit()
-
-    row = conn.execute("SELECT follow_up_date FROM policies WHERE id=?", (pid,)).fetchone()
-    assert row["follow_up_date"] == "2026-04-15"
-
-
-def test_sync_client_fu_date_clears_when_no_open(tmp_db):
-    """Parity with the policy helper: closing the only open client-level
-    follow-up should clear clients.follow_up_date."""
-    from policydb.queries import sync_client_follow_up_date
-    conn = get_connection()
-    cid = _seed_client(conn)
-    conn.execute(
-        "INSERT INTO activity_log (activity_date, client_id, policy_id, activity_type, "
-        "subject, follow_up_date, follow_up_done, item_kind, account_exec) "
-        "VALUES (?, ?, NULL, 'Call', 'already done', '2026-06-01', 1, 'followup', 'Grant')",
-        (date.today().isoformat(), cid),
-    )
-    conn.execute("UPDATE clients SET follow_up_date='2026-06-01' WHERE id=?", (cid,))
-    conn.commit()
-
-    sync_client_follow_up_date(conn, cid)
-    conn.commit()
-
-    row = conn.execute("SELECT follow_up_date FROM clients WHERE id=?", (cid,)).fetchone()
-    assert row["follow_up_date"] is None
+# ── sync_policy_follow_up_date / sync_client_follow_up_date ─────────────────
+# Removed in PR #244 (commit 32593a02) — record-level follow_up_date cache
+# columns were dropped from policies/clients/programs via migration 150.
+# activity_log is now the sole source of truth and the "next follow-up" is
+# derived via grouped LEFT JOIN on activity_log, so the sync helpers are gone
+# and the old tests that asserted cache freshness no longer apply.
 
 
 # ── create_followup_activity ─────────────────────────────────────────────────
@@ -199,9 +84,15 @@ def test_create_followup_activity_inserts_and_supersedes(tmp_db):
     assert old_row["follow_up_done"] == 1
     assert old_row["auto_close_reason"] == "superseded"
 
-    # policies.follow_up_date should be synced to the new date
-    pol = conn.execute("SELECT follow_up_date FROM policies WHERE id=?", (pid,)).fetchone()
-    assert pol["follow_up_date"] == "2026-04-20"
+    # After PR #244, the "next follow-up" for a policy is derived from the
+    # earliest open activity_log row via MIN(follow_up_date). Verify directly.
+    derived = conn.execute(
+        """SELECT MIN(follow_up_date) AS next_fu FROM activity_log
+           WHERE policy_id = ? AND follow_up_done = 0 AND follow_up_date IS NOT NULL
+             AND (item_kind = 'followup' OR item_kind IS NULL)""",
+        (pid,),
+    ).fetchone()
+    assert derived["next_fu"] == "2026-04-20"
 
 
 def test_create_followup_activity_note_mode_no_supersede(tmp_db):

--- a/tests/test_open_tasks_routes.py
+++ b/tests/test_open_tasks_routes.py
@@ -65,15 +65,11 @@ def test_panel_rejects_invalid_scope_type(app_client, seeded):
     assert r.status_code == 400
 
 
-def test_mark_done_closes_activity_and_syncs_policy(app_client, seeded):
-    conn = get_connection()
-    # Seed policies.follow_up_date to match the activity
-    conn.execute(
-        "UPDATE policies SET follow_up_date='2026-04-15' WHERE id=?",
-        (seeded["policy_id"],),
-    )
-    conn.commit()
-
+def test_mark_done_closes_activity(app_client, seeded):
+    # After PR #244 migration 150, policies.follow_up_date no longer exists —
+    # the derived "next follow-up" comes from activity_log MIN(follow_up_date)
+    # on open rows. Marking the only open activity done should leave no open
+    # rows, so the derived value is NULL.
     r = app_client.post(
         f"/open-tasks/{seeded['activity_id']}/done",
         data={"return_scope_type": "issue", "return_scope_id": seeded["issue_id"]},
@@ -88,10 +84,14 @@ def test_mark_done_closes_activity_and_syncs_policy(app_client, seeded):
     assert row["follow_up_done"] == 1
     assert row["auto_close_reason"] == "manual"
 
-    pol = conn.execute(
-        "SELECT follow_up_date FROM policies WHERE id=?", (seeded["policy_id"],)
+    # No open follow-up rows remain for this policy
+    derived = conn.execute(
+        """SELECT MIN(follow_up_date) AS next_fu FROM activity_log
+           WHERE policy_id = ? AND follow_up_done = 0 AND follow_up_date IS NOT NULL
+             AND (item_kind = 'followup' OR item_kind IS NULL)""",
+        (seeded["policy_id"],),
     ).fetchone()
-    assert pol["follow_up_date"] is None  # synced after mark-done
+    assert derived["next_fu"] is None
 
 
 def test_snooze_shifts_date_by_days(app_client, seeded):

--- a/tests/test_tabbed_pages.py
+++ b/tests/test_tabbed_pages.py
@@ -2,6 +2,7 @@
 
 import sqlite3
 import json
+from datetime import date, timedelta
 from pathlib import Path
 
 import pytest
@@ -21,6 +22,13 @@ def app_client(tmp_path, monkeypatch):
     init_db(path=db_path)
 
     conn = get_connection(db_path)
+    # Derive dates relative to today so the seeded policy stays in-term no
+    # matter when the suite runs. test_db_persistence PATCHes renewal_status
+    # to "Bound", which fires the bind_order guard — an expired policy would
+    # be blocked by "This policy still needs to be renewed first".
+    _today = date.today()
+    _eff = (_today - timedelta(days=90)).isoformat()
+    _exp = (_today + timedelta(days=275)).isoformat()
     # Seed a client + policy for testing
     conn.execute(
         "INSERT INTO clients (id, name, industry_segment) VALUES (1, 'Test Client', 'Construction')"
@@ -30,8 +38,9 @@ def app_client(tmp_path, monkeypatch):
                    effective_date, expiration_date, premium, limit_amount, deductible,
                    renewal_status, is_opportunity, archived)
            VALUES (1, 'POL-001', 1, 'General Liability', 'Test Carrier',
-                   '2025-04-01', '2026-04-01', 50000, 1000000, 5000,
-                   'Not Started', 0, 0)"""
+                   ?, ?, 50000, 1000000, 5000,
+                   'Not Started', 0, 0)""",
+        (_eff, _exp),
     )
     conn.commit()
     conn.close()
@@ -82,21 +91,18 @@ class TestPolicyCellPatch:
         assert r.status_code == 200
         assert r.json()["formatted"] == "$45,000"
 
-    def test_date_field_follow_up(self, app_client):
+    def test_follow_up_date_rejected_on_cell_endpoint(self, app_client):
+        # Migration 150 dropped policies.follow_up_date; the /cell endpoint no
+        # longer accepts this field. Callers must use /{uid}/followup-field
+        # which routes through activity_log.
         r = self._patch(app_client, "follow_up_date", "2026-05-01")
-        assert r.status_code == 200
-        assert r.json()["ok"] is True
-        assert r.json()["formatted"] == "2026-05-01"
+        assert r.status_code == 400
+        assert "follow_up_date" in r.json().get("error", "")
 
     def test_date_field_effective(self, app_client):
         r = self._patch(app_client, "effective_date", "2025-07-01")
         assert r.status_code == 200
         assert r.json()["formatted"] == "2025-07-01"
-
-    def test_date_field_clear(self, app_client):
-        r = self._patch(app_client, "follow_up_date", "")
-        assert r.status_code == 200
-        assert r.json()["formatted"] == ""
 
     def test_bool_field_is_bor(self, app_client):
         r = self._patch(app_client, "is_bor", "true")
@@ -161,9 +167,12 @@ class TestPolicyCellPatch:
         assert r.json()["formatted"] == "General Liability"
 
     def test_commission_rate(self, app_client):
+        # Cell endpoint stores commission as a fraction in the DB but returns
+        # the percent-formatted string for display. "0.12" → stored 0.12,
+        # returned "12" (12% via Tabulator's _format: percent column).
         r = self._patch(app_client, "commission_rate", "0.12")
         assert r.status_code == 200
-        assert r.json()["formatted"] == "0.120"
+        assert r.json()["formatted"] == "12"
 
     def test_project_name(self, app_client):
         r = self._patch(app_client, "project_name", "Main St Condos")

--- a/tests/test_timeline_engine.py
+++ b/tests/test_timeline_engine.py
@@ -173,6 +173,12 @@ def test_skip_child_policies_in_program(tmp_db):
     _insert_test_client(conn)
     _insert_test_policy(conn, 'PGM-001', 1, eff_date, exp_date,
                         id=1, is_program=1, milestone_profile='Full Renewal')
+    # Migration 103 repointed policies.program_id FK to programs(id) (was
+    # policies.id before). Tests that set program_id must insert the
+    # corresponding programs row first or the FK constraint fails.
+    conn.execute(
+        "INSERT INTO programs (id, program_uid, client_id, name) VALUES (1, 'PGM-001', 1, 'Test Program')"
+    )
     _insert_test_policy(conn, 'POL-002', 1, eff_date, exp_date,
                         id=2, program_id=1, milestone_profile='')
     conn.commit()
@@ -519,6 +525,10 @@ def test_review_queue_excludes_child_policies(tmp_db):
     # Program policy
     _insert_test_policy(conn, "PGM-001", 1, eff_date=eff, exp_date=exp,
                         id=1, is_program=1, review_cycle="1w", carrier="TestCo")
+    # Migration 103 repointed policies.program_id FK → programs(id).
+    conn.execute(
+        "INSERT INTO programs (id, program_uid, client_id, name) VALUES (1, 'PGM-001', 1, 'Test Program')"
+    )
     # Child policy in that program
     _insert_test_policy(conn, "POL-002", 1, eff_date=eff, exp_date=exp,
                         id=2, program_id=1, review_cycle="1w", carrier="TestCo")
@@ -539,6 +549,10 @@ def test_program_review_cascade_to_children(tmp_db):
     _insert_test_client(conn, 1, "Acme")
     _insert_test_policy(conn, "PGM-001", 1, eff_date=eff, exp_date=exp,
                         id=1, is_program=1, review_cycle="1w", carrier="TestCo")
+    # Migration 103 repointed policies.program_id FK → programs(id).
+    conn.execute(
+        "INSERT INTO programs (id, program_uid, client_id, name) VALUES (1, 'PGM-001', 1, 'Test Program')"
+    )
     _insert_test_policy(conn, "POL-002", 1, eff_date=eff, exp_date=exp,
                         id=2, program_id=1, review_cycle="1w", carrier="TestCo")
     conn.commit()


### PR DESCRIPTION
## Summary

Circling back on the reconcile process to confirm it still works after the recent wave of changes uncovered **two reconcile regressions**, **one structural fix** for a whole class of inline-script bugs, and — after merging `main` — **16 stale tests** from an earlier PR that needed updating. Reconcile is now verified end-to-end and the full suite is green.

## Why

- User asked to "circle back to the reconcile process… ensure that this still functions as intended" after a lot of recent commits.
- Initial code audit was clean, but a browser walkthrough with a synthetic CSV surfaced two real regressions.
- Fixing the second one required hoisting `initClientAutocomplete` out of the footer IIFE, which caught two more pages that were also broken.
- The worktree turned out to be 6 commits behind `main`, including PR #244 which dropped `follow_up_date` from `policies`/`clients`/`programs` via migration 150. That had already run against the shared sqlite DB but the worktree's code still queried the removed column, so three more endpoints were 500'ing. Merging `main` pulled in the query rewrites; the post-merge cleanup fixed the last 16 stale tests.

## What changed

### Reconcile regressions
- **F1** — `reconcile/index.html:73`: `initClientAutocomplete` inline script fired before `base.html`'s footer IIFE defined the function → `ReferenceError`. "Limit to Client" filter was dead. Fixed structurally via F4 below.
- **F2 (hard blocker)** — `reconcile/_pairing_board.html:59–77`: stale per-program stats loop referenced `pgm.matched_premium` / `matched_count` / `carrier_count` / `fully_reconciled` / `new_carriers` that commit `8e59fc8e` had already stripped from `program_reconcile_summary()`. Any run-match touching a policy with `program_id` set (Fieldale Farms, 15 rows) returned 500. Deleted the broken loop; the outer banner and "Okay All Program Matches" bulk-confirm button still work.

### Structural
- **F4** — Hoisted `initClientAutocomplete` to an early-body `<script>` block in `base.html` (right after `<body class="h-full">`). Pure function with no DOM references at definition time, so it's safe to define before body content renders. Deleted the duplicate definition from the footer IIFE. Simplified the defensive guard in `_issue_create_slideover.html` back to a plain inline call. Four templates (`reconcile/index.html`, `policies/new.html`, `charts/index.html`, `activities/list.html`) had the same bug and are now all fixed by the hoist.

### Runtime fix in policies.py
- **F5.1** — `src/policydb/web/routes/policies.py:3817`: removed `follow_up_date` from the `/cell` endpoint's `date_fields` allowlist. Migration 150 dropped `policies.follow_up_date`; the dedicated `/{uid}/followup-field` endpoint is the canonical write path.

### Merge of `origin/main`
Clean merge of 6 commits (PRs #243–#248). Most notable: PR #244 "Deprecate record-level follow_up_date; derive from activity_log" and migration 150.

### Stale test cleanup (all 16 failing tests)
- **`test_tabbed_pages.py`** — fixture dates made relative to `date.today()` (was hitting bind_order's `needs_renew` guard because 2026-04-01 is now past-expiration); `follow_up_date` cell tests rewritten to expect 400; `commission_rate` assertion updated for current percent-display format (`"12"` for `0.12`).
- **`test_open_tasks.py`** — deleted 6 tests calling removed `sync_policy_follow_up_date`/`sync_client_follow_up_date` helpers; rewrote the supersession test to verify derived next-follow-up via `MIN(follow_up_date)` on `activity_log`.
- **`test_open_tasks_routes.py`** — rewrote `test_mark_done_closes_activity` to drop the stale cache check.
- **`test_llm_schemas.py`** — bumped `POLICY_EXTRACTION_SCHEMA` version `1 → 2` and field count `28 → 25`.
- **`test_compliance.py`** — updated `compliance_pct` assertions to match the current formula (excludes Needs Review / Waived / N/A / Pending Info from denominator); added `endorsements` column to the test fixture's `policies` CREATE TABLE (missing since migration 147).
- **`test_timeline_engine.py`** — 3 tests now insert a matching `programs` row before creating child policies with `program_id=1` (migration 103 repointed the FK to `programs(id)`).

## Verification

### Reconcile walkthrough (synthetic CSV, 7 rows, Meridian Development Group)

| # | Scenario | Expected | Actual |
|---|----------|----------|--------|
| 1 | Exact match (Travelers GL) | Score 100, clean | ✅ Score 100, clean |
| 2 | Carrier alias (`Chubb Limited → Chubb`) | High score + cosmetic | ✅ Validation panel shows alias; target policy archived so paired to next-best (POL-003, 55) — not a reconciler bug |
| 3 | Coverage alias (`CGL → General Liability`) | Clean match | ✅ Score 100, no diff |
| 4 | Real premium diff (+\$5k) | `diff_fields=premium` | ✅ In XLSX Differences sheet |
| 5 | Fuzzy policy number (spaces vs dashes) | Normalized clean match | ✅ Score 100 |
| 6 | Unmatched (new Crime policy) | Red bucket | ✅ Unmatched |
| 7 | **Railroad Protective Liability** | Distinct from GL, unmatched | ✅ `Railroad Protective Liability → Railroad Protective` (critical invariant intact) |

Counter totals: Paired 3 / Review 2 / Unmatched 2 / Extra 51 / Total 58. OOB counter pattern confirmed: "Confirm All Paired (5)" decremented to (1) via `hx-swap-oob="true"`. XLSX export is a valid 19KB, 5-sheet file (Summary / Differences / Missing / Extra / All Results).

### Route smoke tests
All previously-500 routes now return 200:
- `/reconcile`, `/policies/new`, `/charts` (were broken by F4)
- `/activities`, `/clients/1`, `/action-center`, `/action-center?tab=followups`, `/action-center?tab=activities` (were broken by F5)

### Test suite
- Before: 16 failed (on both `main` and worktree)
- After: **522 passed, 0 failed**

### DB state
Policies count before/after: 65 / 65. Zero writes to the shared sqlite during validation — confirmed via a backup + diff. No restore needed.

## Test plan

- [x] `/reconcile` renders with no JS console errors
- [x] Upload a standard-template CSV through column mapping and validation panel
- [x] Run match renders pairing board without 500
- [x] Program Reconciliation banner renders cleanly when the scope contains a policy with `program_id`
- [x] Confirm single row collapses the row and updates counters via OOB
- [x] Confirm All Paired updates the button counter via OOB
- [x] XLSX export downloads and openpyxl can parse it with the expected 5 sheets
- [x] Railroad Protective Liability does not false-match as General Liability
- [x] `pytest tests/` green (522 passed)
- [x] `/clients/{id}`, `/action-center?tab=followups`, `/activities` all return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)