### PR TITLE
Audit + drop policies.exposure_* columns (migration 151)

### DIFF
--- a/src/policydb/bind_order.py
+++ b/src/policydb/bind_order.py
@@ -359,24 +359,14 @@ def _sync_policy_to_program_location(
     ).fetchone()
     if not project:
         return
+    # Address fields live on the projects row directly now; just link the
+    # policy to the project.
     conn.execute(
         """UPDATE policies SET
               project_id = ?,
-              project_name = ?,
-              exposure_address = COALESCE(NULLIF(?, ''), exposure_address),
-              exposure_city = COALESCE(NULLIF(?, ''), exposure_city),
-              exposure_state = COALESCE(NULLIF(?, ''), exposure_state),
-              exposure_zip = COALESCE(NULLIF(?, ''), exposure_zip)
+              project_name = ?
            WHERE policy_uid = ?""",
-        (
-            project["id"],
-            project["name"],
-            project["address"] or "",
-            project["city"] or "",
-            project["state"] or "",
-            project["zip"] or "",
-            policy_uid,
-        ),
+        (project["id"], project["name"], policy_uid),
     )
 
 

--- a/src/policydb/cli.py
+++ b/src/policydb/cli.py
@@ -426,14 +426,12 @@ def policy_add(client_name):
             default="Not Started",
         )
         commission_rate = click.prompt("Commission rate (0.12 = 12%, 0 if unknown)", type=float, default=0.0)
-        exposure_basis = click.prompt("Exposure basis (e.g. Payroll, Revenue, Sq Ft — optional)", default="", show_default=False)
-        exposure_amount = click.prompt("Exposure amount (0 if unknown)", type=float, default=0.0)
-        exposure_unit = click.prompt("Exposure unit (e.g. per $100, per $1,000, per unit, per sq ft)", default="", show_default=False)
         notes = click.prompt("Internal notes (optional)", default="", show_default=False)
+        click.echo("  (Link exposures after creation via `policydb exposure add`.)")
     else:
-        limit_amount = deductible = commission_rate = exposure_amount = 0.0
+        limit_amount = deductible = commission_rate = 0.0
         description = coverage_form = layer_position = "Primary"
-        colleague = uw_name = exposure_basis = exposure_unit = notes = ""
+        colleague = uw_name = notes = ""
         is_standalone = False
         status = "Not Started"
 
@@ -443,15 +441,14 @@ def policy_add(client_name):
             effective_date, expiration_date, premium, limit_amount, deductible,
             description, coverage_form, layer_position, is_standalone,
             underwriter_name, renewal_status, commission_rate,
-            exposure_basis, exposure_amount, exposure_unit, account_exec, notes)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            account_exec, notes)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             uid, client["id"], pol_type, carrier, policy_number or None,
             eff, exp, premium, limit_amount or None, deductible or None,
             description or None, coverage_form or None, layer_position or "Primary",
             1 if is_standalone else 0,
             uw_name or None, status, commission_rate or None,
-            exposure_basis or None, exposure_amount or None, exposure_unit or None,
             account_exec, notes or None,
         ),
     )
@@ -511,9 +508,6 @@ def policy_show(policy_uid, fmt):
         ("Renewal Status", row["renewal_status"]),
         ("Placement Colleague", row["placement_colleague"] or "—"),
         ("Underwriter", row["underwriter_name"] or "—"),
-        ("Exposure Basis", row["exposure_basis"] or "—"),
-        ("Exposure Amount", fmt_currency(row["exposure_amount"]) if row["exposure_amount"] else "—"),
-        ("Exposure Unit", row["exposure_unit"] or "—"),
         ("Internal Notes", row["notes"] or "—"),
     ]
     for label, value in fields:
@@ -550,9 +544,6 @@ def policy_edit(policy_uid):
         ("renewal_status", "Renewal status", row["renewal_status"]),
         ("commission_rate", "Commission rate", str(row["commission_rate"] or 0)),
         ("prior_premium", "Prior premium", str(row["prior_premium"] or "")),
-        ("exposure_basis", "Exposure basis", row["exposure_basis"] or ""),
-        ("exposure_amount", "Exposure amount", str(row["exposure_amount"] or "")),
-        ("exposure_unit", "Exposure unit", row["exposure_unit"] or ""),
         ("notes", "Internal notes", row["notes"] or ""),
     ]
     updates = {}
@@ -560,7 +551,7 @@ def policy_edit(policy_uid):
         val = click.prompt(f"  {label}", default=current, show_default=True)
         if val != current:
             # Type coercion for numeric fields
-            if col in ("premium", "limit_amount", "deductible", "commission_rate", "prior_premium", "exposure_amount"):
+            if col in ("premium", "limit_amount", "deductible", "commission_rate", "prior_premium"):
                 try:
                     updates[col] = float(val) if val else None
                 except ValueError:

--- a/src/policydb/db.py
+++ b/src/policydb/db.py
@@ -226,28 +226,31 @@ def _run_hygiene_062(conn: sqlite3.Connection) -> None:
             conn.execute("UPDATE clients SET name = ? WHERE id = ?", (n, r["id"]))
             changed["client_name"] += 1
 
+    # Normalize address fields on the `projects` table (authoritative now
+    # that the legacy policies.exposure_* columns have been dropped).
     for r in conn.execute(
-        "SELECT id, exposure_zip, exposure_state, exposure_city FROM policies WHERE exposure_zip IS NOT NULL OR exposure_state IS NOT NULL OR exposure_city IS NOT NULL"
+        """SELECT id, zip, state, city FROM projects
+           WHERE zip IS NOT NULL OR state IS NOT NULL OR city IS NOT NULL"""
     ).fetchall():
         updates = {}
-        if r["exposure_zip"]:
-            fmt = format_zip(r["exposure_zip"])
-            if fmt != r["exposure_zip"]:
-                updates["exposure_zip"] = fmt
+        if r["zip"]:
+            fmt = format_zip(r["zip"])
+            if fmt != r["zip"]:
+                updates["zip"] = fmt
                 changed["zip"] += 1
-        if r["exposure_state"]:
-            fmt = format_state(r["exposure_state"])
-            if fmt != r["exposure_state"]:
-                updates["exposure_state"] = fmt
+        if r["state"]:
+            fmt = format_state(r["state"])
+            if fmt != r["state"]:
+                updates["state"] = fmt
                 changed["state"] += 1
-        if r["exposure_city"]:
-            fmt = format_city(r["exposure_city"])
-            if fmt != r["exposure_city"]:
-                updates["exposure_city"] = fmt
+        if r["city"]:
+            fmt = format_city(r["city"])
+            if fmt != r["city"]:
+                updates["city"] = fmt
                 changed["city"] += 1
         if updates:
             set_clause = ", ".join(f"{k} = ?" for k in updates)
-            conn.execute(f"UPDATE policies SET {set_clause} WHERE id = ?", (*updates.values(), r["id"]))  # noqa: S608
+            conn.execute(f"UPDATE projects SET {set_clause} WHERE id = ?", (*updates.values(), r["id"]))  # noqa: S608
 
     conn.commit()
     total = sum(changed.values())
@@ -2022,6 +2025,34 @@ def _init_db_inner(conn: sqlite3.Connection, db_path: Path) -> None:
         conn.commit()
         logger.info("Migration 150: dropped policies/clients/programs.follow_up_date (activity_log is sole source of truth)")
 
+    if 151 not in applied:
+        # Idempotent: skip any DROP COLUMN line whose column is already gone.
+        def _has_policy_col(col: str) -> bool:
+            return any(
+                r[1] == col for r in conn.execute("PRAGMA table_info(policies)").fetchall()
+            )
+        _dropped_cols = {
+            "exposure_basis", "exposure_amount", "exposure_unit",
+            "exposure_denominator", "exposure_address", "exposure_city",
+            "exposure_state", "exposure_zip",
+        }
+        _migration_sql = (_MIGRATIONS_DIR / "151_drop_policy_exposure_columns.sql").read_text()
+        _filtered_lines = []
+        for _line in _migration_sql.splitlines():
+            _stripped = _line.strip().rstrip(";")
+            if _stripped.startswith("ALTER TABLE policies DROP COLUMN "):
+                _col = _stripped.split()[-1]
+                if _col in _dropped_cols and not _has_policy_col(_col):
+                    continue
+            _filtered_lines.append(_line)
+        conn.executescript("\n".join(_filtered_lines))
+        conn.execute(
+            "INSERT INTO schema_version (version, description) VALUES (?, ?)",
+            (151, "Drop deprecated policies.exposure_* columns (data lives on client_exposures + projects)"),
+        )
+        conn.commit()
+        logger.info("Migration 151: dropped 8 deprecated policies.exposure_* columns")
+
     # Data hygiene: fix 'None' string corruption in text fields (runs every startup, fast no-op if clean)
     conn.execute("UPDATE clients SET cn_number = NULL WHERE cn_number = 'None'")
 
@@ -2070,17 +2101,10 @@ def _init_db_inner(conn: sqlite3.Connection, db_path: Path) -> None:
     except Exception:
         pass  # Table may not exist on older schemas
 
-    # Backfill project addresses from linked policies (idempotent — only fills empty project addresses)
-    conn.execute("""
-        UPDATE projects SET
-            address = (SELECT p.exposure_address FROM policies p WHERE p.project_id = projects.id AND p.exposure_address IS NOT NULL AND p.exposure_address != '' LIMIT 1),
-            city = (SELECT p.exposure_city FROM policies p WHERE p.project_id = projects.id AND p.exposure_city IS NOT NULL AND p.exposure_city != '' LIMIT 1),
-            state = (SELECT p.exposure_state FROM policies p WHERE p.project_id = projects.id AND p.exposure_state IS NOT NULL AND p.exposure_state != '' LIMIT 1),
-            zip = (SELECT p.exposure_zip FROM policies p WHERE p.project_id = projects.id AND p.exposure_zip IS NOT NULL AND p.exposure_zip != '' LIMIT 1)
-        WHERE (project_type = 'Location' OR project_type IS NULL)
-          AND (address IS NULL OR address = '')
-          AND EXISTS (SELECT 1 FROM policies p WHERE p.project_id = projects.id AND p.exposure_address IS NOT NULL AND p.exposure_address != '')
-    """)
+    # (The startup backfill of project addresses from legacy
+    # policies.exposure_* columns has been retired — those columns were
+    # dropped by migration 151.  Migration 151 itself runs one final
+    # backfill before the DROP so no data is lost.)
 
     # Normalize carrier names (idempotent)
     try:

--- a/src/policydb/dedup.py
+++ b/src/policydb/dedup.py
@@ -37,10 +37,6 @@ _COMPARE_FIELDS = [
     "retention",
     "project_name",
     "first_named_insured",
-    "exposure_address",
-    "exposure_city",
-    "exposure_state",
-    "exposure_zip",
     "notes",
     "broker_fee",
 ]
@@ -58,10 +54,6 @@ _FIELD_LABELS = {
     "retention": "Retention",
     "project_name": "Project/Location",
     "first_named_insured": "First Named Insured",
-    "exposure_address": "Address",
-    "exposure_city": "City",
-    "exposure_state": "State",
-    "exposure_zip": "ZIP",
     "notes": "Notes",
     "broker_fee": "Broker Fee",
 }

--- a/src/policydb/exporter.py
+++ b/src/policydb/exporter.py
@@ -197,16 +197,18 @@ def export_llm_client_md(conn: sqlite3.Connection, client_id: int) -> str:
     for pc in policy_contacts_rows:
         policy_contacts_map[pc["policy_id"]].append(dict(pc))
 
-    # Primary location address per project (from most recent policy)
+    # Primary location address per project — now read directly from the
+    # `projects` table (the deprecated policies.exposure_* columns were
+    # dropped).
     project_addresses: dict[str, str] = {}
-    for p in sorted([dict(r) for r in policies], key=lambda x: x.get("id", 0)):
-        proj = (p.get("project_name") or "").strip()
-        if proj not in project_addresses:
-            parts = [p.get("exposure_address"), p.get("exposure_city"),
-                     p.get("exposure_state"), p.get("exposure_zip")]
-            addr = ", ".join(x for x in parts if x)
-            if addr:
-                project_addresses[proj] = addr
+    for _pr in conn.execute(
+        "SELECT name, address, city, state, zip FROM projects WHERE client_id = ?",
+        (client["id"],),
+    ).fetchall():
+        parts = [_pr["address"], _pr["city"], _pr["state"], _pr["zip"]]
+        addr = ", ".join(x for x in parts if x)
+        if addr:
+            project_addresses[(_pr["name"] or "").strip()] = addr
 
     # Tower layers grouped by project then tower_group
     tower_by_project: dict = defaultdict(lambda: defaultdict(list))
@@ -1246,7 +1248,12 @@ def export_client_xlsx(conn: sqlite3.Connection, client_id: int) -> bytes:
 
 
 def export_full_xlsx(conn: sqlite3.Connection, client_id: int, client_name: str) -> bytes:
-    """Full internal data export: all policy fields + contacts + notes + activities."""
+    """Full internal data export: all policy fields + contacts + notes + activities.
+
+    The primary exposure + address come from the joined client_exposures
+    (via v_policy_status).  A separate ``Exposures`` sheet lists every
+    linked exposure for every policy, one row per link.
+    """
     policies = conn.execute(
         """SELECT policy_uid, policy_type, carrier, policy_number,
                   effective_date, expiration_date, premium, limit_amount, deductible,
@@ -1256,12 +1263,35 @@ def export_full_xlsx(conn: sqlite3.Connection, client_id: int, client_name: str)
                   placement_colleague, placement_colleague_email,
                   underwriter_name, underwriter_contact,
                   follow_up_date, attachment_point, participation_of,
-                  exposure_basis, exposure_amount, exposure_unit,
+                  primary_exposure_type AS exposure_basis,
+                  primary_exposure_amount AS exposure_amount,
+                  primary_exposure_unit AS exposure_unit,
                   exposure_address, exposure_city, exposure_state, exposure_zip,
                   notes, account_exec, urgency, days_to_renewal,
                   first_named_insured, access_point
            FROM v_policy_status WHERE client_id = ?
            ORDER BY project_name, policy_type, layer_position""",
+        (client_id,),
+    ).fetchall()
+
+    # Full exposure roll — one row per policy_exposure_links entry.
+    exposures = conn.execute(
+        """SELECT p.policy_uid, p.policy_type, p.carrier,
+                  ce.exposure_type, ce.amount, ce.denominator, ce.unit,
+                  ce.year,
+                  pel.is_primary, pel.rate,
+                  COALESCE(pr_pol.name, pr_exp.name) AS location_name,
+                  COALESCE(pr_pol.address, pr_exp.address) AS location_address,
+                  COALESCE(pr_pol.city,    pr_exp.city)    AS location_city,
+                  COALESCE(pr_pol.state,   pr_exp.state)   AS location_state,
+                  COALESCE(pr_pol.zip,     pr_exp.zip)     AS location_zip
+           FROM policies p
+           JOIN policy_exposure_links pel ON pel.policy_uid = p.policy_uid
+           JOIN client_exposures ce ON ce.id = pel.exposure_id
+           LEFT JOIN projects pr_pol ON pr_pol.id = p.project_id
+           LEFT JOIN projects pr_exp ON pr_exp.id = ce.project_id
+           WHERE p.client_id = ? AND p.archived = 0
+           ORDER BY p.policy_uid, pel.is_primary DESC, ce.exposure_type""",
         (client_id,),
     ).fetchall()
 
@@ -1356,6 +1386,8 @@ def export_full_xlsx(conn: sqlite3.Connection, client_id: int, client_name: str)
     wb = Workbook()
     wb.remove(wb.active)
     _write_sheet(wb, "Policies (Full)", [dict(r) for r in policies])
+    if exposures:
+        _write_sheet(wb, "Exposures", [dict(r) for r in exposures])
     _write_sheet(wb, "Contacts", [dict(r) for r in contacts])
     _write_sheet(wb, "Policy Team", [dict(r) for r in policy_team])
     _write_sheet(wb, "Project Notes", [dict(r) for r in project_notes])
@@ -2976,7 +3008,10 @@ def export_book_review_xlsx(conn: sqlite3.Connection, client_id: int, client_nam
                   p.deductible, p.description, p.coverage_form, p.layer_position,
                   p.tower_group, p.renewal_status, p.first_named_insured,
                   p.placement_colleague, p.underwriter_name,
-                  p.exposure_address, p.project_name, p.project_id,
+                  -- Address from the linked project (the legacy
+                  -- policies.exposure_address column was dropped).
+                  pr.address AS exposure_address,
+                  p.project_name, p.project_id,
                   p.program_id, p.is_opportunity,
                   p.flagged,
                   pr.name AS location_name,

--- a/src/policydb/migrations/151_drop_policy_exposure_columns.sql
+++ b/src/policydb/migrations/151_drop_policy_exposure_columns.sql
@@ -1,0 +1,196 @@
+-- Migration 151: drop the deprecated policies.exposure_* columns.
+--
+-- Exposure rating data now lives exclusively on client_exposures +
+-- policy_exposure_links (see migrations 086, 089 and the Bug 3 PR).
+-- Location address lives on the projects row.  The seven columns being
+-- dropped here were the last dual-write surface; all read sites were
+-- rewired in this commit.
+--
+-- One final backfill runs before the DROPs so any straggler data still
+-- sitting on the legacy columns ends up on the projects row or in
+-- client_exposures before the schema change makes it unreachable.
+-- (Per the planning discussion: we're okay dropping data if the backfill
+-- can't find a sensible target, since the normalized tables are the
+-- source of truth going forward.)
+
+-- ─── Final backfill: straggler address data → projects ─────────────────
+-- For any project that is still missing address fields, copy them from
+-- the most recent linked policy's exposure_* columns as a last chance.
+UPDATE projects
+SET address = (
+        SELECT p.exposure_address
+        FROM policies p
+        WHERE p.project_id = projects.id
+          AND p.exposure_address IS NOT NULL
+          AND p.exposure_address != ''
+        ORDER BY p.id DESC
+        LIMIT 1
+    )
+WHERE (address IS NULL OR address = '')
+  AND EXISTS (
+      SELECT 1 FROM policies p
+      WHERE p.project_id = projects.id
+        AND p.exposure_address IS NOT NULL
+        AND p.exposure_address != ''
+  );
+
+UPDATE projects
+SET city = (
+        SELECT p.exposure_city
+        FROM policies p
+        WHERE p.project_id = projects.id
+          AND p.exposure_city IS NOT NULL
+          AND p.exposure_city != ''
+        ORDER BY p.id DESC
+        LIMIT 1
+    )
+WHERE (city IS NULL OR city = '')
+  AND EXISTS (
+      SELECT 1 FROM policies p
+      WHERE p.project_id = projects.id
+        AND p.exposure_city IS NOT NULL
+        AND p.exposure_city != ''
+  );
+
+UPDATE projects
+SET state = (
+        SELECT p.exposure_state
+        FROM policies p
+        WHERE p.project_id = projects.id
+          AND p.exposure_state IS NOT NULL
+          AND p.exposure_state != ''
+        ORDER BY p.id DESC
+        LIMIT 1
+    )
+WHERE (state IS NULL OR state = '')
+  AND EXISTS (
+      SELECT 1 FROM policies p
+      WHERE p.project_id = projects.id
+        AND p.exposure_state IS NOT NULL
+        AND p.exposure_state != ''
+  );
+
+UPDATE projects
+SET zip = (
+        SELECT p.exposure_zip
+        FROM policies p
+        WHERE p.project_id = projects.id
+          AND p.exposure_zip IS NOT NULL
+          AND p.exposure_zip != ''
+        ORDER BY p.id DESC
+        LIMIT 1
+    )
+WHERE (zip IS NULL OR zip = '')
+  AND EXISTS (
+      SELECT 1 FROM policies p
+      WHERE p.project_id = projects.id
+        AND p.exposure_zip IS NOT NULL
+        AND p.exposure_zip != ''
+  );
+
+-- Drop the views that reference these columns so the DROP COLUMN can
+-- succeed.  init_db() rebuilds every view from views.py after migrations
+-- run, so this is safe.
+DROP VIEW IF EXISTS v_policy_status;
+DROP VIEW IF EXISTS v_schedule;
+DROP VIEW IF EXISTS v_tower;
+DROP VIEW IF EXISTS v_renewal_pipeline;
+DROP VIEW IF EXISTS v_review_queue;
+
+-- Drop the audit trigger that references exposure_address in its WHEN
+-- clause; we recreate it below without the reference.
+DROP TRIGGER IF EXISTS audit_policies_update;
+
+-- ─── Drop the deprecated columns (SQLite 3.35+) ────────────────────────
+ALTER TABLE policies DROP COLUMN exposure_basis;
+ALTER TABLE policies DROP COLUMN exposure_amount;
+ALTER TABLE policies DROP COLUMN exposure_unit;
+ALTER TABLE policies DROP COLUMN exposure_denominator;
+ALTER TABLE policies DROP COLUMN exposure_address;
+ALTER TABLE policies DROP COLUMN exposure_city;
+ALTER TABLE policies DROP COLUMN exposure_state;
+ALTER TABLE policies DROP COLUMN exposure_zip;
+
+-- Recreate audit_policies_update without the exposure_address WHEN clause
+-- (matches the version from migration 150, minus that single line).
+CREATE TRIGGER audit_policies_update
+AFTER UPDATE ON policies
+WHEN OLD.policy_type IS NOT NEW.policy_type
+   OR OLD.carrier IS NOT NEW.carrier
+   OR OLD.policy_number IS NOT NEW.policy_number
+   OR OLD.effective_date IS NOT NEW.effective_date
+   OR OLD.expiration_date IS NOT NEW.expiration_date
+   OR OLD.premium IS NOT NEW.premium
+   OR OLD.limit_amount IS NOT NEW.limit_amount
+   OR OLD.deductible IS NOT NEW.deductible
+   OR OLD.description IS NOT NEW.description
+   OR OLD.coverage_form IS NOT NEW.coverage_form
+   OR OLD.layer_position IS NOT NEW.layer_position
+   OR OLD.renewal_status IS NOT NEW.renewal_status
+   OR OLD.commission_rate IS NOT NEW.commission_rate
+   OR OLD.prior_premium IS NOT NEW.prior_premium
+   OR OLD.account_exec IS NOT NEW.account_exec
+   OR OLD.notes IS NOT NEW.notes
+   OR OLD.project_name IS NOT NEW.project_name
+   OR OLD.first_named_insured IS NOT NEW.first_named_insured
+   OR OLD.is_opportunity IS NOT NEW.is_opportunity
+   OR OLD.opportunity_status IS NOT NEW.opportunity_status
+   OR OLD.is_program IS NOT NEW.is_program
+   OR OLD.archived IS NOT NEW.archived
+   OR OLD.placement_colleague IS NOT NEW.placement_colleague
+   OR OLD.underwriter_name IS NOT NEW.underwriter_name
+BEGIN
+    INSERT INTO audit_log (table_name, row_id, operation, old_values, new_values)
+    VALUES ('policies', NEW.policy_uid, 'UPDATE',
+        json_object(
+            'policy_uid', OLD.policy_uid,
+            'client_id', OLD.client_id,
+            'policy_type', OLD.policy_type,
+            'carrier', OLD.carrier,
+            'policy_number', OLD.policy_number,
+            'effective_date', OLD.effective_date,
+            'expiration_date', OLD.expiration_date,
+            'premium', OLD.premium,
+            'limit_amount', OLD.limit_amount,
+            'deductible', OLD.deductible,
+            'renewal_status', OLD.renewal_status,
+            'commission_rate', OLD.commission_rate,
+            'prior_premium', OLD.prior_premium,
+            'account_exec', OLD.account_exec,
+            'notes', OLD.notes,
+            'project_name', OLD.project_name,
+            'first_named_insured', OLD.first_named_insured,
+            'is_opportunity', OLD.is_opportunity,
+            'opportunity_status', OLD.opportunity_status,
+            'is_program', OLD.is_program,
+            'archived', OLD.archived,
+            'placement_colleague', OLD.placement_colleague,
+            'underwriter_name', OLD.underwriter_name
+        ),
+        json_object(
+            'policy_uid', NEW.policy_uid,
+            'client_id', NEW.client_id,
+            'policy_type', NEW.policy_type,
+            'carrier', NEW.carrier,
+            'policy_number', NEW.policy_number,
+            'effective_date', NEW.effective_date,
+            'expiration_date', NEW.expiration_date,
+            'premium', NEW.premium,
+            'limit_amount', NEW.limit_amount,
+            'deductible', NEW.deductible,
+            'renewal_status', NEW.renewal_status,
+            'commission_rate', NEW.commission_rate,
+            'prior_premium', NEW.prior_premium,
+            'account_exec', NEW.account_exec,
+            'notes', NEW.notes,
+            'project_name', NEW.project_name,
+            'first_named_insured', NEW.first_named_insured,
+            'is_opportunity', NEW.is_opportunity,
+            'opportunity_status', NEW.opportunity_status,
+            'is_program', NEW.is_program,
+            'archived', NEW.archived,
+            'placement_colleague', NEW.placement_colleague,
+            'underwriter_name', NEW.underwriter_name
+        )
+    );
+END;

--- a/src/policydb/models.py
+++ b/src/policydb/models.py
@@ -59,13 +59,6 @@ class Policy:
     underwriter_contact: Optional[str] = None
     commission_rate: Optional[float] = None
     prior_premium: Optional[float] = None
-    exposure_basis: Optional[str] = None
-    exposure_amount: Optional[float] = None
-    exposure_unit: Optional[str] = None
-    exposure_address: Optional[str] = None
-    exposure_city: Optional[str] = None
-    exposure_state: Optional[str] = None
-    exposure_zip: Optional[str] = None
     notes: Optional[str] = None
 
     @classmethod

--- a/src/policydb/prompt_assembler.py
+++ b/src/policydb/prompt_assembler.py
@@ -262,24 +262,46 @@ def assemble_policy(conn: sqlite3.Connection, record_id: int, depth: int = DEPTH
     lines.append(_field("Description", r.get("description")))
     lines.append(_field("Notes", r.get("notes")))
 
-    # Exposure block
-    exp_parts = []
-    exp_parts.append(_field("Exposure Basis", r.get("exposure_basis")))
-    if r.get("exposure_amount") and r.get("exposure_unit"):
-        try:
-            exp_parts.append(_field("Exposure", f"{float(r['exposure_amount']):,.0f} {r['exposure_unit']}"))
-        except (TypeError, ValueError):
-            exp_parts.append(_field("Exposure Amount", r.get("exposure_amount")))
-    elif r.get("exposure_amount"):
-        exp_parts.append(_field("Exposure Amount", r.get("exposure_amount"), "currency"))
-    addr_parts = [r.get("exposure_address"), r.get("exposure_city"), r.get("exposure_state"), r.get("exposure_zip")]
-    addr_line = ", ".join(p for p in addr_parts if p)
-    if addr_line:
-        exp_parts.append(_field("Exposure Location", addr_line))
-    exp_block = "".join(exp_parts)
-    if exp_block:
+    # Exposure block — emits every linked exposure from client_exposures,
+    # primary first.  Address comes from the linked location (projects row).
+    exposure_rows = conn.execute(
+        """SELECT ce.exposure_type, ce.amount, ce.denominator, ce.unit,
+                  ce.year, pel.is_primary,
+                  COALESCE(pr_pol.address, pr_exp.address) AS addr,
+                  COALESCE(pr_pol.city,    pr_exp.city)    AS city,
+                  COALESCE(pr_pol.state,   pr_exp.state)   AS state,
+                  COALESCE(pr_pol.zip,     pr_exp.zip)     AS zip
+           FROM policy_exposure_links pel
+           JOIN client_exposures ce ON ce.id = pel.exposure_id
+           LEFT JOIN policies pol ON pol.policy_uid = pel.policy_uid
+           LEFT JOIN projects pr_pol ON pr_pol.id = pol.project_id
+           LEFT JOIN projects pr_exp ON pr_exp.id = ce.project_id
+           WHERE pel.policy_uid = ?
+           ORDER BY pel.is_primary DESC, ce.exposure_type""",
+        (r.get("policy_uid"),),
+    ).fetchall()
+    if exposure_rows:
         lines.append("\n### Exposure\n")
-        lines.append(exp_block)
+        for idx, er in enumerate(exposure_rows):
+            prefix = "- **Primary**: " if er["is_primary"] else "- "
+            amt_parts = []
+            if er["amount"] is not None:
+                try:
+                    amt_parts.append(f"{float(er['amount']):,.0f}")
+                except (TypeError, ValueError):
+                    amt_parts.append(str(er["amount"]))
+            if er["denominator"] and er["denominator"] != 1:
+                amt_parts.append(f"per {er['denominator']}")
+            if er["unit"]:
+                amt_parts.append(f"({er['unit']})")
+            amt_str = " ".join(amt_parts) if amt_parts else ""
+            lines.append(f"{prefix}{er['exposure_type']}: {amt_str}\n")
+            addr_parts = [er["addr"], er["city"], er["state"], er["zip"]]
+            addr_line = ", ".join(p for p in addr_parts if p)
+            if addr_line:
+                lines.append(f"    Location: {addr_line}\n")
+            if er["year"]:
+                lines.append(f"    Year: {er['year']}\n")
 
     # Opportunity block (only if this is an opportunity)
     if r.get("is_opportunity"):

--- a/src/policydb/queries.py
+++ b/src/policydb/queries.py
@@ -22,6 +22,83 @@ def _normalize_address(raw: str | None) -> str:
     return re.sub(r"\s+", " ", raw.strip().lower())
 
 
+def attach_primary_exposure(
+    conn: sqlite3.Connection, policies: list[dict]
+) -> None:
+    """Stamp each policy dict with primary-exposure + location fields.
+
+    Called by route handlers that hydrate policy rows from queries which
+    don't already join ``policy_exposure_links`` / ``client_exposures`` /
+    ``projects``.  After running, each policy dict carries:
+
+      primary_exposure_type, primary_exposure_amount,
+      primary_exposure_denominator, primary_exposure_unit,
+      exposure_location_address, exposure_location_city,
+      exposure_location_state, exposure_location_zip
+
+    Missing fields are set to ``None`` so templates can render safely.
+    Address fallback priority: ``policies.project_id`` > primary exposure's
+    own ``project_id`` > ``None``.
+    """
+    if not policies:
+        return
+
+    uids = [
+        p.get("policy_uid") for p in policies
+        if isinstance(p, dict) and p.get("policy_uid")
+    ]
+    if not uids:
+        for p in policies:
+            if isinstance(p, dict):
+                _stamp_exposure_defaults(p)
+        return
+
+    placeholders = ",".join("?" * len(uids))
+    rows = conn.execute(
+        f"""SELECT pel.policy_uid,
+                   ce.exposure_type, ce.amount, ce.denominator, ce.unit,
+                   ce.project_id AS exposure_project_id,
+                   pr_pol.address AS pol_address, pr_pol.city AS pol_city,
+                   pr_pol.state AS pol_state, pr_pol.zip AS pol_zip,
+                   pr_exp.address AS exp_address, pr_exp.city AS exp_city,
+                   pr_exp.state AS exp_state, pr_exp.zip AS exp_zip
+            FROM policies p
+            LEFT JOIN policy_exposure_links pel
+              ON pel.policy_uid = p.policy_uid AND pel.is_primary = 1
+            LEFT JOIN client_exposures ce ON ce.id = pel.exposure_id
+            LEFT JOIN projects pr_pol ON pr_pol.id = p.project_id
+            LEFT JOIN projects pr_exp ON pr_exp.id = ce.project_id
+            WHERE p.policy_uid IN ({placeholders})""",  # noqa: S608
+        uids,
+    ).fetchall()
+    by_uid = {r["policy_uid"]: r for r in rows}
+    for p in policies:
+        if not isinstance(p, dict):
+            continue
+        r = by_uid.get(p.get("policy_uid"))
+        if r is None:
+            _stamp_exposure_defaults(p)
+            continue
+        p["primary_exposure_type"] = r["exposure_type"]
+        p["primary_exposure_amount"] = r["amount"]
+        p["primary_exposure_denominator"] = r["denominator"]
+        p["primary_exposure_unit"] = r["unit"]
+        p["exposure_location_address"] = r["pol_address"] or r["exp_address"]
+        p["exposure_location_city"] = r["pol_city"] or r["exp_city"]
+        p["exposure_location_state"] = r["pol_state"] or r["exp_state"]
+        p["exposure_location_zip"] = r["pol_zip"] or r["exp_zip"]
+
+
+def _stamp_exposure_defaults(p: dict) -> None:
+    for k in (
+        "primary_exposure_type", "primary_exposure_amount",
+        "primary_exposure_denominator", "primary_exposure_unit",
+        "exposure_location_address", "exposure_location_city",
+        "exposure_location_state", "exposure_location_zip",
+    ):
+        p.setdefault(k, None)
+
+
 def find_or_create_project_from_address(
     conn,
     *,
@@ -913,10 +990,9 @@ def renew_policy(
             limit_amount, deductible, description, coverage_form,
             layer_position, tower_group, is_standalone,
             renewal_status, commission_rate, account_exec, notes,
-            project_name, project_id, exposure_basis, exposure_amount, exposure_unit,
-            exposure_address, exposure_city, exposure_state, exposure_zip,
+            project_name, project_id,
             prior_policy_uid)
-           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
         (
             new_uid, old["client_id"], old["policy_type"], old["carrier"], None,
             new_eff.isoformat(), new_exp.isoformat(),
@@ -925,11 +1001,45 @@ def renew_policy(
             old["layer_position"] or "Primary", old["tower_group"], old["is_standalone"],
             "Not Started", old["commission_rate"], old["account_exec"], None,
             old["project_name"], old["project_id"],
-            old["exposure_basis"], old["exposure_amount"], old["exposure_unit"],
-            old["exposure_address"], old["exposure_city"], old["exposure_state"], old["exposure_zip"],
             uid,
         ),
     )
+
+    # Carry exposure links forward to the new term.  The underlying
+    # client_exposures rows stay shared across terms (they're year-scoped
+    # by the exposure itself); we just need fresh link rows for the new
+    # policy_uid.  If the new term's effective date rolls into a new year,
+    # reuse or create year-matched client_exposures rows so the rate
+    # calculation uses the right exposure amount.
+    from policydb.exposures import (
+        find_or_create_exposure as _find_or_create_exp,
+        create_exposure_link as _create_exp_link,
+    )
+    _old_links = conn.execute(
+        """SELECT ce.client_id, ce.project_id, ce.exposure_type,
+                  ce.amount, ce.denominator, pel.is_primary
+           FROM policy_exposure_links pel
+           JOIN client_exposures ce ON ce.id = pel.exposure_id
+           WHERE pel.policy_uid = ?""",
+        (uid,),
+    ).fetchall()
+    _new_year = new_eff.year
+    for _l in _old_links:
+        _new_exp_id = _find_or_create_exp(
+            conn,
+            client_id=_l["client_id"],
+            project_id=_l["project_id"],
+            exposure_type=_l["exposure_type"],
+            year=_new_year,
+            amount=_l["amount"],
+            denominator=_l["denominator"] or 1,
+        )
+        try:
+            _create_exp_link(
+                conn, new_uid, _new_exp_id, is_primary=bool(_l["is_primary"]),
+            )
+        except Exception as _e:
+            logger.warning("renew_policy: failed to link exposure %s: %s", _new_exp_id, _e)
 
     # Copy contact_policy_assignments from the expiring term to the new term
     new_policy_id = conn.execute(
@@ -4975,16 +5085,23 @@ def get_all_policies_for_grid(conn: sqlite3.Connection) -> list[dict]:
         p.notes,
         p.placement_colleague,
         p.underwriter_name,
-        p.exposure_basis,
-        p.exposure_amount,
-        p.exposure_address,
-        p.exposure_city,
-        p.exposure_state,
-        p.exposure_zip,
+        -- Primary exposure (from normalized client_exposures table)
+        ce.exposure_type AS exposure_basis,
+        ce.amount        AS exposure_amount,
+        -- Location-derived address fields (resolved via policies.project_id
+        -- first, then the primary exposure's own project_id fallback)
+        COALESCE(pr.address, pr_ce.address) AS exposure_address,
+        COALESCE(pr.city,    pr_ce.city)    AS exposure_city,
+        COALESCE(pr.state,   pr_ce.state)   AS exposure_state,
+        COALESCE(pr.zip,     pr_ce.zip)     AS exposure_zip,
         p.attachment_point,
         p.participation_of
     FROM policies p
     JOIN clients c ON p.client_id = c.id
+    LEFT JOIN projects pr ON pr.id = p.project_id
+    LEFT JOIN policy_exposure_links pel ON pel.policy_uid = p.policy_uid AND pel.is_primary = 1
+    LEFT JOIN client_exposures ce ON ce.id = pel.exposure_id
+    LEFT JOIN projects pr_ce ON pr_ce.id = ce.project_id
     WHERE p.archived = 0
     ORDER BY c.name, p.policy_type, p.layer_position
     """
@@ -5434,7 +5551,9 @@ def get_vacation_checklist(conn: sqlite3.Connection, return_date: str) -> dict:
 
 _POL_ROLLUP_COLS = """
     p.id, p.policy_uid, p.policy_type, p.carrier, p.premium,
-    p.exposure_amount, p.exposure_basis,
+    -- Primary exposure from the normalized client_exposures table.
+    ce.amount AS exposure_amount,
+    ce.exposure_type AS exposure_basis,
     p.expiration_date, p.renewal_status, p.is_opportunity,
     (SELECT MIN(follow_up_date) FROM activity_log
        WHERE policy_id = p.id AND follow_up_done = 0 AND follow_up_date IS NOT NULL
@@ -5447,6 +5566,8 @@ _POL_ROLLUP_COLS = """
 _POL_ROLLUP_JOINS = """
     LEFT JOIN projects pr ON pr.id = p.project_id
     LEFT JOIN programs pg ON pg.id = p.program_id
+    LEFT JOIN policy_exposure_links pel_roll ON pel_roll.policy_uid = p.policy_uid AND pel_roll.is_primary = 1
+    LEFT JOIN client_exposures ce ON ce.id = pel_roll.exposure_id
 """
 
 

--- a/src/policydb/reconciler.py
+++ b/src/policydb/reconciler.py
@@ -451,7 +451,7 @@ def _score_pair(
 
     # ── Text field diff tracking (no scoring weight, just diff detection) ────
     for tf in ("first_named_insured", "placement_colleague",
-               "underwriter_name", "exposure_address", "project_name"):
+               "underwriter_name", "project_name"):
         ext_val = str(ext.get(tf) or "").strip()
         db_val = str(db.get(tf) or "").strip()
         if ext_val and not db_val:

--- a/src/policydb/views.py
+++ b/src/policydb/views.py
@@ -65,13 +65,18 @@ SELECT
     p.access_point,
     p.project_name,
     p.project_id,
-    p.exposure_basis,
-    p.exposure_amount,
-    p.exposure_unit,
-    p.exposure_address,
-    p.exposure_city,
-    p.exposure_state,
-    p.exposure_zip,
+    -- Primary exposure, pulled from the normalized client_exposures table
+    -- (deprecated policies.exposure_* columns were dropped in migration 151).
+    ce.exposure_type AS primary_exposure_type,
+    ce.amount       AS primary_exposure_amount,
+    ce.denominator  AS primary_exposure_denominator,
+    ce.unit         AS primary_exposure_unit,
+    -- Primary-exposure location: resolved via policies.project_id (the
+    -- canonical link) or via the primary exposure's own project.
+    COALESCE(pr.address, pr_ce.address) AS exposure_address,
+    COALESCE(pr.city,    pr_ce.city)    AS exposure_city,
+    COALESCE(pr.state,   pr_ce.state)   AS exposure_state,
+    COALESCE(pr.zip,     pr_ce.zip)     AS exposure_zip,
     -- Opportunities have no expiration date; NULL days/urgency keeps them out of renewal logic
     CASE WHEN p.is_opportunity = 1 THEN NULL
          ELSE CAST(julianday(p.expiration_date) - julianday('now') AS INTEGER)
@@ -101,6 +106,10 @@ SELECT
 FROM policies p
 JOIN clients c ON p.client_id = c.id
 LEFT JOIN programs pg ON pg.id = p.program_id
+LEFT JOIN projects pr ON pr.id = p.project_id
+LEFT JOIN policy_exposure_links pel ON pel.policy_uid = p.policy_uid AND pel.is_primary = 1
+LEFT JOIN client_exposures ce ON ce.id = pel.exposure_id
+LEFT JOIN projects pr_ce ON pr_ce.id = ce.project_id
 LEFT JOIN (
     SELECT policy_id, MIN(follow_up_date) AS follow_up_date
     FROM activity_log
@@ -185,11 +194,11 @@ SELECT
     p.coverage_form AS "Form",
     p.layer_position AS "Layer",
     p.project_name AS "Project",
-    COALESCE(CASE WHEN ce.exposure_type IS NOT NULL AND ce.denominator IS NOT NULL
-                  THEN ce.exposure_type || ' /' || ce.denominator
-                  ELSE ce.exposure_type END, p.exposure_basis) AS "Exposure Basis",
-    COALESCE(ce.amount, p.exposure_amount) AS "Exposure Amount",
-    COALESCE(CASE WHEN ce.denominator IS NOT NULL THEN 'per ' || ce.denominator END, p.exposure_unit) AS "Exposure Unit",
+    CASE WHEN ce.exposure_type IS NOT NULL AND ce.denominator IS NOT NULL
+         THEN ce.exposure_type || ' /' || ce.denominator
+         ELSE ce.exposure_type END AS "Exposure Basis",
+    ce.amount AS "Exposure Amount",
+    CASE WHEN ce.denominator IS NOT NULL THEN 'per ' || ce.denominator END AS "Exposure Unit",
     pel.rate AS "Rate",
     p.description AS "Comments"
 FROM policies p

--- a/src/policydb/web/routes/clients.py
+++ b/src/policydb/web/routes/clients.py
@@ -1265,20 +1265,25 @@ def client_tab_policies(request: Request, client_id: int, conn=Depends(get_db)):
     programs = []
     _program_linked_ids = set()
 
-    # Project notes & addresses
-    notes_rows = conn.execute("SELECT id, LOWER(TRIM(name)) AS key, name, notes FROM projects WHERE client_id = ?", (client_id,)).fetchall()
+    # Project notes & addresses — addresses now live on the `projects` table
+    # (the deprecated policies.exposure_* columns were dropped).
+    notes_rows = conn.execute(
+        """SELECT id, LOWER(TRIM(name)) AS key, name, notes,
+                  address, city, state, zip
+           FROM projects WHERE client_id = ?""",
+        (client_id,),
+    ).fetchall()
     project_notes = {r["key"]: r["notes"] for r in notes_rows}
     project_ids = {r["key"]: r["id"] for r in notes_rows}
-    project_addresses: dict = {}
-    for p in sorted(policies, key=lambda x: x.get("id", 0), reverse=True):
-        key = _proj_key(p.get("project_name"))
-        if key and key not in project_addresses:
-            project_addresses[key] = {
-                "exposure_address": p.get("exposure_address") or "",
-                "exposure_city": p.get("exposure_city") or "",
-                "exposure_state": p.get("exposure_state") or "",
-                "exposure_zip": p.get("exposure_zip") or "",
-            }
+    project_addresses: dict = {
+        r["key"]: {
+            "exposure_address": r["address"] or "",
+            "exposure_city":    r["city"]    or "",
+            "exposure_state":   r["state"]   or "",
+            "exposure_zip":     r["zip"]     or "",
+        }
+        for r in notes_rows
+    }
 
     from policydb.queries import get_schematic_completeness
     schematic_completeness = get_schematic_completeness(conn, client_id)
@@ -2102,25 +2107,26 @@ def client_detail(request: Request, client_id: int, add_contact: str = "", conn=
     programs = []
     _program_linked_ids = set()
 
-    # Load project notes keyed by normalized project name (from projects table)
+    # Load project notes + addresses keyed by normalized project name.
+    # Addresses live on the projects table (deprecated policies.exposure_*
+    # columns were dropped).
     notes_rows = conn.execute(
-        "SELECT id, LOWER(TRIM(name)) AS key, name, notes FROM projects WHERE client_id = ?",
+        """SELECT id, LOWER(TRIM(name)) AS key, name, notes,
+                  address, city, state, zip
+           FROM projects WHERE client_id = ?""",
         (client_id,),
     ).fetchall()
     project_notes = {r["key"]: r["notes"] for r in notes_rows}
     project_ids = {r["key"]: r["id"] for r in notes_rows}
-
-    # Build project address dict from most recent policy per project
-    project_addresses: dict = {}
-    for p in sorted(policies, key=lambda x: x.get("id", 0), reverse=True):
-        key = _proj_key(p.get("project_name"))
-        if key not in project_addresses:
-            project_addresses[key] = {
-                "exposure_address": p.get("exposure_address") or "",
-                "exposure_city":    p.get("exposure_city") or "",
-                "exposure_state":   p.get("exposure_state") or "",
-                "exposure_zip":     p.get("exposure_zip") or "",
-            }
+    project_addresses: dict = {
+        r["key"]: {
+            "exposure_address": r["address"] or "",
+            "exposure_city":    r["city"]    or "",
+            "exposure_state":   r["state"]   or "",
+            "exposure_zip":     r["zip"]     or "",
+        }
+        for r in notes_rows
+    }
 
     scratch_row = conn.execute(
         "SELECT content, updated_at FROM client_scratchpad WHERE client_id=?",
@@ -4380,7 +4386,9 @@ def export_followups_csv(client_id: int, conn=Depends(get_db)):
 def _project_note_ctx(conn, client_id: int, project_name: str) -> dict:
     """Shared context builder for project note partials."""
     row = conn.execute(
-        "SELECT id, notes FROM projects WHERE client_id = ? AND LOWER(TRIM(name)) = LOWER(TRIM(?))",
+        """SELECT id, notes, address, city, state, zip
+           FROM projects
+           WHERE client_id = ? AND LOWER(TRIM(name)) = LOWER(TRIM(?))""",
         (client_id, project_name),
     ).fetchone()
     policy_count = conn.execute(
@@ -4388,25 +4396,18 @@ def _project_note_ctx(conn, client_id: int, project_name: str) -> dict:
         (client_id, project_name),
     ).fetchone()[0]
     client = conn.execute("SELECT * FROM clients WHERE id = ?", (client_id,)).fetchone()
-    # Pull address from the most recent policy in this project
-    addr_row = conn.execute(
-        """SELECT exposure_address, exposure_city, exposure_state, exposure_zip
-           FROM policies
-           WHERE client_id = ? AND LOWER(TRIM(COALESCE(project_name,''))) = LOWER(TRIM(?))
-             AND archived = 0
-           ORDER BY id DESC LIMIT 1""",
-        (client_id, project_name),
-    ).fetchone()
+    # Address now lives on the projects row directly (the deprecated
+    # policies.exposure_* columns were dropped).
     return {
         "project_name": project_name,
         "project_id": row["id"] if row else None,
         "note": row["notes"] if row else "",
         "policy_count": policy_count,
         "client": dict(client) if client else {},
-        "exposure_address": addr_row["exposure_address"] if addr_row else "",
-        "exposure_city": addr_row["exposure_city"] if addr_row else "",
-        "exposure_state": addr_row["exposure_state"] if addr_row else "",
-        "exposure_zip": addr_row["exposure_zip"] if addr_row else "",
+        "exposure_address": row["address"] if row else "",
+        "exposure_city": row["city"] if row else "",
+        "exposure_state": row["state"] if row else "",
+        "exposure_zip": row["zip"] if row else "",
     }
 
 
@@ -4438,31 +4439,30 @@ def project_note_save(
     exposure_zip: str = Form(""),
     conn=Depends(get_db),
 ):
-    """HTMX: upsert project note and bulk-update location address on all policies in the project."""
-    exposure_address = exposure_address.strip() if exposure_address else ""
-    exposure_city = format_city(exposure_city) if exposure_city else ""
-    exposure_state = format_state(exposure_state) if exposure_state else ""
-    exposure_zip = format_zip(exposure_zip) if exposure_zip else ""
+    """HTMX: upsert the project note + address on the `projects` row.
+
+    Address fields are stored on the projects row directly — the
+    deprecated ``policies.exposure_*`` columns were dropped.  Any policy
+    that points at this project via ``policies.project_id`` automatically
+    picks up the new address via the joined views.
+    """
+    addr = exposure_address.strip() if exposure_address else ""
+    city = format_city(exposure_city) if exposure_city else ""
+    state = format_state(exposure_state) if exposure_state else ""
+    zip_code = format_zip(exposure_zip) if exposure_zip else ""
     conn.execute(
-        "INSERT INTO projects (client_id, name, notes) VALUES (?, ?, ?) "
-        "ON CONFLICT(client_id, name) DO UPDATE SET notes=excluded.notes",
-        (client_id, project_name, notes.strip()),
-    )
-    conn.execute(
-        """UPDATE policies SET
-               exposure_address = ?,
-               exposure_city    = ?,
-               exposure_state   = ?,
-               exposure_zip     = ?
-           WHERE client_id = ?
-             AND LOWER(TRIM(COALESCE(project_name,''))) = LOWER(TRIM(?))
-             AND archived = 0""",
+        """INSERT INTO projects
+             (client_id, name, notes, address, city, state, zip)
+           VALUES (?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(client_id, name) DO UPDATE SET
+             notes   = excluded.notes,
+             address = excluded.address,
+             city    = excluded.city,
+             state   = excluded.state,
+             zip     = excluded.zip""",
         (
-            exposure_address or None,
-            exposure_city or None,
-            exposure_state or None,
-            exposure_zip or None,
-            client_id, project_name,
+            client_id, project_name, notes.strip(),
+            addr or None, city or None, state or None, zip_code or None,
         ),
     )
     conn.commit()
@@ -4543,7 +4543,6 @@ def project_detail(
         """SELECT p.id, p.policy_uid, p.policy_type, p.carrier, p.renewal_status,
                   p.premium, p.expiration_date, p.effective_date, p.policy_number,
                   p.limit_amount, p.is_opportunity, p.client_id,
-                  p.exposure_address, p.exposure_city, p.exposure_state, p.exposure_zip,
                   CAST(julianday(p.expiration_date) - julianday('now') AS INTEGER) AS days_to_renewal
            FROM policies p
            WHERE p.project_id = ? AND p.archived = 0
@@ -4551,15 +4550,14 @@ def project_detail(
         (project_id,),
     ).fetchall()
     project = dict(project)
-    # Pull address from first policy that has one (fallback when project has no own address)
-    if not project.get("address"):
-        for pol in policies:
-            if pol["exposure_address"] or pol["exposure_city"]:
-                project["exposure_address"] = pol["exposure_address"] or ""
-                project["exposure_city"] = pol["exposure_city"] or ""
-                project["exposure_state"] = pol["exposure_state"] or ""
-                project["exposure_zip"] = pol["exposure_zip"] or ""
-                break
+    # Address lives on the projects row directly (the fallback-to-policy
+    # chain was retired along with the deprecated policies.exposure_*
+    # columns).  Just alias the project fields into the legacy template
+    # keys so existing markup keeps working.
+    project.setdefault("exposure_address", project.get("address") or "")
+    project.setdefault("exposure_city",    project.get("city")    or "")
+    project.setdefault("exposure_state",   project.get("state")   or "")
+    project.setdefault("exposure_zip",     project.get("zip")     or "")
     if project.get("updated_at"):
         try:
             dt = dateparser.parse(project["updated_at"])
@@ -4667,20 +4665,17 @@ def project_print(
     ).fetchone()
     policies = conn.execute(
         """SELECT policy_uid, policy_type, carrier, premium, limit_amount,
-                  effective_date, expiration_date, renewal_status,
-                  exposure_address, exposure_city, exposure_state, exposure_zip
+                  effective_date, expiration_date, renewal_status
            FROM policies WHERE project_id = ? AND archived = 0
            ORDER BY policy_type""",
         (project_id,),
     ).fetchall()
     project = dict(project)
-    for pol in policies:
-        if pol["exposure_address"] or pol["exposure_city"]:
-            project["exposure_address"] = pol["exposure_address"] or ""
-            project["exposure_city"] = pol["exposure_city"] or ""
-            project["exposure_state"] = pol["exposure_state"] or ""
-            project["exposure_zip"] = pol["exposure_zip"] or ""
-            break
+    # Legacy template keys — aliased from the projects row.
+    project.setdefault("exposure_address", project.get("address") or "")
+    project.setdefault("exposure_city",    project.get("city")    or "")
+    project.setdefault("exposure_state",   project.get("state")   or "")
+    project.setdefault("exposure_zip",     project.get("zip")     or "")
     return templates.TemplateResponse(
         "clients/project_print.html",
         {
@@ -6125,13 +6120,8 @@ async def project_pipeline_field(
         conn.execute(f"UPDATE projects SET {field} = ? WHERE id = ?",
                      (clean_value, project_id))
         formatted = value.strip()
-        # Sync address fields to linked policies
-        _address_to_exposure = {"address": "exposure_address", "city": "exposure_city",
-                                "state": "exposure_state", "zip": "exposure_zip"}
-        if field in _address_to_exposure:
-            exposure_field = _address_to_exposure[field]
-            conn.execute(f"UPDATE policies SET {exposure_field} = ? WHERE project_id = ? AND archived = 0",
-                         (clean_value, project_id))
+        # Address fields live on projects only now — the deprecated sync to
+        # policies.exposure_* has been removed since those columns were dropped.
 
     conn.commit()
     return JSONResponse({"ok": True, "formatted": formatted})
@@ -6740,28 +6730,15 @@ def client_locations(request: Request, client_id: int, conn=Depends(get_db)):
             "program_count": program_count,
         })
 
-    # Smart suggestions: group unassigned by shared exposure_address
-    suggestions = []
-    from collections import defaultdict
-    addr_groups: dict[str, list] = defaultdict(list)
-    for p in unassigned:
-        addr = (p.get("exposure_address") or "").strip()
-        if addr:
-            addr_groups[addr].append(p)
-    for addr, pols in addr_groups.items():
-        if len(pols) >= 2:
-            matching_loc = next(
-                (loc for loc in locations if addr.lower() in loc["address"].lower()),
-                None,
-            )
-            suggestions.append({
-                "address": addr, "policies": pols, "count": len(pols),
-                "matching_location": matching_loc,
-            })
-
+    # The "smart suggestions" flow previously grouped unassigned policies
+    # by shared policies.exposure_address.  That column was dropped along
+    # with the rest of the deprecated exposure_* set, so the signal no
+    # longer exists.  The board now just shows the unassigned list and
+    # the user picks a location manually via the existing drag-to-assign
+    # UI.
     return templates.TemplateResponse("clients/_location_board.html", {
         "request": request, "client_id": client_id, "client_name": client["name"],
-        "unassigned": unassigned, "locations": locations, "suggestions": suggestions,
+        "unassigned": unassigned, "locations": locations, "suggestions": [],
     })
 
 
@@ -6773,25 +6750,18 @@ def location_assign(
     project_id: int = Form(...),
     conn=Depends(get_db),
 ):
-    """Assign a policy to a location/project."""
+    """Assign a policy to a location/project.
+
+    Only ``policies.project_id`` / ``project_name`` need updating — the
+    address lives on the projects row itself and is joined back in via
+    the views (``v_policy_status``/``v_schedule``) or Python helpers.
+    """
     project = conn.execute("SELECT name FROM projects WHERE id=?", (project_id,)).fetchone()
     if project:
         conn.execute(
             "UPDATE policies SET project_id=?, project_name=? WHERE policy_uid=? AND client_id=?",
             (project_id, project["name"], policy_uid, client_id),
         )
-        loc = conn.execute(
-            "SELECT address, city, state, zip FROM projects WHERE id=?",
-            (project_id,),
-        ).fetchone()
-        if loc:
-            conn.execute(
-                """UPDATE policies SET exposure_address=?, exposure_city=?,
-                   exposure_state=?, exposure_zip=?
-                   WHERE policy_uid=? AND client_id=?""",
-                (loc["address"] or "", loc["city"] or "", loc["state"] or "", loc["zip"] or "",
-                 policy_uid, client_id),
-            )
         conn.commit()
     return HTMLResponse("", headers={"HX-Trigger": "locationChanged"})
 
@@ -6816,32 +6786,28 @@ def location_unassign(
 def location_bulk_assign(
     request: Request,
     client_id: int,
-    address: str = Form(...),
     project_id: int = Form(...),
+    policy_uids: str = Form(""),
     conn=Depends(get_db),
 ):
-    """Bulk-assign all unassigned policies sharing an exposure_address to a location."""
+    """Bulk-assign a comma-separated list of policy_uids to a location.
+
+    Previously this flow grouped by shared ``policies.exposure_address``.
+    That column was dropped, so the signal is gone — callers now pass
+    the explicit list of policy_uids to assign.  If ``policy_uids`` is
+    empty this is a no-op.
+    """
+    uids = [u.strip() for u in (policy_uids or "").split(",") if u.strip()]
+    if not uids:
+        return HTMLResponse("", headers={"HX-Trigger": "locationChanged"})
     project = conn.execute("SELECT name FROM projects WHERE id=?", (project_id,)).fetchone()
     if project:
+        ph = ",".join("?" * len(uids))
         conn.execute(
-            """UPDATE policies SET project_id=?, project_name=?
-               WHERE client_id=? AND archived=0
-               AND TRIM(exposure_address)=TRIM(?)
-               AND (project_id IS NULL OR project_id=0)""",
-            (project_id, project["name"], client_id, address),
+            f"""UPDATE policies SET project_id=?, project_name=?
+                WHERE client_id=? AND archived=0 AND policy_uid IN ({ph})""",  # noqa: S608
+            [project_id, project["name"], client_id, *uids],
         )
-        loc = conn.execute(
-            "SELECT address, city, state, zip FROM projects WHERE id=?",
-            (project_id,),
-        ).fetchone()
-        if loc:
-            conn.execute(
-                """UPDATE policies SET exposure_address=?, exposure_city=?,
-                   exposure_state=?, exposure_zip=?
-                   WHERE project_id=? AND client_id=? AND archived=0""",
-                (loc["address"] or "", loc["city"] or "", loc["state"] or "", loc["zip"] or "",
-                 project_id, client_id),
-            )
         conn.commit()
     return HTMLResponse("", headers={"HX-Trigger": "locationChanged"})
 
@@ -7097,7 +7063,7 @@ def client_ai_bulk_import_apply(
                               "effective_date", "expiration_date", "description", "layer_position",
                               "tower_group", "attachment_point", "participation_of",
                               "first_named_insured",
-                              "underwriter_name", "placement_colleague", "exposure_address",
+                              "underwriter_name", "placement_colleague",
                               "coverage_form", "notes"]:
                     val = d.get(field)
                     if val is not None and str(val).strip():
@@ -7138,9 +7104,9 @@ def client_ai_bulk_import_apply(
                         effective_date, expiration_date, premium, limit_amount, deductible,
                         description, layer_position, tower_group, attachment_point,
                         participation_of, first_named_insured, underwriter_name,
-                        placement_colleague, exposure_address, coverage_form, notes,
+                        placement_colleague, coverage_form, notes,
                         project_id, project_name, renewal_status
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'Not Started')""",
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'Not Started')""",
                     (
                         uid, client_id,
                         d.get("policy_type", ""), d.get("carrier", ""), d.get("policy_number", ""),
@@ -7151,7 +7117,7 @@ def client_ai_bulk_import_apply(
                         d.get("tower_group", ""), d.get("attachment_point"),
                         d.get("participation_of"),
                         d.get("first_named_insured", ""), d.get("underwriter_name", ""),
-                        d.get("placement_colleague", ""), d.get("exposure_address", ""),
+                        d.get("placement_colleague", ""),
                         d.get("coverage_form", ""), d.get("notes", ""),
                         entry["location_id"], entry.get("location_name") or d.get("project_name", ""),
                     ),

--- a/src/policydb/web/routes/data_health.py
+++ b/src/policydb/web/routes/data_health.py
@@ -122,7 +122,7 @@ def blitz_save(
         "first_named_insured", "limit_amount", "deductible",
         "attachment_point", "description", "access_point",
         "opportunity_status", "target_effective_date",
-        "prior_premium", "exposure_amount", "coverage_form",
+        "prior_premium", "coverage_form",
         "layer_position", "notes", "policy_number_unknown",
     }
     _CLIENT_COLUMNS = {
@@ -138,7 +138,7 @@ def blitz_save(
     save_value = value.strip()
     # Parse currency fields through the standard parser
     currency_fields = {"premium", "limit_amount", "deductible", "attachment_point",
-                       "prior_premium", "exposure_amount"}
+                       "prior_premium"}
     if field in currency_fields:
         from policydb.utils import parse_currency_with_magnitude
         parsed = parse_currency_with_magnitude(save_value)

--- a/src/policydb/web/routes/policies.py
+++ b/src/policydb/web/routes/policies.py
@@ -52,10 +52,12 @@ US_STATES = [
     ("WI", "Wisconsin"), ("WY", "Wyoming"), ("DC", "District of Columbia"),
 ]
 
-# Fields that can serve autocomplete suggestions from prior DB entries
+# Fields that can serve autocomplete suggestions from prior DB entries.
+# (The old exposure_* entries were retired when those columns were dropped;
+# exposure type/unit pickers now read from `client_exposures` directly.)
 _AUTOCOMPLETE_FIELDS = {
-    "carrier", "exposure_basis", "exposure_unit", "project_name",
-    "exposure_city", "exposure_state", "access_point", "first_named_insured",
+    "carrier", "project_name",
+    "access_point", "first_named_insured",
     "tower_group", "policy_type", "coverage_form",
 }
 
@@ -66,8 +68,6 @@ def _renewal_statuses() -> list[str]:
 
 _CONFIG_SEEDS: dict[str, str] = {
     "carrier": "carriers",
-    "exposure_basis": "exposure_basis_options",
-    "exposure_unit": "exposure_unit_options",
     "policy_type": "policy_types",
     "coverage_form": "coverage_forms",
 }
@@ -116,16 +116,20 @@ def get_status_color(status: str, all_statuses: list | None = None) -> tuple[str
 
 @router.get("/project-defaults", response_class=JSONResponse)
 def policy_project_defaults(project_name: str, client_id: int = 0, conn=Depends(get_db)):
-    """Return most recent exposure/location fields for a known project name."""
+    """Return address fields for a known project name (for UI pre-fill).
+
+    The deprecated ``policies.exposure_*`` columns were dropped; the
+    authoritative address lives on ``projects`` now.  This endpoint returns
+    the matching project's address so the new-policy form can mirror the
+    old pre-fill behavior.
+    """
     if not project_name.strip():
         return JSONResponse({})
     row = conn.execute(
-        """SELECT exposure_address, exposure_city, exposure_state, exposure_zip,
-                  exposure_basis, exposure_unit
-           FROM policies
-           WHERE LOWER(TRIM(project_name)) = LOWER(TRIM(?))
+        """SELECT address, city, state, zip
+           FROM projects
+           WHERE LOWER(TRIM(name)) = LOWER(TRIM(?))
              AND (? = 0 OR client_id = ?)
-             AND archived = 0
            ORDER BY id DESC LIMIT 1""",
         (project_name, client_id, client_id),
     ).fetchone()
@@ -135,7 +139,7 @@ def policy_project_defaults(project_name: str, client_id: int = 0, conn=Depends(
 
 
 # Fields where autocomplete should be scoped to the same client
-_CLIENT_SCOPED_AC_FIELDS = {"project_name", "exposure_city", "tower_group"}
+_CLIENT_SCOPED_AC_FIELDS = {"project_name", "tower_group"}
 
 
 def _sync_project_id(conn, policy_id: int, client_id: int, project_name: str | None) -> None:
@@ -326,20 +330,22 @@ def policy_spreadsheet(request: Request, conn=Depends(get_db)):
          "editor": "input", "headerFilter": "input"},
         {"field": "underwriter_name", "title": "Underwriter", "width": 140,
          "editor": "input", "headerFilter": "input"},
-        {"field": "exposure_basis", "title": "Exposure Basis", "width": 120,
-         "editor": "input"},
+        # Primary exposure (read-only; linked rows live on client_exposures
+        # and are edited through the client's Exposures grid).
+        {"field": "exposure_basis", "title": "Primary Exposure", "width": 130,
+         "editor": False},
         {"field": "exposure_amount", "title": "Exposure Amount", "width": 130,
-         "editor": "number", "editorParams": {"selectContents": True},
-         "_format": "currency"},
+         "editor": False, "_format": "currency"},
+        # Address fields are read-only mirrors of the linked location
+        # (policies.project_id → projects.*).  Edit on the location.
         {"field": "exposure_address", "title": "Address", "width": 160,
-         "editor": "input"},
+         "editor": False},
         {"field": "exposure_city", "title": "City", "width": 120,
-         "editor": "input"},
+         "editor": False},
         {"field": "exposure_state", "title": "State", "width": 80,
-         "editor": "list", "editorParams": {"values": states, "autocomplete": True, "freetext": True, "listOnEmpty": True},
-         "headerFilter": "list", "headerFilterParams": {"values": {s: s for s in states}, "clearable": True}},
+         "editor": False},
         {"field": "exposure_zip", "title": "ZIP", "width": 80,
-         "editor": "input"},
+         "editor": False},
         {"field": "attachment_point", "title": "Attachment Pt", "width": 120,
          "editor": "number", "editorParams": {"selectContents": True},
          "_format": "currency"},
@@ -420,7 +426,9 @@ async def policy_quick_add(request: Request, conn=Depends(get_db)):
     )
     conn.commit()
 
-    # Return the new row in the same shape as get_all_policies_for_grid
+    # Return the new row in the same shape as get_all_policies_for_grid —
+    # exposure fields are NULL for a freshly-added row since no exposure
+    # has been linked yet.
     row = conn.execute(
         """SELECT p.policy_uid, p.client_id, c.name AS client_name,
                   p.policy_type, p.carrier, p.access_point, p.policy_number,
@@ -430,8 +438,9 @@ async def policy_quick_add(request: Request, conn=Depends(get_db)):
                   p.coverage_form, p.layer_position, p.project_name,
                   p.first_named_insured, p.description, p.notes,
                   p.placement_colleague, p.underwriter_name,
-                  p.exposure_basis, p.exposure_amount, p.exposure_address,
-                  p.exposure_city, p.exposure_state, p.exposure_zip,
+                  NULL AS exposure_basis, NULL AS exposure_amount,
+                  NULL AS exposure_address, NULL AS exposure_city,
+                  NULL AS exposure_state, NULL AS exposure_zip,
                   p.attachment_point, p.participation_of
            FROM policies p JOIN clients c ON p.client_id = c.id
            WHERE p.policy_uid = ?""",
@@ -491,13 +500,6 @@ def policy_new_post(
     underwriter_name: str = Form(""),
     underwriter_contact: str = Form(""),
     project_name: str = Form(""),
-    exposure_basis: str = Form(""),
-    exposure_amount: str = Form(""),
-    exposure_unit: str = Form(""),
-    exposure_address: str = Form(""),
-    exposure_city: str = Form(""),
-    exposure_state: str = Form(""),
-    exposure_zip: str = Form(""),
     commission_rate: str = Form(""),
     prior_premium: str = Form(""),
     notes: str = Form(""),
@@ -532,10 +534,6 @@ def policy_new_post(
     premium = str(_parse_money(premium) or 0) if premium else premium
     limit_amount = str(_parse_money(limit_amount) or '') if limit_amount else limit_amount
     deductible = str(_parse_money(deductible) or '') if deductible else deductible
-    exposure_address = exposure_address.strip() if exposure_address else ""
-    exposure_city = format_city(exposure_city) if exposure_city else ""
-    exposure_state = format_state(exposure_state) if exposure_state else ""
-    exposure_zip = format_zip(exposure_zip) if exposure_zip else ""
     conn.execute(
         """INSERT INTO policies
            (policy_uid, client_id, policy_type, carrier, policy_number,
@@ -544,11 +542,9 @@ def policy_new_post(
             is_opportunity, opportunity_status, target_effective_date,
             renewal_status, underwriter_name, underwriter_contact,
             account_exec, project_name,
-            exposure_basis, exposure_amount, exposure_unit,
-            exposure_address, exposure_city, exposure_state, exposure_zip,
             commission_rate, prior_premium, notes,
             attachment_point, participation_of, first_named_insured, access_point)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (uid, client_id, policy_type, carrier or None, policy_number or None,
          effective_date or None, expiration_date or None, _float(premium) or 0,
          _float(limit_amount), _float(deductible),
@@ -560,9 +556,6 @@ def policy_new_post(
          renewal_status,
          underwriter_name or None, underwriter_contact or None,
          account_exec, project_name or None,
-         exposure_basis or None, _float(exposure_amount), exposure_unit or None,
-         exposure_address or None, exposure_city or None,
-         exposure_state or None, exposure_zip or None,
          _float(commission_rate), _float(prior_premium), notes or None,
          _float(attachment_point), _float(participation_of),
          first_named_insured or None, access_point or None),
@@ -1429,7 +1422,7 @@ def policy_provenance(request: Request, policy_uid: str, field: str = "", conn=D
         "policy_type": "Coverage Type", "carrier": "Carrier", "policy_number": "Policy #",
         "effective_date": "Effective", "expiration_date": "Expiration",
         "premium": "Premium", "limit_amount": "Limit", "deductible": "Deductible",
-        "project_name": "Location", "exposure_address": "Address",
+        "project_name": "Location",
         "first_named_insured": "First Named Insured",
         "placement_colleague": "Placement", "underwriter_name": "Underwriter",
         "description": "Description",
@@ -3037,7 +3030,18 @@ def policy_tab_pulse(
     rows = [dict(p)]
     _attach_milestone_progress(conn, rows)
     _attach_readiness_score(conn, rows)
+    # Stamp primary exposure + location fields (legacy policies.exposure_*
+    # columns were dropped — location address now comes from the linked
+    # projects row via the primary exposure link).
+    from policydb.queries import attach_primary_exposure
+    attach_primary_exposure(conn, rows)
     readiness = rows[0]
+    # Map the primary exposure's location fields back onto the `p` dict
+    # so existing templates that read `policy.exposure_city` etc. still
+    # work without rewiring every site.
+    p = dict(p)
+    p["exposure_city"]  = readiness.get("exposure_location_city")
+    p["exposure_state"] = readiness.get("exposure_location_state")
 
     # Computed metrics
     days_to_renewal = None
@@ -3948,12 +3952,6 @@ async def policy_cell_save(request: Request, policy_uid: str, conn=Depends(get_d
         val = value.strip()
         conn.execute("UPDATE policies SET layer_position = ? WHERE policy_uid = ?", (val or None, uid))
         formatted = val
-    elif field == "exposure_state":
-        formatted = format_state(value)
-        conn.execute("UPDATE policies SET exposure_state = ? WHERE policy_uid = ?", (formatted or None, uid))
-    elif field == "exposure_city":
-        formatted = format_city(value)
-        conn.execute("UPDATE policies SET exposure_city = ? WHERE policy_uid = ?", (formatted or None, uid))
     elif field == "review_cycle":
         val = value.strip()
         conn.execute("UPDATE policies SET review_cycle = ? WHERE policy_uid = ?", (val or None, uid))
@@ -3963,9 +3961,6 @@ async def policy_cell_save(request: Request, policy_uid: str, conn=Depends(get_d
     elif field == "policy_number":
         formatted = normalize_policy_number(value)
         conn.execute("UPDATE policies SET policy_number = ? WHERE policy_uid = ?", (formatted, uid))
-    elif field == "exposure_zip":
-        formatted = format_zip(value)
-        conn.execute("UPDATE policies SET exposure_zip = ? WHERE policy_uid = ?", (formatted or None, uid))
     elif field in text_fields:
         val = value.strip()
         conn.execute(f"UPDATE policies SET {field} = ? WHERE policy_uid = ?", (val or None, uid))  # noqa: S608

--- a/src/policydb/web/routes/reconcile.py
+++ b/src/policydb/web/routes/reconcile.py
@@ -279,7 +279,10 @@ def _load_db_policies(conn, client_id: int, scope: str) -> list[dict]:
                    p.policy_number, p.effective_date, p.expiration_date,
                    p.premium, p.limit_amount, p.deductible, p.client_id,
                    p.first_named_insured, p.placement_colleague, p.underwriter_name,
-                   p.exposure_address, p.project_name, p.project_id,
+                   -- Address comes from the linked location (legacy policy
+                   -- column dropped).
+                   pr.address AS exposure_address,
+                   p.project_name, p.project_id,
                    p.is_program, p.program_id,
                    pr.name AS location_name,
                    prog.policy_uid AS program_uid
@@ -1222,7 +1225,7 @@ async def reconcile_fill(
 
     _CURRENCY = {"premium", "limit_amount", "deductible"}
     _TEXT = {"carrier", "policy_number", "first_named_insured", "placement_colleague",
-             "underwriter_name", "exposure_address", "project_name"}
+             "underwriter_name", "project_name"}
     _DATE = {"effective_date", "expiration_date"}
     _ALLOWED = _CURRENCY | _TEXT | _DATE
 
@@ -1674,7 +1677,7 @@ _ALLOWED_FIELDS = {
     "effective_date", "expiration_date",
     "premium", "limit_amount", "deductible",
     "first_named_insured", "placement_colleague",
-    "underwriter_name", "exposure_address",
+    "underwriter_name",
 }
 
 _CURRENCY_FIELDS = {"premium", "limit_amount", "deductible"}
@@ -1691,7 +1694,6 @@ _FIELD_DISPLAY = {
     "first_named_insured": "First Named Insured",
     "placement_colleague": "Placement Colleague",
     "underwriter_name": "Underwriter",
-    "exposure_address": "Address",
     "project_name": "Location / Project",
 }
 

--- a/src/policydb/web/templates/briefing.html
+++ b/src/policydb/web/templates/briefing.html
@@ -61,7 +61,6 @@
             {% if item.policy_type %}<span class="text-xs text-gray-400">{{ item.policy_type }}</span>{% endif %}
             {% if item.carrier %}<span class="text-xs text-gray-400">· {{ item.carrier }}</span>{% endif %}
             {% if item.project_name %}<span class="text-xs text-gray-400 italic">{{ item.project_name }}</span>{% endif %}
-            {% if item.exposure_city or item.exposure_state %}<span class="text-xs text-gray-300">({{ [item.exposure_city, item.exposure_state] | select | join(', ') }})</span>{% endif %}
           </div>
 
           {# Line 2: Source reason + context details #}
@@ -343,9 +342,6 @@ document.addEventListener('click', function(e) {
           <td class="py-2 pr-3 text-xs">
             <span class="text-gray-600">{{ p.policy_type }}</span>
             {% if p.project_name %}<span class="text-gray-400 ml-1 italic">{{ p.project_name }}</span>{% endif %}
-            {% if p.exposure_city or p.exposure_state %}
-            <span class="text-gray-300 ml-1">({{ [p.exposure_city, p.exposure_state] | select | join(', ') }})</span>
-            {% endif %}
           </td>
           <td class="py-2 pr-3 text-xs text-gray-500">{{ p.carrier }}</td>
           <td class="py-2 pr-3 text-xs">

--- a/src/policydb/web/templates/reconcile/index.html
+++ b/src/policydb/web/templates/reconcile/index.html
@@ -181,12 +181,6 @@
     { value: "commission_rate",         label: "Commission Rate" },
     { value: "prior_premium",           label: "Prior Premium" },
     { value: "renewal_status",          label: "Renewal Status" },
-    { value: "exposure_address",        label: "Exposure Address" },
-    { value: "exposure_city",           label: "Exposure City" },
-    { value: "exposure_state",          label: "Exposure State" },
-    { value: "exposure_zip",            label: "Exposure ZIP" },
-    { value: "exposure_basis",          label: "Exposure Basis" },
-    { value: "exposure_amount",         label: "Exposure Amount" },
     { value: "is_standalone",           label: "Standalone (1/0)" },
   ];
 

--- a/tests/test_exposure_column_drop.py
+++ b/tests/test_exposure_column_drop.py
@@ -1,0 +1,208 @@
+"""Audit PR regression tests — policies.exposure_* columns are gone and
+the new `attach_primary_exposure()` helper hydrates dicts correctly.
+"""
+import pytest
+
+import policydb.web.app  # noqa: F401 — boot FastAPI app
+
+from policydb.db import get_connection, init_db
+from policydb.exposures import create_exposure_link, find_or_create_exposure
+from policydb.queries import (
+    attach_primary_exposure,
+    find_or_create_project_from_address,
+)
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.sqlite"
+    monkeypatch.setattr("policydb.db.DB_PATH", db_path)
+    monkeypatch.setattr("policydb.db.DB_DIR", tmp_path)
+    monkeypatch.setattr("policydb.db.EXPORTS_DIR", tmp_path / "exports")
+    monkeypatch.setattr("policydb.db.CONFIG_PATH", tmp_path / "config.yaml")
+    init_db(path=db_path)
+    return db_path
+
+
+def _seed_client(conn, name="Acme Corp"):
+    conn.execute(
+        "INSERT INTO clients (name, industry_segment) VALUES (?, 'Construction')",
+        (name,),
+    )
+    return conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+
+def _seed_policy(conn, client_id, uid="POL-9001", project_id=None):
+    conn.execute(
+        """INSERT INTO policies
+             (policy_uid, client_id, policy_type, carrier, premium,
+              effective_date, expiration_date, project_id)
+           VALUES (?, ?, 'GL', 'Travelers', 50000, '2026-01-01', '2027-01-01', ?)""",
+        (uid, client_id, project_id),
+    )
+    return conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+
+# ── Schema tests ───────────────────────────────────────────────────────────
+
+
+def test_all_deprecated_columns_dropped(tmp_db):
+    conn = get_connection()
+    cols = {r["name"] for r in conn.execute("PRAGMA table_info(policies)").fetchall()}
+    dropped = {
+        "exposure_basis", "exposure_amount", "exposure_unit",
+        "exposure_denominator", "exposure_address", "exposure_city",
+        "exposure_state", "exposure_zip",
+    }
+    leaks = dropped & cols
+    assert not leaks, f"Deprecated columns still present: {leaks}"
+
+
+def test_migration_151_registered(tmp_db):
+    conn = get_connection()
+    row = conn.execute(
+        "SELECT description FROM schema_version WHERE version = 151"
+    ).fetchone()
+    assert row is not None
+    assert "exposure" in row["description"].lower()
+
+
+def test_audit_trigger_does_not_reference_dropped_columns(tmp_db):
+    conn = get_connection()
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE name = 'audit_policies_update'"
+    ).fetchone()
+    assert row is not None
+    dropped_refs = [
+        "exposure_basis", "exposure_amount", "exposure_unit",
+        "exposure_address", "exposure_city", "exposure_state", "exposure_zip",
+    ]
+    for ref in dropped_refs:
+        assert ref not in row["sql"], f"audit_policies_update still references {ref}"
+
+
+def test_views_do_not_reference_dropped_columns(tmp_db):
+    """Every view must be able to SELECT from the reshaped `policies`
+    table.  If a view still references a dropped column, CREATE VIEW
+    would fail at startup and `init_db()` would raise — so instead of
+    grepping the SQL text (which picks up harmless code comments), we
+    try to run each view to confirm it resolves against the live schema.
+    """
+    conn = get_connection()
+    view_names = [
+        r["name"] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'view'"
+        ).fetchall()
+    ]
+    for name in view_names:
+        # LIMIT 0 avoids any row work but still forces SQLite to resolve
+        # every column referenced in the SELECT list + joins.
+        conn.execute(f"SELECT * FROM {name} LIMIT 0")  # noqa: S608
+
+
+# ── attach_primary_exposure() ──────────────────────────────────────────────
+
+
+def test_attach_primary_exposure_no_links_sets_none(tmp_db):
+    conn = get_connection()
+    cid = _seed_client(conn)
+    _seed_policy(conn, cid, "POL-A")
+    policies = [{"policy_uid": "POL-A"}]
+    attach_primary_exposure(conn, policies)
+    assert policies[0]["primary_exposure_type"] is None
+    assert policies[0]["primary_exposure_amount"] is None
+    assert policies[0]["exposure_location_address"] is None
+
+
+def test_attach_primary_exposure_hydrates_from_primary_link(tmp_db):
+    conn = get_connection()
+    cid = _seed_client(conn)
+    # Pre-create a project so the exposure can attach to a location
+    project_id = find_or_create_project_from_address(
+        conn, client_id=cid, address="1 Primary St", city="Austin", state="TX",
+    )
+    _seed_policy(conn, cid, "POL-B", project_id=project_id)
+    exp_id = find_or_create_exposure(
+        conn, client_id=cid, project_id=project_id,
+        exposure_type="Payroll", year=2026, amount=5_000_000, denominator=100,
+    )
+    create_exposure_link(conn, "POL-B", exp_id, is_primary=True)
+
+    policies = [{"policy_uid": "POL-B"}]
+    attach_primary_exposure(conn, policies)
+    assert policies[0]["primary_exposure_type"] == "Payroll"
+    assert policies[0]["primary_exposure_amount"] == 5_000_000
+    assert policies[0]["primary_exposure_denominator"] == 100
+    assert policies[0]["exposure_location_address"] == "1 Primary St"
+    assert policies[0]["exposure_location_city"] == "Austin"
+    assert policies[0]["exposure_location_state"] == "TX"
+
+
+def test_attach_primary_exposure_ignores_non_primary_links(tmp_db):
+    """Non-primary links should not populate the primary_exposure_* fields."""
+    conn = get_connection()
+    cid = _seed_client(conn)
+    _seed_policy(conn, cid, "POL-C")
+    payroll_id = find_or_create_exposure(
+        conn, client_id=cid, project_id=None,
+        exposure_type="Payroll", year=2026, amount=1_000_000, denominator=100,
+    )
+    sales_id = find_or_create_exposure(
+        conn, client_id=cid, project_id=None,
+        exposure_type="Gross Sales", year=2026, amount=10_000_000, denominator=1000,
+    )
+    create_exposure_link(conn, "POL-C", sales_id, is_primary=True)
+    create_exposure_link(conn, "POL-C", payroll_id, is_primary=False)
+
+    policies = [{"policy_uid": "POL-C"}]
+    attach_primary_exposure(conn, policies)
+    assert policies[0]["primary_exposure_type"] == "Gross Sales"
+    assert policies[0]["primary_exposure_amount"] == 10_000_000
+
+
+def test_attach_primary_exposure_falls_back_to_exposure_project(tmp_db):
+    """When policies.project_id is NULL but the exposure has a project_id,
+    the address comes from the exposure's own project."""
+    conn = get_connection()
+    cid = _seed_client(conn)
+    _seed_policy(conn, cid, "POL-D", project_id=None)
+    exp_project_id = find_or_create_project_from_address(
+        conn, client_id=cid, address="2 Exposure Ave", city="Dallas",
+    )
+    exp_id = find_or_create_exposure(
+        conn, client_id=cid, project_id=exp_project_id,
+        exposure_type="Revenue", year=2026, amount=2_000_000, denominator=1000,
+    )
+    create_exposure_link(conn, "POL-D", exp_id, is_primary=True)
+
+    policies = [{"policy_uid": "POL-D"}]
+    attach_primary_exposure(conn, policies)
+    assert policies[0]["exposure_location_address"] == "2 Exposure Ave"
+    assert policies[0]["exposure_location_city"] == "Dallas"
+
+
+def test_v_policy_status_exposes_primary_fields_via_view(tmp_db):
+    """The v_policy_status view joins client_exposures + projects and
+    exposes the expected aliases for legacy templates/queries."""
+    conn = get_connection()
+    cid = _seed_client(conn)
+    pid = find_or_create_project_from_address(
+        conn, client_id=cid, address="100 View Way",
+    )
+    _seed_policy(conn, cid, "POL-E", project_id=pid)
+    exp_id = find_or_create_exposure(
+        conn, client_id=cid, project_id=pid,
+        exposure_type="Payroll", year=2026, amount=750_000, denominator=100,
+    )
+    create_exposure_link(conn, "POL-E", exp_id, is_primary=True)
+
+    row = conn.execute(
+        """SELECT primary_exposure_type, primary_exposure_amount,
+                  primary_exposure_denominator, exposure_address
+           FROM v_policy_status WHERE policy_uid = 'POL-E'"""
+    ).fetchone()
+    assert row is not None
+    assert row["primary_exposure_type"] == "Payroll"
+    assert row["primary_exposure_amount"] == 750_000
+    assert row["primary_exposure_denominator"] == 100
+    assert row["exposure_address"] == "100 View Way"


### PR DESCRIPTION
## Summary

Follow-up audit PR to Bug 3 (#248). That PR stopped the **writes** to the deprecated `policies.exposure_*` columns; this PR audits every remaining **read** site, rewires each to the normalized source (`client_exposures` + `policy_exposure_links` + `projects`), and drops the 8 columns via migration 151.

**Columns dropped:** `exposure_basis`, `exposure_amount`, `exposure_unit`, `exposure_denominator`, `exposure_address`, `exposure_city`, `exposure_state`, `exposure_zip`.

## What changed

**Schema + helper:**
- `views.py::v_policy_status` joins `policy_exposure_links` → `client_exposures` → `projects` (twice — via `policies.project_id` and `ce.project_id`) and exposes `primary_exposure_*` + `exposure_address/city/state/zip` aliases so legacy templates and exports keep working.
- `queries.py::attach_primary_exposure()` — new batch helper that stamps each policy dict with primary-exposure + location fields via a single JOIN.
- `queries.py::renew_policy()` — carries exposure links forward via `find_or_create_exposure` + `create_exposure_link` instead of copying deprecated policy columns.

**Migration 151:**
- Final backfill of `projects.address/city/state/zip` from any straggler `policies.exposure_*` data before the DROP
- Drops views that reference the columns (`init_db()` rebuilds them after migrations run)
- Drops the `audit_policies_update` trigger (its WHEN clause referenced `OLD.exposure_address`) and recreates it without the reference
- `ALTER TABLE DROP COLUMN` for all 8 columns
- Idempotent re-run: skips DROP COLUMN lines whose column is already gone

**Rewired read sites (37 files):**
- `policies.py`: autocomplete field list, Tabulator column spec (now read-only), policy-new form (7 Form params + INSERT columns dropped), pulse tab handler (calls `attach_primary_exposure()`), cell PATCH allowlists
- `clients.py`: `project_addresses` builder, `_project_note_ctx()`, project header edit POST, project detail + print handlers, project cell-patch address sync (removed), smart-suggestions flow (retired — signal is gone), `location_assign`/`bulk_assign` (no more address sync), program bulk import, client health score SLA check
- `prompt_assembler.py`: policy Exposure block emits every linked exposure from `client_exposures` (primary first, with location/year/denominator)
- `exporter.py`: `export_full_xlsx` adds new `Exposures` sheet (one row per link) + keeps legacy column names as aliases; `export_book_review_xlsx` reads `pr.address` from joined project
- `reconcile.py` / `reconciler.py`: `exposure_address` dropped from TEXT allowlist + diff tracking + PATCH allowlist
- `dedup.py`: `_COMPARE_FIELDS` and `_FIELD_LABELS` drop address fields
- `bind_order.py`: only updates `project_id` / `project_name`, no address mirror
- `cli.py`: `policy add` / `edit` stop prompting for exposure fields; `policy show` drops the three exposure rows
- `db.py`: startup normalization operates on `projects`, not `policies`; legacy backfill moved into migration 151 (one-shot)
- `data_health.py`, `models.py`: drop exposure fields from allowlists / dataclass

**Templates:**
- `briefing.html`: removed dead `item.exposure_city`/`p.exposure_state` display lines (data source didn't include those columns anyway)
- `reconcile/index.html`: dropped 6 exposure options from the reconcile-field picker
- `_tab_details.html`, `new.html`: dead datalists + JS autocomplete hooks removed
- `_tab_pulse.html`, `clients/project.html`, `project_print.html`, `_tab_policies.html`, `_project_header_edit.html`: no changes — route handlers setdefault the legacy keys from the `projects` row or `attach_primary_exposure()`

## Test plan

- [x] `tests/test_exposure_column_drop.py` — 9 new cases:
  - All 8 deprecated columns absent from `PRAGMA table_info(policies)`
  - Migration 151 registered in `schema_version`
  - `audit_policies_update` trigger has no references to dropped columns
  - Every view in `sqlite_master` resolves `SELECT * ... LIMIT 0` cleanly
  - `attach_primary_exposure()` defaults to `None` when no link exists
  - Hydrates primary link + location from `policies.project_id`
  - Ignores non-primary links when picking primary fields
  - Falls back to exposure's own `project_id` when policy has no `project_id`
  - `v_policy_status` exposes the expected `primary_exposure_*` aliases
- [x] Full suite: **515 passing** (was 506 after Bug 3), same 19 pre-existing main failures untouched
- [x] Migration smoke test: fresh DB init → all 8 columns dropped, views + trigger rebuilt cleanly
- [x] App boots clean (754 routes) post-rebase
- [ ] Manual: open a client detail page and confirm the Exposures card on policy rows still displays linked exposures
- [ ] Manual: run `policydb serve`, export a client's full XLSX, verify the `Exposures` sheet is populated and the policies sheet has address columns
- [ ] Manual: AI-export a policy through the prompt builder and confirm the Exposure block lists all linked exposures with location and year

🤖 Generated with [Claude Code](https://claude.com/claude-code)