### PR TITLE
AI exposure approval flow, contact picker fix, issue scratchpad

### DIFF
--- a/src/policydb/db.py
+++ b/src/policydb/db.py
@@ -2053,6 +2053,15 @@ def _init_db_inner(conn: sqlite3.Connection, db_path: Path) -> None:
         conn.commit()
         logger.info("Migration 151: dropped 8 deprecated policies.exposure_* columns")
 
+    if 152 not in applied:
+        conn.executescript((_MIGRATIONS_DIR / "152_issue_scratchpad.sql").read_text())
+        conn.execute(
+            "INSERT INTO schema_version (version, description) VALUES (?, ?)",
+            (152, "Add issue_scratchpad table for per-issue working notes"),
+        )
+        conn.commit()
+        logger.info("Migration 152: added issue_scratchpad table")
+
     # Data hygiene: fix 'None' string corruption in text fields (runs every startup, fast no-op if clean)
     conn.execute("UPDATE clients SET cn_number = NULL WHERE cn_number = 'None'")
 

--- a/src/policydb/migrations/152_issue_scratchpad.sql
+++ b/src/policydb/migrations/152_issue_scratchpad.sql
@@ -1,0 +1,17 @@
+-- Per-issue working notes (scratchpad) with auto-save support.
+-- Mirrors client_scratchpad (014), policy_scratchpad (040), and
+-- project_scratchpad (143). Issue header rows live on activity_log,
+-- so this FK references activity_log.id.
+
+CREATE TABLE IF NOT EXISTS issue_scratchpad (
+    issue_id   INTEGER PRIMARY KEY REFERENCES activity_log(id) ON DELETE CASCADE,
+    content    TEXT NOT NULL DEFAULT '',
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TRIGGER IF NOT EXISTS issue_scratchpad_updated
+    AFTER UPDATE ON issue_scratchpad
+BEGIN
+    UPDATE issue_scratchpad SET updated_at = CURRENT_TIMESTAMP
+    WHERE issue_id = NEW.issue_id;
+END;

--- a/src/policydb/web/routes/clients.py
+++ b/src/policydb/web/routes/clients.py
@@ -2775,8 +2775,20 @@ def contact_add(
     conn=Depends(get_db),
 ):
     from policydb.web.routes.contacts import _find_similar_contacts
-    # Run duplicate check before creating — warn but don't block
-    dupes = _find_similar_contacts(conn, name.strip(), source="client") if name.strip() else []
+    # Many-to-many: an existing contact can legitimately be attached to a
+    # new client. Only run the similarity check when the submitted name is
+    # NOT already an exact match for a contact row — otherwise reusing a
+    # contact from the autocomplete fires a false-positive duplicate warning.
+    trimmed = name.strip()
+    existing_exact = conn.execute(
+        "SELECT 1 FROM contacts WHERE LOWER(TRIM(name)) = LOWER(TRIM(?))",
+        (trimmed,),
+    ).fetchone() if trimmed else None
+    dupes = (
+        _find_similar_contacts(conn, trimmed, source="client")
+        if trimmed and not existing_exact
+        else []
+    )
     cid = get_or_create_contact(conn, name,
                                 email=clean_email(email) or None,
                                 phone=format_phone(phone) or None,

--- a/src/policydb/web/routes/inbox.py
+++ b/src/policydb/web/routes/inbox.py
@@ -193,6 +193,18 @@ def scratchpad_clear(source: str = Form(...), source_id: str = Form(""), scope_i
         except (ValueError, IndexError):
             return HTMLResponse("Invalid project ID", status_code=400)
         conn.execute("UPDATE project_scratchpad SET content='', updated_at=CURRENT_TIMESTAMP WHERE project_id=?", (pid,))
+    elif source == "issue":
+        # scope_id is the issue_uid — resolve to activity_log.id
+        issue_row = conn.execute(
+            "SELECT id FROM activity_log WHERE issue_uid = ? AND item_kind = 'issue'",
+            (sid,),
+        ).fetchone()
+        if not issue_row:
+            return HTMLResponse("Issue not found", status_code=404)
+        conn.execute(
+            "UPDATE issue_scratchpad SET content='', updated_at=CURRENT_TIMESTAMP WHERE issue_id=?",
+            (issue_row["id"],),
+        )
     conn.commit()
     return HTMLResponse("", headers={
         "HX-Trigger": '{"activityLogged": "Scratchpad cleared"}'
@@ -219,7 +231,9 @@ def scratchpad_process(
     sid = scope_id or source_id
     resolved_client_id = client_id
     resolved_policy_uid = None
+    resolved_policy_id = policy_id
     resolved_project_id = 0
+    resolved_issue_id: int | None = None
     content_for_note = details or ""
 
     if source == "client" and not resolved_client_id:
@@ -255,13 +269,35 @@ def scratchpad_process(
             row2 = conn.execute("SELECT content FROM project_scratchpad WHERE project_id=?", (resolved_project_id,)).fetchone()
             if row2:
                 content_for_note = row2["content"] or ""
+    elif source == "issue":
+        # scope_id is the issue_uid — resolve to issue's activity_log row
+        issue_row = conn.execute(
+            "SELECT id, client_id, policy_id, project_id, program_id "
+            "FROM activity_log WHERE issue_uid = ? AND item_kind = 'issue'",
+            (sid,),
+        ).fetchone()
+        if not issue_row:
+            return HTMLResponse("Issue not found", status_code=404)
+        resolved_issue_id = issue_row["id"]
+        if not resolved_client_id and issue_row["client_id"]:
+            resolved_client_id = issue_row["client_id"]
+        if not resolved_policy_id and issue_row["policy_id"]:
+            resolved_policy_id = issue_row["policy_id"]
+        if not resolved_project_id and issue_row["project_id"]:
+            resolved_project_id = issue_row["project_id"]
+        if not content_for_note:
+            scratch_row = conn.execute(
+                "SELECT content FROM issue_scratchpad WHERE issue_id=?",
+                (resolved_issue_id,),
+            ).fetchone()
+            if scratch_row:
+                content_for_note = scratch_row["content"] or ""
     elif source == "dashboard" and not content_for_note:
         row = conn.execute("SELECT content FROM user_notes WHERE id=1").fetchone()
         if row:
             content_for_note = row["content"] or ""
 
     # Resolve policy_id (integer FK) from policy_uid if needed
-    resolved_policy_id = policy_id
     if not resolved_policy_id and resolved_policy_uid:
         pid_row = conn.execute("SELECT id FROM policies WHERE policy_uid=?", (resolved_policy_uid,)).fetchone()
         if pid_row:
@@ -277,14 +313,14 @@ def scratchpad_process(
     account_exec = cfg.get("default_account_exec", "Grant")
     dur = round_duration(duration_hours)
 
-    # 1. Create activity
+    # 1. Create activity (issue_id auto-links when scratchpad was scoped to an issue)
     cursor = conn.execute(
         """INSERT INTO activity_log
-           (activity_date, client_id, policy_id, project_id, activity_type, subject, details,
-            follow_up_date, account_exec, duration_hours)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+           (activity_date, client_id, policy_id, project_id, issue_id, activity_type,
+            subject, details, follow_up_date, account_exec, duration_hours)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (date.today().isoformat(), resolved_client_id or None, resolved_policy_id or None,
-         resolved_project_id or None, activity_type,
+         resolved_project_id or None, resolved_issue_id, activity_type,
          subject or "Scratchpad note", content_for_note or None,
          follow_up_date or None, account_exec, dur),
     )
@@ -304,6 +340,11 @@ def scratchpad_process(
         conn.execute("UPDATE policy_scratchpad SET content='', updated_at=CURRENT_TIMESTAMP WHERE policy_uid=?", (puid,))
     elif source == "project" and resolved_project_id:
         conn.execute("UPDATE project_scratchpad SET content='', updated_at=CURRENT_TIMESTAMP WHERE project_id=?", (resolved_project_id,))
+    elif source == "issue" and resolved_issue_id:
+        conn.execute(
+            "UPDATE issue_scratchpad SET content='', updated_at=CURRENT_TIMESTAMP WHERE issue_id=?",
+            (resolved_issue_id,),
+        )
 
     conn.commit()
 

--- a/src/policydb/web/routes/issues.py
+++ b/src/policydb/web/routes/issues.py
@@ -895,11 +895,21 @@ def issue_detail(
 
     open_tasks_data = get_open_tasks(conn, "issue", issue_id)
 
+    # Working notes (scratchpad) for this issue — migration 152
+    scratch_row = conn.execute(
+        "SELECT content, updated_at FROM issue_scratchpad WHERE issue_id = ?",
+        (issue_id,),
+    ).fetchone()
+    issue_scratchpad = scratch_row["content"] if scratch_row else ""
+    issue_scratchpad_updated = scratch_row["updated_at"] if scratch_row else ""
+
     ctx = {
         "request": request,
         "active": "action-center",
         "issue": issue,
         "activities": activities,
+        "issue_scratchpad": issue_scratchpad,
+        "issue_scratchpad_updated": issue_scratchpad_updated,
         "total_hours": round(total_hours, 1),
         "merged_from_issues": merged_from_issues,
         "merged_from_flash": merged_from or "",
@@ -921,6 +931,65 @@ def issue_detail(
         "data": open_tasks_data,
     }
     return templates.TemplateResponse("issues/detail.html", ctx)
+
+
+def _issue_scratchpad_ctx(request, conn, issue_uid: str, content: str | None = None) -> dict:
+    """Build context for the issues/_scratchpad.html partial."""
+    issue_row = conn.execute(
+        "SELECT id, issue_uid FROM activity_log WHERE issue_uid = ? AND item_kind = 'issue'",
+        (issue_uid,),
+    ).fetchone()
+    issue = dict(issue_row) if issue_row else {"id": 0, "issue_uid": issue_uid}
+    if content is None:
+        row = conn.execute(
+            "SELECT content, updated_at FROM issue_scratchpad WHERE issue_id=?",
+            (issue["id"],),
+        ).fetchone()
+        content = row["content"] if row else ""
+        updated = row["updated_at"] if row else ""
+    else:
+        row = conn.execute(
+            "SELECT updated_at FROM issue_scratchpad WHERE issue_id=?",
+            (issue["id"],),
+        ).fetchone()
+        updated = row["updated_at"] if row else ""
+    return {
+        "request": request,
+        "issue": issue,
+        "issue_scratchpad": content,
+        "issue_scratchpad_updated": updated,
+    }
+
+
+@router.post("/issues/{issue_uid}/scratchpad")
+def issue_scratchpad_save(
+    request: Request,
+    issue_uid: str,
+    content: str = Form(""),
+    conn=Depends(get_db),
+):
+    """Auto-save per-issue working notes. Returns JSON when Accept requests it."""
+    from datetime import datetime, timezone
+    issue_row = conn.execute(
+        "SELECT id FROM activity_log WHERE issue_uid = ? AND item_kind = 'issue'",
+        (issue_uid,),
+    ).fetchone()
+    if not issue_row:
+        return HTMLResponse("Issue not found", status_code=404)
+    issue_id = issue_row["id"]
+    conn.execute(
+        "INSERT INTO issue_scratchpad (issue_id, content) VALUES (?, ?) "
+        "ON CONFLICT(issue_id) DO UPDATE SET content = excluded.content",
+        (issue_id, content),
+    )
+    conn.commit()
+    if "application/json" in (request.headers.get("accept") or ""):
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M")
+        return JSONResponse({"ok": True, "saved_at": now})
+    return templates.TemplateResponse(
+        "issues/_scratchpad.html",
+        _issue_scratchpad_ctx(request, conn, issue_uid, content),
+    )
 
 
 # ── Scoped RFI view: filtered to the issue's linked policies ────────────────

--- a/src/policydb/web/routes/policies.py
+++ b/src/policydb/web/routes/policies.py
@@ -3196,11 +3196,13 @@ def policy_timeline_set_profile(
     if not policy_dict:
         return HTMLResponse("Not found", status_code=404)
 
+    new_profile = milestone_profile.strip() or None
     conn.execute(
         "UPDATE policies SET milestone_profile = ? WHERE policy_uid = ?",
-        (milestone_profile.strip() or None, uid),
+        (new_profile, uid),
     )
     conn.commit()
+    policy_dict["milestone_profile"] = new_profile or ""
 
     from policydb.timeline_engine import generate_policy_timelines, get_policy_timeline, suggest_profile
     generate_policy_timelines(conn, policy_uid=uid)

--- a/src/policydb/web/routes/policies.py
+++ b/src/policydb/web/routes/policies.py
@@ -1684,88 +1684,150 @@ def _ai_import_parse_inner(request: Request, conn, uid: str, result: dict):
                 f"client record has {client_fein['fein']}"
             )
 
-    # ── Route exposures through client_exposures / policy_exposure_links ──
-    # Each entry in the `exposures` list becomes a row in client_exposures
-    # plus a link in policy_exposure_links.  If an entry carries address
-    # fields, we also upsert a `projects` (location) row and attach the
-    # exposure to it.  The policy's own project_id is only stamped when it
-    # was previously unassigned — we never overwrite a user-picked location.
+    # ── Build exposure diffs for the AI Review panel ──
+    # Each entry in the `exposures` list becomes a row the user can
+    # approve individually.  Nothing is written to client_exposures /
+    # policy_exposure_links / projects here — that happens in the
+    # /ai-import/apply-exposures endpoint after the user clicks Apply.
+    # For each valid entry we try to match an existing client_exposures
+    # row on (client_id, project_id, exposure_type, year) so the UI can
+    # show "update existing" vs "new" and surface the amount diff.
     exposures_parsed = result["parsed"].get("exposures") or []
+    ai_exposure_data: list[dict] = []
+    ai_exposure_year: int | None = None
     if exposures_parsed:
-        from policydb.exposures import find_or_create_exposure, create_exposure_link
-        from policydb.queries import find_or_create_project_from_address
-
         eff_date = result["parsed"].get("effective_date") or policy_dict.get("effective_date", "")
         year = int(eff_date[:4]) if eff_date and len(eff_date) >= 4 else datetime.now().year
+        ai_exposure_year = year
         client_id = policy_dict["client_id"]
-        policy_uid = policy_dict["policy_uid"]
         policy_project_id = policy_dict.get("project_id")
 
-        # Normalize and filter out empty/invalid entries up front so the
-        # primary-flag decision isn't skewed by rows that would be skipped.
-        valid_exposures: list[dict] = []
-        for exp in exposures_parsed:
+        # Normalize and filter entries; non-valid ones still appear in the
+        # panel as "invalid" so the user knows the LLM returned them.
+        valid_indices: list[int] = []
+        for idx, exp in enumerate(exposures_parsed):
             if not isinstance(exp, dict):
+                ai_exposure_data.append({
+                    "index": idx, "valid": False, "reason": "Not an object",
+                    "raw": str(exp)[:80],
+                })
                 continue
             exposure_type = (exp.get("exposure_type") or "").strip()
             try:
                 amount = float(exp.get("amount") or 0) or None
             except (ValueError, TypeError):
                 amount = None
-            if not exposure_type or not amount:
-                continue
             try:
                 denominator = int(exp.get("denominator") or 1) or 1
             except (ValueError, TypeError):
                 denominator = 1
-            valid_exposures.append({
-                **exp,
+            unit = (exp.get("unit") or "").strip()
+            label = (exp.get("location_label") or "").strip()
+
+            if not exposure_type:
+                ai_exposure_data.append({
+                    "index": idx, "valid": False, "reason": "Missing exposure_type",
+                    "raw": json.dumps(exp)[:120],
+                })
+                continue
+            if not amount:
+                ai_exposure_data.append({
+                    "index": idx, "valid": False,
+                    "reason": "Missing or zero amount",
+                    "exposure_type": exposure_type,
+                    "raw": json.dumps(exp)[:120],
+                })
+                continue
+
+            # Try to resolve an existing project for the diff (read-only —
+            # we do not insert anything here).
+            addr = (exp.get("address") or "").strip()
+            city = (exp.get("city") or "").strip()
+            state = (exp.get("state") or "").strip()
+            zip_code = (exp.get("zip") or "").strip()
+            has_address = bool(addr or city or state or zip_code or label)
+
+            matched_project = None
+            if addr:
+                from policydb.queries import _normalize_address
+                norm = _normalize_address(addr)
+                if norm:
+                    for r in conn.execute(
+                        """SELECT id, name, address FROM projects
+                           WHERE client_id = ? AND address IS NOT NULL AND TRIM(address) != ''""",
+                        (client_id,),
+                    ).fetchall():
+                        if _normalize_address(r["address"] or "") == norm:
+                            matched_project = dict(r)
+                            break
+            if not matched_project and label:
+                r = conn.execute(
+                    """SELECT id, name, address FROM projects
+                       WHERE client_id = ? AND LOWER(TRIM(name)) = LOWER(TRIM(?))""",
+                    (client_id, label),
+                ).fetchone()
+                if r:
+                    matched_project = dict(r)
+
+            # Look up existing client_exposures row for the match decision.
+            match_project_id = matched_project["id"] if matched_project else None
+            existing_row = conn.execute(
+                """SELECT id, amount, denominator, unit, project_id
+                   FROM client_exposures
+                   WHERE client_id = ? AND COALESCE(project_id, 0) = COALESCE(?, 0)
+                     AND exposure_type = ? AND year = ?""",
+                (client_id, match_project_id, exposure_type, year),
+            ).fetchone()
+            existing_dict = dict(existing_row) if existing_row else None
+
+            # Resolve a display name for the location decision.
+            if matched_project:
+                loc_display = matched_project.get("name") or matched_project.get("address") or "Matched location"
+                loc_action = "link_to_existing"
+            elif has_address:
+                parts = [p for p in [label, addr, city, state] if p]
+                loc_display = ", ".join(parts) if parts else "New location"
+                loc_action = "create_new"
+            else:
+                loc_display = None
+                loc_action = "none"  # attach to client root
+
+            valid_indices.append(len(ai_exposure_data))
+            ai_exposure_data.append({
+                "index": idx,
+                "valid": True,
                 "exposure_type": exposure_type,
                 "amount": amount,
                 "denominator": denominator,
+                "unit": unit,
+                "location_label": label,
+                "address": addr,
+                "city": city,
+                "state": state,
+                "zip": zip_code,
+                "has_address": has_address,
+                "loc_display": loc_display,
+                "loc_action": loc_action,
+                "matched_project_id": match_project_id,
+                "existing": existing_dict,
+                "match_type": "update" if existing_dict else "new",
+                "llm_is_primary": bool(exp.get("is_primary")),
+                "would_stamp_policy_project": bool(
+                    match_project_id and not policy_project_id
+                ),
             })
 
-        # Decide which valid entry is primary: first LLM-flagged one, else
-        # the first in order.
-        primary_idx = next(
-            (i for i, e in enumerate(valid_exposures) if e.get("is_primary")),
-            0 if valid_exposures else -1,
-        )
-
-        for idx, exp in enumerate(valid_exposures):
-            # Upsert a location/project from the exposure address when present.
-            exp_project_id = find_or_create_project_from_address(
-                conn,
-                client_id=client_id,
-                address=exp.get("address"),
-                city=exp.get("city"),
-                state=exp.get("state"),
-                zip_code=exp.get("zip"),
-                label=exp.get("location_label"),
-            )
-
-            # Stamp policies.project_id only when previously unassigned.
-            if exp_project_id and not policy_project_id:
-                conn.execute(
-                    "UPDATE policies SET project_id = ? WHERE policy_uid = ?",
-                    (exp_project_id, policy_uid),
-                )
-                policy_project_id = exp_project_id
-
-            exp_id = find_or_create_exposure(
-                conn,
-                client_id=client_id,
-                project_id=exp_project_id,
-                exposure_type=exp["exposure_type"],
-                year=year,
-                amount=exp["amount"],
-                denominator=exp["denominator"],
-            )
-            create_exposure_link(
-                conn, policy_uid, exp_id, is_primary=(idx == primary_idx),
-            )
-
-        conn.commit()
+        # Decide which valid entry should default to primary: first
+        # LLM-flagged one among valid entries, else the first valid one.
+        primary_panel_idx = -1
+        for list_idx in valid_indices:
+            if ai_exposure_data[list_idx].get("llm_is_primary"):
+                primary_panel_idx = list_idx
+                break
+        if primary_panel_idx == -1 and valid_indices:
+            primary_panel_idx = valid_indices[0]
+        for list_idx in valid_indices:
+            ai_exposure_data[list_idx]["is_primary_default"] = (list_idx == primary_panel_idx)
 
     # ── Build policy-level diffs ──
     _field_labels = {f["key"]: f["label"] for f in POLICY_EXTRACTION_SCHEMA["fields"]}
@@ -1990,8 +2052,10 @@ def _ai_import_parse_inner(request: Request, conn, uid: str, result: dict):
             ai_sub_coverage_data.append(sc_entry)
 
     logger.debug(
-        "AI import parse inner: diffs built — %d policy diffs, %d locations, %d sub-coverages",
+        "AI import parse inner: diffs built — %d policy diffs, %d locations, "
+        "%d sub-coverages, %d exposures",
         len(ai_policy_diffs), len(ai_location_data), len(ai_sub_coverage_data),
+        len(ai_exposure_data),
     )
 
     # Build the same context as policy_tab_details
@@ -2077,6 +2141,8 @@ def _ai_import_parse_inner(request: Request, conn, uid: str, result: dict):
         "ai_policy_diffs": ai_policy_diffs,
         "ai_location_data": ai_location_data,
         "ai_sub_coverage_data": ai_sub_coverage_data,
+        "ai_exposure_data": ai_exposure_data,
+        "ai_exposure_year": ai_exposure_year,
         "ai_parsed_json": json.dumps(result["parsed"], default=str),
     })
 
@@ -2258,6 +2324,144 @@ async def policy_ai_import_apply_location(
             loc_name = loc_row["name"] or loc_name
 
     return JSONResponse({"ok": True, "location_name": loc_name, "created": created, "project_id": project_id})
+
+
+@router.post("/{policy_uid}/ai-import/apply-exposures")
+async def policy_ai_import_apply_exposures(
+    request: Request,
+    policy_uid: str,
+    conn=Depends(get_db),
+):
+    """Apply user-approved exposures from AI import.
+
+    Body: {"year": int, "exposures": [{exposure_type, amount, denominator,
+    unit, location_label, address, city, state, zip, loc_action,
+    matched_project_id, is_primary}, ...]}
+
+    For each row:
+      1. Upsert a location (project) if the entry has address fields and no
+         matched_project_id was provided.
+      2. Upsert the client_exposures row.
+      3. Create / refresh the policy_exposure_links row.
+      4. Stamp policies.project_id to the first upserted project_id IFF the
+         policy has no project_id yet (never overwrites user-picked location).
+    """
+    uid = policy_uid.upper()
+    body = await request.json()
+    year = body.get("year")
+    rows = body.get("exposures") or []
+
+    if not isinstance(year, int) or year <= 0:
+        return JSONResponse({"ok": False, "error": "Missing or invalid year"}, status_code=400)
+    if not rows:
+        return JSONResponse({"ok": False, "error": "No exposures supplied"}, status_code=400)
+
+    policy = get_policy_by_uid(conn, uid)
+    if not policy:
+        return JSONResponse({"ok": False, "error": "Policy not found"}, status_code=404)
+
+    from policydb.exposures import find_or_create_exposure, create_exposure_link
+    from policydb.queries import find_or_create_project_from_address
+
+    client_id = policy["client_id"]
+    policy_project_id = policy["project_id"]
+    applied = 0
+    locations_created = 0
+
+    # Primary flag: at most one should be true in the request body.  Find it.
+    primary_requested = next(
+        (i for i, r in enumerate(rows) if r.get("is_primary")),
+        None,
+    )
+
+    for idx, r in enumerate(rows):
+        exposure_type = (r.get("exposure_type") or "").strip()
+        try:
+            amount = float(r.get("amount") or 0) or None
+        except (ValueError, TypeError):
+            amount = None
+        if not exposure_type or not amount:
+            continue
+        try:
+            denominator = int(r.get("denominator") or 1) or 1
+        except (ValueError, TypeError):
+            denominator = 1
+
+        # Resolve project: either a pre-matched id from the diff, or upsert
+        # from address fields.
+        matched_id = r.get("matched_project_id")
+        if matched_id:
+            exp_project_id = int(matched_id)
+        else:
+            before_count = conn.execute(
+                "SELECT COUNT(*) FROM projects WHERE client_id = ?", (client_id,)
+            ).fetchone()[0]
+            exp_project_id = find_or_create_project_from_address(
+                conn,
+                client_id=client_id,
+                address=r.get("address"),
+                city=r.get("city"),
+                state=r.get("state"),
+                zip_code=r.get("zip"),
+                label=r.get("location_label"),
+            )
+            if exp_project_id:
+                after_count = conn.execute(
+                    "SELECT COUNT(*) FROM projects WHERE client_id = ?", (client_id,)
+                ).fetchone()[0]
+                if after_count > before_count:
+                    locations_created += 1
+
+        # Stamp policies.project_id when previously unassigned.
+        if exp_project_id and not policy_project_id:
+            conn.execute(
+                "UPDATE policies SET project_id = ?, updated_at = datetime('now') "
+                "WHERE policy_uid = ?",
+                (exp_project_id, uid),
+            )
+            policy_project_id = exp_project_id
+
+        exp_id = find_or_create_exposure(
+            conn,
+            client_id=client_id,
+            project_id=exp_project_id,
+            exposure_type=exposure_type,
+            year=year,
+            amount=amount,
+            denominator=denominator,
+        )
+
+        # If the extracted amount differs from the stored amount for an
+        # existing row, update it (find_or_create_exposure only inserts).
+        stored = conn.execute(
+            "SELECT amount, denominator FROM client_exposures WHERE id = ?",
+            (exp_id,),
+        ).fetchone()
+        if stored and (
+            (stored["amount"] or 0) != amount
+            or (stored["denominator"] or 1) != denominator
+        ):
+            conn.execute(
+                "UPDATE client_exposures SET amount = ?, denominator = ?, "
+                "updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+                (amount, denominator, exp_id),
+            )
+
+        create_exposure_link(
+            conn, uid, exp_id, is_primary=(idx == primary_requested),
+        )
+        applied += 1
+
+    conn.commit()
+    logger.info(
+        "AI import: applied %d exposures (year=%s, created %d locations) for policy %s",
+        applied, year, locations_created, uid,
+    )
+    return JSONResponse({
+        "ok": True,
+        "applied": applied,
+        "locations_created": locations_created,
+    })
 
 
 # ── AI Contact Extraction (email chain → policy contacts) ──

--- a/src/policydb/web/templates/issues/_scratchpad.html
+++ b/src/policydb/web/templates/issues/_scratchpad.html
@@ -1,0 +1,85 @@
+{# Per-issue working notes scratchpad.
+   Mirrors policies/_scratchpad.html — auto-saves every 800ms, can be
+   logged as an activity or cleared. Rendered inside issues/detail.html.
+
+   Context:
+     issue                    — issue dict (uses issue.issue_uid + issue.id)
+     issue_scratchpad         — current text content
+     issue_scratchpad_updated — ISO timestamp string
+#}
+<div id="issue-scratchpad-{{ issue.issue_uid }}" class="card p-4">
+  <div class="flex items-center justify-between mb-2">
+    <h2 class="text-sm font-semibold text-gray-900">Working Notes</h2>
+    <span id="scratch-ts-{{ issue.issue_uid }}" class="text-xs text-gray-400 italic">
+      {% if issue_scratchpad_updated %}saved {{ issue_scratchpad_updated[:16] }}{% endif %}
+    </span>
+  </div>
+  <textarea
+    id="scratch-ta-{{ issue.issue_uid }}"
+    name="content"
+    rows="4"
+    placeholder="Working notes for this issue — type here, then Log as Activity to pin…"
+    class="w-full text-sm text-gray-800 bg-transparent resize-none focus:outline-none placeholder-gray-300 leading-relaxed">{{ issue_scratchpad }}</textarea>
+  <div class="flex justify-end gap-1 mt-1 no-print">
+    <button type="button" id="scratch-log-{{ issue.issue_uid }}"
+      onclick="logScratchCombined('issue', '{{ issue.issue_uid }}')"
+      {% if not issue_scratchpad or not issue_scratchpad.strip() %}disabled{% endif %}
+      class="text-xs bg-marsh text-white px-3 py-1 rounded hover:bg-marsh-light disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
+      Log as Activity
+    </button>
+    <button type="button" id="scratch-clear-{{ issue.issue_uid }}"
+      onclick="clearScratch('issue', '{{ issue.issue_uid }}')"
+      {% if not issue_scratchpad or not issue_scratchpad.strip() %}disabled{% endif %}
+      class="text-xs text-gray-400 border border-gray-200 px-3 py-1 rounded hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
+      Clear
+    </button>
+  </div>
+</div>
+
+<script>
+(function() {
+  var UID = "{{ issue.issue_uid }}";
+  var ta = document.getElementById('scratch-ta-' + UID);
+  var ts = document.getElementById('scratch-ts-' + UID);
+  var logBtn = document.getElementById('scratch-log-' + UID);
+  var clearBtn = document.getElementById('scratch-clear-' + UID);
+  if (!ta) return;
+
+  function updateBtns() {
+    var hasContent = (ta.value || '').trim().length > 0;
+    if (logBtn) logBtn.disabled = !hasContent;
+    if (clearBtn) clearBtn.disabled = !hasContent;
+  }
+
+  var mde = window.initMarkdownEditor ? window.initMarkdownEditor('scratch-ta-' + UID, {minHeight: '100px'}) : null;
+
+  var saveTimer = null;
+  var saving = false;
+  function autoSave() {
+    if (saving) return;
+    saving = true;
+    var fd = new FormData();
+    fd.set('content', ta.value);
+    fetch('/issues/' + UID + '/scratchpad', {
+      method: 'POST', body: fd,
+      headers: {'Accept': 'application/json'}
+    }).then(function(r) { return r.json(); }).then(function(data) {
+      if (data && data.ok && ts) ts.textContent = 'saved ' + data.saved_at;
+    }).catch(function() {}).finally(function() { saving = false; });
+  }
+
+  if (mde) {
+    mde.on('change', function() {
+      updateBtns();
+      clearTimeout(saveTimer);
+      saveTimer = setTimeout(autoSave, 800);
+    });
+  } else {
+    ta.addEventListener('input', function() {
+      updateBtns();
+      clearTimeout(saveTimer);
+      saveTimer = setTimeout(autoSave, 800);
+    });
+  }
+})();
+</script>

--- a/src/policydb/web/templates/issues/detail.html
+++ b/src/policydb/web/templates/issues/detail.html
@@ -273,6 +273,9 @@
         {% endif %}
       </div>
 
+      {# ── Working Notes (scratchpad) ── #}
+      {% include "issues/_scratchpad.html" %}
+
       {# ── Full Log Activity Panel ── #}
       <div class="card p-4">
         <h3 class="text-sm font-semibold text-gray-900 mb-3">Log Activity</h3>

--- a/src/policydb/web/templates/policies/_ai_review_panel.html
+++ b/src/policydb/web/templates/policies/_ai_review_panel.html
@@ -1,10 +1,14 @@
-{# AI Import Review Panel — shows diffs for policy fields, locations, and COPE data.
-   Rendered inside _tab_details.html when ai_policy_diffs or ai_location_data are present.
+{# AI Import Review Panel — shows diffs for policy fields, locations, COPE,
+   sub-coverages, and exposures. Rendered inside _tab_details.html when any of
+   those lists are populated.
    Context:
-     ai_policy_diffs   — list of {field, label, current, extracted, is_fill}
-     ai_location_data   — list of location dicts with diffs, cope_diffs, match info
-     ai_parsed_json     — JSON string of all parsed data (for apply endpoints)
-     policy             — current policy dict
+     ai_policy_diffs      — list of {field, label, current, extracted, is_fill}
+     ai_location_data      — list of location dicts with diffs, cope_diffs, match info
+     ai_sub_coverage_data  — list of sub-coverage dicts
+     ai_exposure_data      — list of exposure dicts (valid + invalid)
+     ai_exposure_year      — int year the exposures roll up to
+     ai_parsed_json        — JSON string of all parsed data (for apply endpoints)
+     policy                — current policy dict
 #}
 <div id="ai-review-panel" class="mb-6" data-parsed='{{ ai_parsed_json }}'>
 
@@ -228,6 +232,113 @@
   </div>
   {% endif %}
 
+  {# ══════════════════════════════════════════════════════════════════════════
+     SECTION D — Exposure Review
+     ══════════════════════════════════════════════════════════════════════════ #}
+  {% if ai_exposure_data is defined and ai_exposure_data %}
+  <div class="card border-amber-200 bg-amber-50/20 mb-4" id="ai-exposures-card"
+       data-exposure-year="{{ ai_exposure_year or '' }}">
+    <div class="px-5 py-3 border-b border-amber-100 flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-4 h-4 text-amber-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 7h6m-6 4h6m-6 4h6M5 7h.01M5 11h.01M5 15h.01M4 19h16a1 1 0 001-1V6a1 1 0 00-1-1H4a1 1 0 00-1 1v12a1 1 0 001 1z"/>
+        </svg>
+        <span class="text-xs font-semibold text-amber-700 uppercase tracking-wide">Exposures</span>
+        {% if ai_exposure_year %}
+        <span class="text-[10px] text-amber-500 font-medium">Year {{ ai_exposure_year }}</span>
+        {% endif %}
+      </div>
+      <span class="text-xs text-gray-400">{{ ai_exposure_data | length }} found</span>
+    </div>
+
+    {% for exp in ai_exposure_data %}
+    {% if not exp.valid %}
+    {# Invalid entry — shown for transparency, can't be applied #}
+    <div class="border-b border-amber-50 last:border-b-0 px-5 py-2.5 flex items-center gap-3 bg-amber-50/10"
+         id="ai-exp-item-{{ exp.index }}">
+      <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+      </svg>
+      <span class="text-xs font-medium text-gray-500">
+        {{ exp.exposure_type or 'Entry ' ~ (exp.index + 1) }}
+      </span>
+      <span class="text-xs text-gray-400">Skipped — {{ exp.reason }}</span>
+    </div>
+    {% else %}
+    <div class="border-b border-amber-50 last:border-b-0" id="ai-exp-item-{{ exp.index }}"
+         data-exposure-type="{{ exp.exposure_type }}"
+         data-amount="{{ exp.amount }}"
+         data-denominator="{{ exp.denominator }}"
+         data-unit="{{ exp.unit }}"
+         data-location-label="{{ exp.location_label }}"
+         data-address="{{ exp.address }}"
+         data-city="{{ exp.city }}"
+         data-state="{{ exp.state }}"
+         data-zip="{{ exp.zip }}"
+         data-loc-action="{{ exp.loc_action }}"
+         data-matched-project-id="{{ exp.matched_project_id or '' }}">
+      {# Exposure header row #}
+      <div class="px-5 py-2.5 flex items-center gap-3 bg-amber-50/30">
+        <input type="checkbox" class="ai-exp-select rounded border-gray-300 text-amber-600 focus:ring-amber-500"
+               value="{{ exp.index }}" checked>
+        <span class="text-xs font-semibold text-amber-800">{{ exp.exposure_type }}</span>
+        <span class="text-xs text-gray-500">
+          {{ '{:,.0f}'.format(exp.amount) }}
+          {% if exp.unit %} {{ exp.unit }}{% endif %}
+          {% if exp.denominator and exp.denominator != 1 %} / {{ exp.denominator }}{% endif %}
+        </span>
+        {% if exp.match_type == 'update' %}
+        <span class="px-2 py-0.5 rounded-full text-[10px] font-bold bg-amber-100 text-amber-700">
+          Update existing
+          {% if exp.existing and exp.existing.amount and exp.existing.amount != exp.amount %}
+          ({{ '{:,.0f}'.format(exp.existing.amount) }} → {{ '{:,.0f}'.format(exp.amount) }})
+          {% endif %}
+        </span>
+        {% else %}
+        <span class="px-2 py-0.5 rounded-full text-[10px] font-bold bg-blue-100 text-blue-700">New</span>
+        {% endif %}
+        <label class="ml-auto flex items-center gap-1 text-[10px] text-amber-700 font-medium cursor-pointer">
+          <input type="radio" name="ai-exp-primary" value="{{ exp.index }}"
+                 class="ai-exp-primary text-amber-600 focus:ring-amber-500"
+                 {% if exp.is_primary_default %}checked{% endif %}>
+          Primary
+        </label>
+      </div>
+
+      {# Location disclosure row #}
+      {% if exp.loc_display %}
+      <div class="px-5 py-2 flex items-center gap-2 text-xs text-gray-500 border-t border-amber-50">
+        <svg class="w-3.5 h-3.5 text-amber-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"/>
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"/>
+        </svg>
+        {% if exp.loc_action == 'link_to_existing' %}
+        <span>Will attach to existing location: <span class="font-medium text-gray-700">{{ exp.loc_display }}</span></span>
+        {% elif exp.loc_action == 'create_new' %}
+        <span>Will create new location: <span class="font-medium text-gray-700">{{ exp.loc_display }}</span></span>
+        {% endif %}
+        {% if exp.would_stamp_policy_project %}
+        <span class="px-1.5 py-0.5 rounded-full bg-amber-100 text-[9px] text-amber-700 font-semibold">Sets policy location</span>
+        {% endif %}
+      </div>
+      {% endif %}
+    </div>
+    {% endif %}
+    {% endfor %}
+
+    <div class="px-5 py-3 border-t border-amber-100 flex items-center gap-3">
+      <button type="button" onclick="applyExposures()"
+              class="px-4 py-1.5 rounded-lg text-xs font-medium bg-amber-600 text-white hover:bg-amber-700 transition-colors">
+        Apply Selected Exposures
+      </button>
+      <button type="button" onclick="document.querySelectorAll('.ai-exp-select').forEach(function(cb){cb.checked=true})"
+              class="text-xs text-amber-500 hover:text-amber-700">Select All</button>
+      <button type="button" onclick="document.querySelectorAll('.ai-exp-select').forEach(function(cb){cb.checked=false})"
+              class="text-xs text-gray-400 hover:text-gray-600">Clear All</button>
+    </div>
+  </div>
+  {% endif %}
+
 </div>
 
 <script>
@@ -399,6 +510,68 @@ function applySubCoverages() {
         applied + ' sub-coverage' + (applied !== 1 ? 's' : '') + ' applied</div>';
       card.className = 'card border-emerald-200 bg-emerald-50/20 mb-4';
     }
+  });
+}
+
+function applyExposures() {
+  var card = document.getElementById('ai-exposures-card');
+  if (!card) return;
+
+  var year = parseInt(card.dataset.exposureYear || '', 10);
+  if (!year) {
+    alert('Cannot apply exposures: no year resolved from policy effective date.');
+    return;
+  }
+
+  /* Primary radio — only one across the whole group, may be on an unchecked row */
+  var primaryEl = document.querySelector('.ai-exp-primary:checked');
+  var primaryIdx = primaryEl ? parseInt(primaryEl.value, 10) : null;
+
+  var rows = [];
+  document.querySelectorAll('.ai-exp-select:checked').forEach(function(cb) {
+    var idx = parseInt(cb.value, 10);
+    var item = document.getElementById('ai-exp-item-' + idx);
+    if (!item) return;
+    var ds = item.dataset;
+    rows.push({
+      index: idx,
+      exposure_type: ds.exposureType,
+      amount: parseFloat(ds.amount),
+      denominator: parseInt(ds.denominator || '1', 10) || 1,
+      unit: ds.unit || '',
+      location_label: ds.locationLabel || '',
+      address: ds.address || '',
+      city: ds.city || '',
+      state: ds.state || '',
+      zip: ds.zip || '',
+      loc_action: ds.locAction || 'none',
+      matched_project_id: ds.matchedProjectId ? parseInt(ds.matchedProjectId, 10) : null,
+      is_primary: (idx === primaryIdx)
+    });
+  });
+
+  if (!rows.length) return;
+
+  var uid = '{{ policy.policy_uid }}';
+  fetch('/policies/' + uid + '/ai-import/apply-exposures', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({year: year, exposures: rows})
+  }).then(function(resp) {
+    return resp.json();
+  }).then(function(data) {
+    if (!data.ok) {
+      alert('Failed to apply exposures: ' + (data.error || 'unknown error'));
+      return;
+    }
+    card.innerHTML = '<div class="px-5 py-4 text-sm text-emerald-600 font-medium flex items-center gap-2">' +
+      '<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>' +
+      data.applied + ' exposure' + (data.applied !== 1 ? 's' : '') + ' applied' +
+      (data.locations_created ? ' (' + data.locations_created + ' location' + (data.locations_created !== 1 ? 's' : '') + ' created)' : '') +
+      '</div>';
+    card.className = 'card border-emerald-200 bg-emerald-50/20 mb-4';
+  }).catch(function(err) {
+    alert('Failed to apply exposures: ' + err);
   });
 }
 </script>

--- a/src/policydb/web/templates/policies/_tab_details.html
+++ b/src/policydb/web/templates/policies/_tab_details.html
@@ -19,7 +19,7 @@ textarea.field-inline { resize: none; }
 </style>
 <div id="tab-details-content">
 
-{% if ai_policy_diffs is defined and (ai_policy_diffs or ai_location_data or ai_sub_coverage_data) %}
+{% if ai_policy_diffs is defined and (ai_policy_diffs or ai_location_data or ai_sub_coverage_data or ai_exposure_data) %}
 {% include 'policies/_ai_review_panel.html' %}
 {% endif %}
 

--- a/src/policydb/web/templates/policies/_timeline.html
+++ b/src/policydb/web/templates/policies/_timeline.html
@@ -1,5 +1,31 @@
 {# Policy Timeline Partial — vertical milestone timeline visualization #}
+{% set _current_profile = policy.milestone_profile or '' %}
+{% set _selected_profile = _current_profile or suggested_profile or '' %}
 <div class="space-y-1">
+    {% if milestone_profiles %}
+    <form
+      hx-post="/policies/{{ policy.policy_uid }}/timeline/profile"
+      hx-target="#policy-timeline-{{ policy.policy_uid }}"
+      hx-swap="innerHTML"
+      class="flex items-center gap-2 pb-2 mb-2 border-b border-gray-100">
+      <label class="text-xs text-gray-500 uppercase tracking-wide">Profile</label>
+      <select name="milestone_profile"
+              class="text-sm border border-gray-200 rounded px-2 py-1 focus:border-marsh focus:outline-none bg-white">
+        <option value="" {% if not _selected_profile %}selected{% endif %}>— Select a profile —</option>
+        {% for prof in milestone_profiles %}
+        <option value="{{ prof.name }}" {% if _selected_profile == prof.name %}selected{% endif %}>{{ prof.name }}{% if not _current_profile and suggested_profile == prof.name %} (suggested){% endif %}</option>
+        {% endfor %}
+      </select>
+      <button type="submit"
+              class="text-xs font-medium bg-marsh text-white px-3 py-1 rounded hover:bg-marsh-light transition-colors">
+        Apply
+      </button>
+      {% if _current_profile %}
+      <span class="text-[10px] text-gray-400">Saved</span>
+      {% endif %}
+    </form>
+    {% endif %}
+
     {% for m in timeline %}
     <div class="flex items-start gap-3 py-2 px-3 rounded
         {% if m.completed_date %}bg-green-50
@@ -60,26 +86,14 @@
 
     {% if not timeline %}
     <div class="py-2">
-      <p class="text-sm text-gray-500 mb-2">No timeline milestones configured. Assign a milestone profile to enable timeline tracking.</p>
       {% if milestone_profiles %}
-      <form
-        hx-post="/policies/{{ policy.policy_uid }}/timeline/profile"
-        hx-target="#policy-timeline-{{ policy.policy_uid }}"
-        hx-swap="innerHTML"
-        class="flex items-center gap-2">
-        <label class="text-xs text-gray-500 uppercase tracking-wide">Profile</label>
-        <select name="milestone_profile"
-                class="text-sm border border-gray-200 rounded px-2 py-1 focus:border-marsh focus:outline-none bg-white">
-          <option value="">— Select a profile —</option>
-          {% for prof in milestone_profiles %}
-          <option value="{{ prof.name }}" {% if suggested_profile == prof.name %}selected{% endif %}>{{ prof.name }}{% if suggested_profile == prof.name %} (suggested){% endif %}</option>
-          {% endfor %}
-        </select>
-        <button type="submit"
-                class="text-xs font-medium bg-marsh text-white px-3 py-1 rounded hover:bg-marsh-light transition-colors">
-          Apply
-        </button>
-      </form>
+      <p class="text-sm text-gray-500">
+        {% if _current_profile %}
+        Profile <span class="font-medium text-gray-700">{{ _current_profile }}</span> is applied, but no milestones fall within the current horizon window.
+        {% else %}
+        No timeline milestones configured. Select a profile above and click Apply to enable timeline tracking.
+        {% endif %}
+      </p>
       {% else %}
       <p class="text-xs text-gray-400">
         No milestone profiles defined.

--- a/tests/test_ai_import_exposures.py
+++ b/tests/test_ai_import_exposures.py
@@ -143,11 +143,11 @@ def test_project_helper_name_match_when_no_address(tmp_db):
 
 
 def _run_ai_exposure_ingest(conn, policy_uid, client_id, exposures, eff_date):
-    """Mirror the exposure loop from _ai_import_parse_inner so we can
-    exercise the same code paths without wiring a Request object.
+    """Mirror the exposure chain from the /ai-import/apply-exposures route.
 
-    Keep this in lock-step with the loop in
-    ``src/policydb/web/routes/policies.py::_ai_import_parse_inner``.
+    This tests the project upsert → client_exposures upsert → link chain
+    without wiring an HTTP Request. Keep in lock-step with
+    ``src/policydb/web/routes/policies.py::policy_ai_import_apply_exposures``.
     """
     year = int(eff_date[:4])
 
@@ -522,3 +522,213 @@ def test_importer_without_exposure_columns_skips_exposure_flow(tmp_db, tmp_path)
     ).fetchone()
     assert pol is not None
     assert get_policy_exposures(conn, pol["policy_uid"]) == []
+
+
+# ── AI import parse route: exposure review (no eager write) ────────────────
+
+
+@pytest.fixture
+def client_and_policy(tmp_db):
+    """Seed a client + policy and yield (client_id, policy_uid)."""
+    conn = get_connection()
+    cid = _seed_client(conn, "Route Test Co")
+    _seed_policy(conn, cid, "POL-7001")
+    conn.commit()
+    return cid, "POL-7001"
+
+
+def _post_parse(policy_uid: str, extracted: dict):
+    """Drive the /ai-import/parse route and return (status, html_body)."""
+    from fastapi.testclient import TestClient
+    from policydb.web.app import app
+    import json
+
+    client = TestClient(app)
+    resp = client.post(
+        f"/policies/{policy_uid}/ai-import/parse",
+        data={"json_text": json.dumps(extracted)},
+    )
+    return resp.status_code, resp.text
+
+
+def _post_apply_exposures(policy_uid: str, year: int, rows: list[dict]):
+    from fastapi.testclient import TestClient
+    from policydb.web.app import app
+
+    client = TestClient(app)
+    resp = client.post(
+        f"/policies/{policy_uid}/ai-import/apply-exposures",
+        json={"year": year, "exposures": rows},
+    )
+    return resp.status_code, resp.json()
+
+
+def test_parse_route_does_not_eager_write_exposures(client_and_policy):
+    """AI parse must build diffs, not write client_exposures."""
+    cid, uid = client_and_policy
+    conn = get_connection()
+
+    status, body = _post_parse(uid, {
+        "effective_date": "2026-05-01",
+        "expiration_date": "2027-05-01",
+        "exposures": [
+            {
+                "exposure_type": "Payroll",
+                "amount": 7500000,
+                "denominator": 100,
+                "unit": "Per $100 Payroll",
+            }
+        ],
+    })
+    assert status == 200
+
+    # Nothing should be in client_exposures or policy_exposure_links yet.
+    exp_count = conn.execute(
+        "SELECT COUNT(*) FROM client_exposures WHERE client_id=?", (cid,)
+    ).fetchone()[0]
+    assert exp_count == 0
+
+    link_count = conn.execute(
+        "SELECT COUNT(*) FROM policy_exposure_links WHERE policy_uid=?", (uid,)
+    ).fetchone()[0]
+    assert link_count == 0
+
+    # The rendered review panel should mention the Exposures section.
+    assert "Exposures" in body
+    assert "Payroll" in body
+    assert "Apply Selected Exposures" in body
+
+
+def test_apply_route_creates_exposure_from_approved_row(client_and_policy):
+    cid, uid = client_and_policy
+
+    status, data = _post_apply_exposures(uid, 2026, [
+        {
+            "exposure_type": "Payroll",
+            "amount": 7500000,
+            "denominator": 100,
+            "unit": "Per $100 Payroll",
+            "is_primary": True,
+        }
+    ])
+    assert status == 200
+    assert data["ok"] is True
+    assert data["applied"] == 1
+
+    conn = get_connection()
+    links = get_policy_exposures(conn, uid)
+    assert len(links) == 1
+    assert links[0]["exposure_type"] == "Payroll"
+    assert links[0]["amount"] == 7500000
+    assert links[0]["year"] == 2026
+    assert links[0]["is_primary"] == 1
+
+
+def test_apply_route_honors_primary_flag_on_non_first_row(client_and_policy):
+    _, uid = client_and_policy
+
+    status, data = _post_apply_exposures(uid, 2026, [
+        {"exposure_type": "Payroll", "amount": 5000000, "denominator": 100,
+         "is_primary": False},
+        {"exposure_type": "Gross Sales", "amount": 25000000, "denominator": 1000,
+         "is_primary": True},
+    ])
+    assert status == 200
+    assert data["applied"] == 2
+
+    conn = get_connection()
+    links = {l["exposure_type"]: l for l in get_policy_exposures(conn, uid)}
+    assert links["Payroll"]["is_primary"] == 0
+    assert links["Gross Sales"]["is_primary"] == 1
+
+
+def test_apply_route_upserts_project_from_address(client_and_policy):
+    cid, uid = client_and_policy
+
+    status, data = _post_apply_exposures(uid, 2026, [
+        {
+            "exposure_type": "Building Value",
+            "amount": 10000000,
+            "denominator": 1,
+            "address": "500 Commerce St",
+            "city": "Dallas",
+            "state": "TX",
+            "zip": "75201",
+            "is_primary": True,
+        }
+    ])
+    assert status == 200
+    assert data["locations_created"] == 1
+
+    conn = get_connection()
+    project = conn.execute(
+        "SELECT id FROM projects WHERE client_id=? AND address='500 Commerce St'",
+        (cid,),
+    ).fetchone()
+    assert project is not None
+
+    # Policy.project_id was stamped because it was previously null.
+    pol = conn.execute(
+        "SELECT project_id FROM policies WHERE policy_uid=?", (uid,)
+    ).fetchone()
+    assert pol["project_id"] == project["id"]
+
+
+def test_apply_route_rejects_missing_year():
+    from fastapi.testclient import TestClient
+    from policydb.web.app import app
+
+    client = TestClient(app)
+    resp = client.post(
+        "/policies/POL-0001/ai-import/apply-exposures",
+        json={"exposures": [{"exposure_type": "Payroll", "amount": 1000}]},
+    )
+    assert resp.status_code == 400
+    assert "year" in resp.json()["error"].lower()
+
+
+def test_apply_route_skips_invalid_rows(client_and_policy):
+    _, uid = client_and_policy
+
+    status, data = _post_apply_exposures(uid, 2026, [
+        {"exposure_type": "", "amount": 1000},       # no type → skipped
+        {"exposure_type": "Payroll", "amount": 0},    # zero amount → skipped
+        {"exposure_type": "Sales", "amount": 500000, "denominator": 1000,
+         "is_primary": True},
+    ])
+    assert status == 200
+    assert data["applied"] == 1
+
+    conn = get_connection()
+    links = get_policy_exposures(conn, uid)
+    assert len(links) == 1
+    assert links[0]["exposure_type"] == "Sales"
+
+
+def test_apply_route_updates_existing_exposure_amount(client_and_policy):
+    """Re-apply with a different amount updates the client_exposures row."""
+    cid, uid = client_and_policy
+
+    # First apply
+    status, _ = _post_apply_exposures(uid, 2026, [
+        {"exposure_type": "Payroll", "amount": 5000000, "denominator": 100,
+         "is_primary": True},
+    ])
+    assert status == 200
+
+    # Second apply with a new amount for the same type/year
+    status, data = _post_apply_exposures(uid, 2026, [
+        {"exposure_type": "Payroll", "amount": 7500000, "denominator": 100,
+         "is_primary": True},
+    ])
+    assert status == 200
+    assert data["applied"] == 1
+
+    conn = get_connection()
+    # Still one row (idempotent on type/year), amount is updated
+    rows = conn.execute(
+        "SELECT amount FROM client_exposures WHERE client_id=? AND exposure_type='Payroll'",
+        (cid,),
+    ).fetchall()
+    assert len(rows) == 1
+    assert rows[0]["amount"] == 7500000

--- a/tests/test_contact_add_no_false_dupe.py
+++ b/tests/test_contact_add_no_false_dupe.py
@@ -1,0 +1,122 @@
+"""Regression: adding an existing contact to a client via the picker must
+not fire the "duplicate contact" warning.
+
+A contact ↔ client relationship is many-to-many (contact_client_assignments),
+so reusing an existing contact row from the picker is the supported flow, not
+a duplicate. The `contact_add` route used to run `_find_similar_contacts` on
+every submit — the exact-name match against the existing row returned itself
+at 100% and surfaced a false-positive warning.
+"""
+import pytest
+
+import policydb.web.app  # noqa: F401 — boot FastAPI app
+
+from policydb.db import get_connection, init_db
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.sqlite"
+    monkeypatch.setattr("policydb.db.DB_PATH", db_path)
+    monkeypatch.setattr("policydb.db.DB_DIR", tmp_path)
+    monkeypatch.setattr("policydb.db.EXPORTS_DIR", tmp_path / "exports")
+    monkeypatch.setattr("policydb.db.CONFIG_PATH", tmp_path / "config.yaml")
+    init_db(path=db_path)
+    return db_path
+
+
+def _seed_client(conn, name):
+    conn.execute(
+        "INSERT INTO clients (name, industry_segment) VALUES (?, 'Construction')",
+        (name,),
+    )
+    return conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+
+def _seed_contact(conn, name, email=None):
+    conn.execute(
+        "INSERT INTO contacts (name, email) VALUES (?, ?)",
+        (name, email),
+    )
+    return conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+
+def test_add_existing_contact_does_not_trigger_duplicate_warning(tmp_db):
+    """Picker → submit exact name → no duplicate warning on the response."""
+    from fastapi.testclient import TestClient
+    from policydb.web.app import app
+
+    conn = get_connection()
+    client_a = _seed_client(conn, "Acme Corp")
+    client_b = _seed_client(conn, "Blue Holdings")
+    # Pre-seed a contact already attached to client A
+    contact_id = _seed_contact(conn, "Alice Johnson", "alice@acme.com")
+    conn.execute(
+        "INSERT INTO contact_client_assignments (contact_id, client_id, contact_type) "
+        "VALUES (?, ?, 'client')",
+        (contact_id, client_a),
+    )
+    conn.commit()
+
+    # Simulate picking Alice from the database list and assigning her to
+    # client B (second client).
+    client = TestClient(app)
+    resp = client.post(
+        f"/clients/{client_b}/contacts/add",
+        data={
+            "name": "Alice Johnson",
+            "email": "alice@acme.com",
+            "phone": "",
+            "mobile": "",
+            "title": "",
+            "role": "",
+            "notes": "",
+        },
+    )
+    assert resp.status_code == 200
+    # The "Possible duplicate" warning block must NOT be present.
+    assert "Possible duplicate" not in resp.text
+    assert "possible duplicate" not in resp.text.lower()
+
+    # Alice should now be linked to BOTH clients via assignments.
+    conn2 = get_connection()
+    assignments = conn2.execute(
+        "SELECT client_id FROM contact_client_assignments WHERE contact_id=?",
+        (contact_id,),
+    ).fetchall()
+    client_ids = {r["client_id"] for r in assignments}
+    assert client_ids == {client_a, client_b}
+
+    # And there should still be exactly one Alice Johnson in contacts.
+    alice_count = conn2.execute(
+        "SELECT COUNT(*) FROM contacts WHERE LOWER(TRIM(name)) = 'alice johnson'"
+    ).fetchone()[0]
+    assert alice_count == 1
+
+
+def test_add_new_contact_near_existing_still_warns(tmp_db):
+    """A genuinely new-but-similar name should still surface the warning."""
+    from fastapi.testclient import TestClient
+    from policydb.web.app import app
+
+    conn = get_connection()
+    client_id = _seed_client(conn, "Acme Corp")
+    _seed_contact(conn, "Alice Johnson", "alice@acme.com")
+    conn.commit()
+
+    client = TestClient(app)
+    resp = client.post(
+        f"/clients/{client_id}/contacts/add",
+        data={
+            "name": "Alice Johnston",  # new name, 1 letter off
+            "email": "",
+            "phone": "",
+            "mobile": "",
+            "title": "",
+            "role": "",
+            "notes": "",
+        },
+    )
+    assert resp.status_code == 200
+    # The similarity check should still fire for a near-match new name.
+    assert "Possible duplicate" in resp.text or "possible duplicate" in resp.text.lower()

--- a/tests/test_issue_scratchpad.py
+++ b/tests/test_issue_scratchpad.py
@@ -1,0 +1,266 @@
+"""Tests for the per-issue working notes (scratchpad) — migration 152.
+
+Mirrors the policy/client scratchpad pattern:
+- Auto-save POST persists content
+- Log-as-activity creates an activity_log row linked to the issue (issue_id)
+  and clears the scratchpad
+- Clear wipes the content without creating an activity
+- Scratchpad is scoped by issue_uid and isolated per issue
+"""
+import pytest
+
+import policydb.web.app  # noqa: F401 — boot FastAPI app
+
+from policydb.db import get_connection, init_db
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.sqlite"
+    monkeypatch.setattr("policydb.db.DB_PATH", db_path)
+    monkeypatch.setattr("policydb.db.DB_DIR", tmp_path)
+    monkeypatch.setattr("policydb.db.EXPORTS_DIR", tmp_path / "exports")
+    monkeypatch.setattr("policydb.db.CONFIG_PATH", tmp_path / "config.yaml")
+    init_db(path=db_path)
+    return db_path
+
+
+def _seed_client(conn, name="Scratch Test Co"):
+    conn.execute(
+        "INSERT INTO clients (name, industry_segment) VALUES (?, 'Construction')",
+        (name,),
+    )
+    return conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+
+def _seed_issue(conn, client_id, issue_uid="ISS-9001", subject="Test issue"):
+    """Insert a manual issue header row and return its (id, issue_uid)."""
+    conn.execute(
+        """INSERT INTO activity_log
+           (activity_date, client_id, activity_type, subject, details,
+            account_exec, item_kind, issue_uid, is_renewal_issue,
+            issue_status, issue_severity)
+           VALUES (date('now'), ?, 'Note', ?, '', 'Grant', 'issue', ?, 0,
+                   'Open', 'Normal')""",
+        (client_id, subject, issue_uid),
+    )
+    issue_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+    conn.commit()
+    return issue_id, issue_uid
+
+
+def test_migration_152_creates_issue_scratchpad_table(tmp_db):
+    conn = get_connection()
+    tables = [
+        r[0] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    ]
+    assert "issue_scratchpad" in tables
+    cols = [r[1] for r in conn.execute("PRAGMA table_info(issue_scratchpad)").fetchall()]
+    assert set(cols) == {"issue_id", "content", "updated_at"}
+
+
+def test_autosave_persists_content(tmp_db):
+    from fastapi.testclient import TestClient
+    from policydb.web.app import app
+
+    conn = get_connection()
+    cid = _seed_client(conn)
+    _, issue_uid = _seed_issue(conn, cid, "ISS-9001")
+
+    client = TestClient(app)
+    resp = client.post(
+        f"/issues/{issue_uid}/scratchpad",
+        data={"content": "Carrier owes us endorsement by Friday."},
+        headers={"Accept": "application/json"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+
+    conn2 = get_connection()
+    row = conn2.execute(
+        """SELECT content FROM issue_scratchpad
+           WHERE issue_id = (SELECT id FROM activity_log WHERE issue_uid = ?)""",
+        (issue_uid,),
+    ).fetchone()
+    assert row is not None
+    assert row["content"] == "Carrier owes us endorsement by Friday."
+
+
+def test_autosave_updates_existing_row(tmp_db):
+    from fastapi.testclient import TestClient
+    from policydb.web.app import app
+
+    conn = get_connection()
+    cid = _seed_client(conn)
+    _, issue_uid = _seed_issue(conn, cid, "ISS-9002")
+
+    client = TestClient(app)
+    client.post(f"/issues/{issue_uid}/scratchpad",
+                data={"content": "first draft"},
+                headers={"Accept": "application/json"})
+    client.post(f"/issues/{issue_uid}/scratchpad",
+                data={"content": "second draft — more specific"},
+                headers={"Accept": "application/json"})
+
+    conn2 = get_connection()
+    rows = conn2.execute(
+        """SELECT content FROM issue_scratchpad
+           WHERE issue_id = (SELECT id FROM activity_log WHERE issue_uid = ?)""",
+        (issue_uid,),
+    ).fetchall()
+    assert len(rows) == 1
+    assert rows[0]["content"] == "second draft — more specific"
+
+
+def test_autosave_404_for_unknown_issue(tmp_db):
+    from fastapi.testclient import TestClient
+    from policydb.web.app import app
+
+    client = TestClient(app)
+    resp = client.post(
+        "/issues/ISS-NOPE/scratchpad",
+        data={"content": "anything"},
+        headers={"Accept": "application/json"},
+    )
+    assert resp.status_code == 404
+
+
+def test_log_as_activity_creates_linked_activity_and_clears(tmp_db):
+    from fastapi.testclient import TestClient
+    from policydb.web.app import app
+
+    conn = get_connection()
+    cid = _seed_client(conn)
+    issue_id, issue_uid = _seed_issue(conn, cid, "ISS-9003")
+
+    client = TestClient(app)
+    # Pre-fill the scratchpad
+    client.post(f"/issues/{issue_uid}/scratchpad",
+                data={"content": "Spoke with UW, waiting on quote rev."},
+                headers={"Accept": "application/json"})
+
+    # Log as activity
+    resp = client.post(
+        "/inbox/scratchpad/process",
+        data={
+            "source": "issue",
+            "scope_id": issue_uid,
+            "activity_type": "Note",
+            "subject": "UW conversation",
+        },
+    )
+    assert resp.status_code == 200
+
+    # A new activity row exists, linked to the issue via issue_id and
+    # carrying the client_id from the issue header.
+    conn2 = get_connection()
+    activity = conn2.execute(
+        """SELECT client_id, issue_id, subject, details
+           FROM activity_log
+           WHERE item_kind != 'issue' AND issue_id = ?
+           ORDER BY id DESC LIMIT 1""",
+        (issue_id,),
+    ).fetchone()
+    assert activity is not None
+    assert activity["client_id"] == cid
+    assert activity["issue_id"] == issue_id
+    assert activity["subject"] == "UW conversation"
+    assert "waiting on quote rev" in activity["details"]
+
+    # Scratchpad is cleared
+    scratch = conn2.execute(
+        "SELECT content FROM issue_scratchpad WHERE issue_id = ?",
+        (issue_id,),
+    ).fetchone()
+    assert scratch["content"] == ""
+
+
+def test_clear_wipes_without_creating_activity(tmp_db):
+    from fastapi.testclient import TestClient
+    from policydb.web.app import app
+
+    conn = get_connection()
+    cid = _seed_client(conn)
+    issue_id, issue_uid = _seed_issue(conn, cid, "ISS-9004")
+
+    client = TestClient(app)
+    client.post(f"/issues/{issue_uid}/scratchpad",
+                data={"content": "junk thoughts, discard me"},
+                headers={"Accept": "application/json"})
+
+    # Capture activity count before clearing
+    conn2 = get_connection()
+    before = conn2.execute(
+        "SELECT COUNT(*) FROM activity_log WHERE item_kind != 'issue' AND issue_id = ?",
+        (issue_id,),
+    ).fetchone()[0]
+
+    resp = client.post(
+        "/inbox/scratchpad/clear",
+        data={"source": "issue", "scope_id": issue_uid},
+    )
+    assert resp.status_code == 200
+
+    conn3 = get_connection()
+    scratch = conn3.execute(
+        "SELECT content FROM issue_scratchpad WHERE issue_id = ?",
+        (issue_id,),
+    ).fetchone()
+    assert scratch["content"] == ""
+
+    after = conn3.execute(
+        "SELECT COUNT(*) FROM activity_log WHERE item_kind != 'issue' AND issue_id = ?",
+        (issue_id,),
+    ).fetchone()[0]
+    assert after == before, "clear must not create activities"
+
+
+def test_scratchpads_are_isolated_per_issue(tmp_db):
+    from fastapi.testclient import TestClient
+    from policydb.web.app import app
+
+    conn = get_connection()
+    cid = _seed_client(conn)
+    id_a, uid_a = _seed_issue(conn, cid, "ISS-9010", "Issue A")
+    id_b, uid_b = _seed_issue(conn, cid, "ISS-9011", "Issue B")
+
+    client = TestClient(app)
+    client.post(f"/issues/{uid_a}/scratchpad",
+                data={"content": "notes for A"},
+                headers={"Accept": "application/json"})
+    client.post(f"/issues/{uid_b}/scratchpad",
+                data={"content": "notes for B"},
+                headers={"Accept": "application/json"})
+
+    conn2 = get_connection()
+    a = conn2.execute(
+        "SELECT content FROM issue_scratchpad WHERE issue_id=?", (id_a,)
+    ).fetchone()
+    b = conn2.execute(
+        "SELECT content FROM issue_scratchpad WHERE issue_id=?", (id_b,)
+    ).fetchone()
+    assert a["content"] == "notes for A"
+    assert b["content"] == "notes for B"
+
+
+def test_issue_detail_page_includes_scratchpad_widget(tmp_db):
+    from fastapi.testclient import TestClient
+    from policydb.web.app import app
+
+    conn = get_connection()
+    cid = _seed_client(conn)
+    _, issue_uid = _seed_issue(conn, cid, "ISS-9020", "Detail render test")
+
+    client = TestClient(app)
+    # Pre-fill so we can assert content is rendered
+    client.post(f"/issues/{issue_uid}/scratchpad",
+                data={"content": "persisted draft"},
+                headers={"Accept": "application/json"})
+
+    resp = client.get(f"/issues/{issue_uid}")
+    assert resp.status_code == 200
+    assert "Working Notes" in resp.text
+    assert "persisted draft" in resp.text
+    assert f"issue-scratchpad-{issue_uid}" in resp.text


### PR DESCRIPTION
This bundles three independent changes that all landed on the same branch after PR #251 merged.

## 1. feat(ai-import): route AI-extracted exposures through the approval flow

The AI policy import was eagerly writing extracted exposures straight to `client_exposures` / `policy_exposure_links` during the parse step, while every other data type (policy fields, locations, COPE, sub-coverages) goes through the AI Review Panel where the user can see the diff and approve row-by-row. This lifts exposures into the same pattern.

**`_ai_import_parse_inner`** — stops writing. Instead builds an `ai_exposure_data` list where each entry has the normalized type/amount/denominator/unit, address fields, a resolved `loc_display`/`loc_action`, a match against the existing `client_exposures` row for the policy's year (for "Update existing" vs "New" badges + amount delta), and an `is_primary_default` flag from the LLM's `is_primary` hint. Invalid entries (no type, zero amount, non-dict) are still shown, but flagged "Skipped — <reason>" and excluded from apply.

**`_ai_review_panel.html`** — new "Exposures" card mirrors the Sub-Coverages layout: one row per entry with select checkbox, Primary radio, match badge (with `(10,200,000 → 5,000,000)` amount delta for updates), and a location disclosure row ("Will create new location X" / "Will attach to existing Y" / "Sets policy location" badge when policy.project_id is unassigned). `applyExposures()` collects the checked rows + primary radio + year and POSTs to the new apply endpoint.

**`POST /policies/{uid}/ai-import/apply-exposures`** — the write path that used to live in parse. Upserts the project from address (or uses the `matched_project_id` passed from the diff), upserts the `client_exposures` row, creates/refreshes the link, and stamps `policies.project_id` only when it was previously unassigned. Also updates `amount`/`denominator` on an existing `client_exposures` row when the value changed (the find-or-create helper was insert-only, so re-applies with a new amount silently didn't take effect).

Tests (`tests/test_ai_import_exposures.py`): 7 new cases — parse doesn't eager-write, apply creates from an approved row, honors the primary flag on a non-first row, upserts a project from address + stamps policy.project_id, rejects missing year, skips invalid rows server-side, and updates an existing amount on re-apply.

## 2. fix(contacts): stop false-positive duplicate warning when attaching existing contact to client

A contact ↔ client relationship is many-to-many via `contact_client_assignments`, so reusing an existing contact from the "Search & assign existing contact" picker is the supported flow — not a duplicate. The picker submits the selected contact's exact name to `/clients/{id}/contacts/add`, and the route ran `_find_similar_contacts` on every submit. The fuzzy name match found the existing row at 100% and surfaced a "Possible duplicate" warning on the response, making it look like adding from the database list was creating a dupe.

**Fix:** before running the similarity check, probe `contacts` for an exact (case/whitespace-insensitive) name match. If one exists, skip the fuzzy check — the route will still call `get_or_create_contact` → reuse the row → insert a new `contact_client_assignments` junction row, which is the intended many-to-many flow. A genuinely new-but-similar name still surfaces the warning.

Tests (`tests/test_contact_add_no_false_dupe.py`): 2 cases — "Alice already on Acme, assign her to Blue Holdings → no warning, both assignments exist, one Alice in contacts", and "Alice Johnston (1-letter-off new name) still warns".

## 3. feat(issues): add scratchpad working notes to the issue view

Issues now get the same auto-saving working-notes widget that already exists on clients, policies, projects, and the dashboard. Free-form thinking goes in the scratchpad while you work an issue; when it's ready to become part of the record you click "Log as Activity" and it becomes a proper `activity_log` row linked to the issue (via `issue_id` FK), with the scratchpad cleared for the next thought.

**Migration 152** — `issue_scratchpad` table keyed on `activity_log.id` (issue headers live on `activity_log`). Mirrors the client/policy/project scratchpad schema: `content TEXT + updated_at DATETIME` + update trigger. Wired into `init_db()` with version check.

**Template** `issues/_scratchpad.html` mirrors `policies/_scratchpad.html` — 800ms debounced autosave via fetch, markdown editor when available, "Log as Activity" / "Clear" buttons, "saved <ts>" indicator. Uses the existing `window.logScratchCombined` / `window.clearScratch` helpers, so the integration with `/inbox/scratchpad/process` and `/inbox/scratchpad/clear` was mostly already there.

**Routes:**
- `issue_detail()` loads the scratchpad row and passes `issue_scratchpad` + `issue_scratchpad_updated` to the template context
- New `POST /issues/{issue_uid}/scratchpad` autosave endpoint (returns JSON or partial)
- `inbox.py::scratchpad_process` + `scratchpad_clear` extended for `source="issue"` — `scope_id` is the `issue_uid`, which we resolve to `activity_log.id` and use to pull `client_id`/`policy_id`/`project_id` from the issue header so the resulting activity inherits the right parents
- Added `issue_id` to the scratchpad `activity_log` INSERT. Previously scratchpad activities never linked to issues. Now they link automatically when the source is an issue (NULL for other sources)

**Placement:** scratchpad sits in the left column between the Activity Timeline and the Log Activity panel — the logical spot for in-progress thinking about what to do next.

Tests (`tests/test_issue_scratchpad.py`): 8 cases — table migration, autosave insert, autosave upsert, 404 on unknown issue_uid, log-as-activity creates a linked row + clears, clear wipes without creating an activity, scratchpads are isolated per issue, issue detail GET renders the widget + prefilled content.

## Test plan

- [x] Full suite: 548 passed (up from 538)
- [x] Exposure review: end-to-end curl — parse does not write, response includes exposures section with per-row match badges, apply POST creates linked exposures with correct primary flag, locations upsert from address
- [x] Contact fix: unit test + manual reasoning from picker POST path
- [x] Issue scratchpad: end-to-end curl on real issue — autosave persisted, issue detail page renders the widget with pre-filled content + saved timestamp, Log as Activity creates an activity linked via `issue_id` and clears the scratchpad