### PR TITLE
fix(timeline): Apply button on Renewal Timeline persists profile selection

### DIFF
--- a/src/policydb/web/routes/policies.py
+++ b/src/policydb/web/routes/policies.py
@@ -3196,11 +3196,13 @@ def policy_timeline_set_profile(
     if not policy_dict:
         return HTMLResponse("Not found", status_code=404)
 
+    new_profile = milestone_profile.strip() or None
     conn.execute(
         "UPDATE policies SET milestone_profile = ? WHERE policy_uid = ?",
-        (milestone_profile.strip() or None, uid),
+        (new_profile, uid),
     )
     conn.commit()
+    policy_dict["milestone_profile"] = new_profile or ""
 
     from policydb.timeline_engine import generate_policy_timelines, get_policy_timeline, suggest_profile
     generate_policy_timelines(conn, policy_uid=uid)

--- a/src/policydb/web/templates/policies/_timeline.html
+++ b/src/policydb/web/templates/policies/_timeline.html
@@ -1,5 +1,31 @@
 {# Policy Timeline Partial — vertical milestone timeline visualization #}
+{% set _current_profile = policy.milestone_profile or '' %}
+{% set _selected_profile = _current_profile or suggested_profile or '' %}
 <div class="space-y-1">
+    {% if milestone_profiles %}
+    <form
+      hx-post="/policies/{{ policy.policy_uid }}/timeline/profile"
+      hx-target="#policy-timeline-{{ policy.policy_uid }}"
+      hx-swap="innerHTML"
+      class="flex items-center gap-2 pb-2 mb-2 border-b border-gray-100">
+      <label class="text-xs text-gray-500 uppercase tracking-wide">Profile</label>
+      <select name="milestone_profile"
+              class="text-sm border border-gray-200 rounded px-2 py-1 focus:border-marsh focus:outline-none bg-white">
+        <option value="" {% if not _selected_profile %}selected{% endif %}>— Select a profile —</option>
+        {% for prof in milestone_profiles %}
+        <option value="{{ prof.name }}" {% if _selected_profile == prof.name %}selected{% endif %}>{{ prof.name }}{% if not _current_profile and suggested_profile == prof.name %} (suggested){% endif %}</option>
+        {% endfor %}
+      </select>
+      <button type="submit"
+              class="text-xs font-medium bg-marsh text-white px-3 py-1 rounded hover:bg-marsh-light transition-colors">
+        Apply
+      </button>
+      {% if _current_profile %}
+      <span class="text-[10px] text-gray-400">Saved</span>
+      {% endif %}
+    </form>
+    {% endif %}
+
     {% for m in timeline %}
     <div class="flex items-start gap-3 py-2 px-3 rounded
         {% if m.completed_date %}bg-green-50
@@ -60,26 +86,14 @@
 
     {% if not timeline %}
     <div class="py-2">
-      <p class="text-sm text-gray-500 mb-2">No timeline milestones configured. Assign a milestone profile to enable timeline tracking.</p>
       {% if milestone_profiles %}
-      <form
-        hx-post="/policies/{{ policy.policy_uid }}/timeline/profile"
-        hx-target="#policy-timeline-{{ policy.policy_uid }}"
-        hx-swap="innerHTML"
-        class="flex items-center gap-2">
-        <label class="text-xs text-gray-500 uppercase tracking-wide">Profile</label>
-        <select name="milestone_profile"
-                class="text-sm border border-gray-200 rounded px-2 py-1 focus:border-marsh focus:outline-none bg-white">
-          <option value="">— Select a profile —</option>
-          {% for prof in milestone_profiles %}
-          <option value="{{ prof.name }}" {% if suggested_profile == prof.name %}selected{% endif %}>{{ prof.name }}{% if suggested_profile == prof.name %} (suggested){% endif %}</option>
-          {% endfor %}
-        </select>
-        <button type="submit"
-                class="text-xs font-medium bg-marsh text-white px-3 py-1 rounded hover:bg-marsh-light transition-colors">
-          Apply
-        </button>
-      </form>
+      <p class="text-sm text-gray-500">
+        {% if _current_profile %}
+        Profile <span class="font-medium text-gray-700">{{ _current_profile }}</span> is applied, but no milestones fall within the current horizon window.
+        {% else %}
+        No timeline milestones configured. Select a profile above and click Apply to enable timeline tracking.
+        {% endif %}
+      </p>
       {% else %}
       <p class="text-xs text-gray-400">
         No milestone profiles defined.


### PR DESCRIPTION
## Summary

The **Apply** button on the Renewal Timeline in the policy view appeared to not save the selected milestone profile. Two bugs were combining to make the save look like a no-op:

1. **Stale policy dict** — [`policy_timeline_set_profile`](src/policydb/web/routes/policies.py) loaded `policy_dict` *before* running the `UPDATE`, then passed the stale dict back to the template. The DB was saving correctly, but the re-rendered partial showed the old (empty) value.
2. **Form vanished after save** — [`_timeline.html`](src/policydb/web/templates/policies/_timeline.html) only rendered the profile `<select>` + Apply button when there were no timeline rows, so the form disappeared once a profile successfully generated milestones. Users couldn't verify or change the active profile. The selected option also checked `suggested_profile` instead of `policy.milestone_profile`, so even in the empty-state case the user's pick wasn't reflected on re-render.

## Fix

- Update `policy_dict["milestone_profile"]` in-place after the `UPDATE` so the HTMX response reflects the saved state.
- Always render the profile selector above the timeline, select based on `policy.milestone_profile` (falling back to the suggested profile only when none is saved), and show a small "Saved" indicator when a profile is active.
- Replace the duplicate form in the empty-state block with a contextual message that distinguishes "no profile assigned" from "profile assigned but no milestones in the horizon window."

## Test plan

Verified end-to-end against a fresh uvicorn instance using `curl`:

- [x] **Initial GET** on a policy with no profile → shows suggested profile as selected with `(suggested)` label
- [x] **POST Apply** `Full Renewal` → DB updated, response shows `Full Renewal selected` + "Saved" indicator
- [x] **POST Apply** `Standard Renewal` (change) → DB updated, response reflects new selection
- [x] **POST Apply** empty (clear) → DB set to NULL, response falls back to suggested profile display
- [x] Profile selector remains visible after successful save so users can change the profile