### PR TITLE
fix(outlook): repair contact sync + folder-toggle scroll jump

### DIFF
--- a/.claude/skills/policydb-outlook/SKILL.md
+++ b/.claude/skills/policydb-outlook/SKILL.md
@@ -17,6 +17,8 @@ Two-way integration with Legacy Outlook for Mac via `osascript` subprocess calls
 | File | Purpose |
 |------|---------|
 | `src/policydb/outlook.py` | AppleScript bridge — `create_draft()`, `search_emails()`, `search_all_folders()`, `get_flagged_emails()`, `is_outlook_available()` |
+| `src/policydb/outlook_contacts.py` | AppleScript bridge for contacts — `ensure_pdb_category()`, `list_pdb_contacts()`, `upsert_contact()`, `delete_contact()`, `split_name()` |
+| `src/policydb/contact_sync.py` | Contact push orchestrator — PolicyDB → Outlook, fenced by PDB category, one-way |
 | `src/policydb/email_sync.py` | Sweep orchestrator — ref tag extraction, resolution, activity creation/enrichment, inbox routing |
 | `src/policydb/web/routes/outlook_routes.py` | Routes: `POST /outlook/compose`, `POST /outlook/sync`, `GET /outlook/status` |
 | `src/policydb/web/templates/outlook/_sync_results.html` | Sync results banner (fixed bottom of viewport) |
@@ -210,6 +212,50 @@ Emails almost always include multiple Marsh colleague addresses in CC/TO. Withou
 7. **`mail folder of msg`** — NOT a valid property; track folder name during iteration instead
 8. **JSON output** — AppleScript has no native JSON; build JSON strings manually with escaping helpers (`escJSON`, `padNum`, `replaceText`)
 9. **Timeout** — 30s per `osascript` call; cap at 500 messages per folder scan
+10. **`try` does NOT catch compile errors.** Unknown property names (e.g. `business phone` instead of `business phone number`) fail the whole script at parse time with `-2741 "Expected end of line but found property"`, before any `try` block runs. Probe the real dictionary with `properties of (first X)` before writing any new bridge function. See `reference_outlook_contact_properties.md` memory for the verified Outlook `contact` property list.
+11. **Notes line endings** — use `linefeed` (LF), not `return` (CR) when building multi-line strings for Outlook note fields; mac apps render bare CRs as one long line.
+12. **Local var names collide with app vocabulary inside `tell` blocks.** `set company to ""` resolves as the app's `company` property and crashes with `-10006`. Prefix locals with `v` (`vCompany`, `vNote`) or pick non-reserved names.
+13. **Nested reference iteration returns empty property reads.** `repeat with cat in (categories of c)` when `c` came from `every contact` gives category refs whose `name of cat` silently returns `""`. Fix: `set catList to get categories of (contents of c)` then iterate `catList`.
+14. **`existingList & scalar` fails when `existingList` is empty.** AppleScript tries to coerce the scalar to type `vector` and errors with `-1700`. Always wrap: `existingList & {scalar}`.
+15. **`email addresses` records need BOTH `address` and `type class`.** Setting `{{address:"x"}}` alone fails `-1700`. Use `{{address:"x", type class:work}}`.
+16. **`plain text note` strips newlines on read**; `note` preserves them. Prefer `note` for round-tripping plain-text.
+17. **Outlook category colors are RGB triples, not `category color N` enum.** Omit the color arg (let Outlook pick) or supply `{r,g,b}` 16-bit ints.
+
+## Contact Sync (PolicyDB → Outlook)
+
+One-way push; PolicyDB is source of truth. Fenced by a user-configurable category (`outlook_contact_category`, default "PDB"). Orchestrated in `contact_sync.sync_contacts_to_outlook`, runs at the end of `/outlook/sync`.
+
+### Push set
+Every contact with at least one `contact_client_assignments` row on a non-archived client. Preferred client assignment (primary → oldest) drives `job_title` and `business_street_address`. Field mapping in `_row_to_payload`:
+
+| PolicyDB | Outlook | Notes |
+|---|---|---|
+| `contacts.name` | `first name` / `last name` / `display name` | Split via `split_name()` (honorifics + suffixes stripped) |
+| `contacts.email` | `email addresses[0].address` | Sanitized via `clean_email()` |
+| `contacts.phone` | `business phone number` | Normalized via `format_phone()` |
+| `contacts.mobile` | `mobile number` | Normalized via `format_phone()` |
+| `contacts.organization` | `company` | — |
+| `cca.title` | `job title` | From preferred assignment |
+| `contacts.expertise_notes` | `note` (truncated 5000 chars, LF line endings) | — |
+| `clients.address` | `business street address` (plain string) | From preferred assignment |
+
+### Safety fences
+- **PDB category is the escape hatch** — `list_pdb_contacts` only returns contacts carrying the category, and `delete_contact` refuses to delete a contact missing it. Untagging in Outlook removes a contact from sync scope.
+- **Empty push set + tracked ids → abort** — if DB has `outlook_contact_id` pointers but Outlook returns zero tagged contacts, the sync stops instead of recreating everything (category likely renamed/deleted).
+- **Archived clients excluded** — the push set query filters `archived = 0`.
+- **Delete phase is opt-in** — gated by `outlook_contact_allow_deletes` config; only deletes contacts that (a) carry PDB tag and (b) are tracked in `contacts.outlook_contact_id`.
+
+### Config keys
+| Key | Default | Purpose |
+|---|---|---|
+| `outlook_contact_sync_enabled` | `true` | Master toggle |
+| `outlook_contact_category` | `"PDB"` | Safety-fence category name |
+| `outlook_contact_allow_deletes` | `true` | Allow push-set orphans to be deleted |
+
+All editable in Settings → Email & Contacts. Reset button clears every `outlook_contact_id`.
+
+### Migration 148
+Adds `outlook_contact_id TEXT` to `contacts`.
 
 ## Email Snippet Display
 

--- a/src/policydb/contact_sync.py
+++ b/src/policydb/contact_sync.py
@@ -44,6 +44,7 @@ def _empty_result(**overrides) -> dict:
         "skipped_orphan": 0,
         "skipped_archived": 0,
         "skipped_email": 0,
+        "skipped_untagged": 0,
         "skipped_unavailable": False,
         "errors": [],
         "ambiguous_bootstrap": [],
@@ -258,6 +259,7 @@ def sync_contacts_to_outlook(conn: sqlite3.Connection) -> dict:
         remote = remote_by_id.get(tracked_id) if tracked_id else None
 
         # Bootstrap path — no tracked id yet
+        ambiguous = False
         if not tracked_id:
             candidates: list[dict] = []
             if email:
@@ -269,14 +271,39 @@ def sync_contacts_to_outlook(conn: sqlite3.Connection) -> dict:
                 result["ambiguous_bootstrap"].append(email)
                 remote = None
                 tracked_id = None
+                ambiguous = True
+
+        if ambiguous:
+            # Refuse to act when email matches multiple PDB contacts — creating
+            # a third row just compounds the mess. User must de-dup in Outlook
+            # or pick one in PolicyDB's outlook_contact_id.
+            continue
 
         try:
             if remote is None:
-                upsert = upsert_contact(payload, outlook_id=None, category_name=category_name)
+                # Either: truly new (no tracked id), or tracked id no longer
+                # appears under the PDB category (user untagged, deleted, or
+                # renamed the category). Passing tracked_id lets upsert_contact
+                # detect the "untagged" case and honor the escape hatch.
+                upsert = upsert_contact(
+                    payload,
+                    outlook_id=tracked_id,
+                    category_name=category_name,
+                )
                 if not upsert.get("ok"):
                     result["errors"].append(
                         f"Create failed for {row.get('name')}: {upsert.get('error', 'unknown')}"
                     )
+                    continue
+                if upsert.get("skipped_untagged"):
+                    # User untagged this contact in Outlook — clear pointer
+                    # and leave them alone.
+                    conn.execute(
+                        "UPDATE contacts SET outlook_contact_id=NULL WHERE id=?",
+                        (row["contact_id"],),
+                    )
+                    conn.commit()
+                    result["skipped_untagged"] += 1
                     continue
                 new_id = upsert.get("outlook_id") or upsert.get("raw")
                 if new_id:
@@ -298,6 +325,14 @@ def sync_contacts_to_outlook(conn: sqlite3.Connection) -> dict:
                         result["errors"].append(
                             f"Update failed for {row.get('name')}: {upsert.get('error', 'unknown')}"
                         )
+                        continue
+                    if upsert.get("skipped_untagged"):
+                        conn.execute(
+                            "UPDATE contacts SET outlook_contact_id=NULL WHERE id=?",
+                            (row["contact_id"],),
+                        )
+                        conn.commit()
+                        result["skipped_untagged"] += 1
                         continue
                     result["updated"] += 1
                 # Even if no update, adopt the id so delete phase doesn't

--- a/src/policydb/outlook_contacts.py
+++ b/src/policydb/outlook_contacts.py
@@ -76,8 +76,9 @@ tell application "Microsoft Outlook"
     set catName to "{esc_name}"
     set foundCat to false
     try
-        repeat with c in categories
-            if name of c is catName then
+        set allCats to get categories
+        repeat with c in allCats
+            if (name of c) as text is catName then
                 set foundCat to true
                 exit repeat
             end if
@@ -85,7 +86,10 @@ tell application "Microsoft Outlook"
     end try
     if not foundCat then
         try
-            make new category with properties {{name:catName, color:category color 7}}
+            -- Outlook's color property is an RGB triple, not an enum.
+            -- Omitting it lets Outlook pick the default swatch; the user can
+            -- recolor the PDB category in Outlook if they want a specific hue.
+            make new category with properties {{name:catName}}
         on error errMsg
             return "{{\\"ok\\": false, \\"error\\": \\"" & my escJSON(errMsg) & "\\"}}"
         end try
@@ -127,83 +131,92 @@ tell application "Microsoft Outlook"
         if matchCount >= 500 then exit repeat
         set hasPdb to false
         try
-            repeat with cat in (categories of c)
-                if name of cat is "{esc_name}" then
+            -- `get ... of (contents of c)` forces reference resolution so the
+            -- inner repeat sees concrete category objects. Without the dual
+            -- dereference, `name of cat` silently returns empty strings when
+            -- iterating `every contact`.
+            set catList to get categories of (contents of c)
+            repeat with cat in catList
+                if (name of cat) as text is "{esc_name}" then
                     set hasPdb to true
                     exit repeat
                 end if
             end repeat
         end try
         if hasPdb then
-            set cId to ""
-            set firstName to ""
-            set lastName to ""
-            set displayName to ""
-            set company to ""
-            set jobTitle to ""
-            set emailAddr to ""
-            set bizPhone to ""
-            set mobPhone to ""
-            set notesText to ""
-            set addrStreet to ""
+            -- Local var names are prefixed `v` to avoid clashing with Outlook's
+            -- AppleScript vocabulary inside the `tell` block. Plain names like
+            -- `company` or `note` get resolved against the app's property
+            -- namespace and cause -10006 "Can't set X to ..." errors.
+            set vId to ""
+            set vFirst to ""
+            set vLast to ""
+            set vDisplay to ""
+            set vCompany to ""
+            set vTitle to ""
+            set vEmail to ""
+            set vBizPhone to ""
+            set vMobPhone to ""
+            set vNote to ""
+            set vStreet to ""
             try
-                set cId to (id of c) as text
+                set vId to (id of c) as text
             end try
             try
-                set firstName to first name of c
+                set vFirst to first name of c
             end try
             try
-                set lastName to last name of c
+                set vLast to last name of c
             end try
             try
-                set displayName to display name of c
+                set vDisplay to display name of c
             end try
             try
-                set company to company of c
+                set vCompany to company of c
             end try
             try
-                set jobTitle to job title of c
+                set vTitle to job title of c
             end try
             try
                 set emails to email addresses of c
                 if (count of emails) > 0 then
                     try
-                        set emailAddr to address of item 1 of emails
+                        set vEmail to address of item 1 of emails
                     end try
                 end if
             end try
             try
-                set bizPhone to business phone of c
+                set vBizPhone to business phone number of c
             end try
             try
-                set mobPhone to mobile phone of c
+                set vMobPhone to mobile number of c
             end try
             try
-                set notesText to plain text content of c
+                -- `note` preserves newlines; `plain text note` strips them.
+                -- Prefer `note` and fall back to `plain text note` if the
+                -- field holds rich formatting we can't round-trip.
+                set vNote to note of c
             on error
                 try
-                    set notesText to notes of c
+                    set vNote to plain text note of c
                 end try
             end try
             try
-                set ba to business address of c
-                try
-                    set addrStreet to street of ba
-                end try
+                set vStreet to business street address of c
             end try
-            set cId to my escJSON(cId)
-            set firstName to my escJSON(firstName)
-            set lastName to my escJSON(lastName)
-            set displayName to my escJSON(displayName)
-            set company to my escJSON(company)
-            set jobTitle to my escJSON(jobTitle)
-            set emailAddr to my escJSON(emailAddr)
-            set bizPhone to my escJSON(bizPhone)
-            set mobPhone to my escJSON(mobPhone)
-            set notesText to my escJSON(notesText)
-            set addrStreet to my escJSON(addrStreet)
+            set vId to my escJSON(vId)
+            set vFirst to my escJSON(vFirst)
+            set vLast to my escJSON(vLast)
+            set vDisplay to my escJSON(vDisplay)
+            set vCompany to my escJSON(vCompany)
+            set vTitle to my escJSON(vTitle)
+            set vEmail to my escJSON(vEmail)
+            set vBizPhone to my escJSON(vBizPhone)
+            set vMobPhone to my escJSON(vMobPhone)
+            set vNote to my escJSON(vNote)
+            set vStreet to my escJSON(vStreet)
             if matchCount > 0 then set output to output & ","
-            set output to output & "{{\\"outlook_id\\":\\"" & cId & "\\",\\"first_name\\":\\"" & firstName & "\\",\\"last_name\\":\\"" & lastName & "\\",\\"display_name\\":\\"" & displayName & "\\",\\"company\\":\\"" & company & "\\",\\"job_title\\":\\"" & jobTitle & "\\",\\"email\\":\\"" & emailAddr & "\\",\\"business_phone\\":\\"" & bizPhone & "\\",\\"mobile_phone\\":\\"" & mobPhone & "\\",\\"notes\\":\\"" & notesText & "\\",\\"business_address_street\\":\\"" & addrStreet & "\\"}}"
+            set output to output & "{{\\"outlook_id\\":\\"" & vId & "\\",\\"first_name\\":\\"" & vFirst & "\\",\\"last_name\\":\\"" & vLast & "\\",\\"display_name\\":\\"" & vDisplay & "\\",\\"company\\":\\"" & vCompany & "\\",\\"job_title\\":\\"" & vTitle & "\\",\\"email\\":\\"" & vEmail & "\\",\\"business_phone\\":\\"" & vBizPhone & "\\",\\"mobile_phone\\":\\"" & vMobPhone & "\\",\\"notes\\":\\"" & vNote & "\\",\\"business_address_street\\":\\"" & vStreet & "\\"}}"
             set matchCount to matchCount + 1
         end if
     end repeat
@@ -231,16 +244,18 @@ return output
 # ─── upsert_contact ─────────────────────────────────────────────────────────
 
 
-# Outlook's `notes` field accepts newlines but the AppleScript source cannot
-# contain a raw newline inside a quoted string. The bridge uses `return & `
-# concatenation for multi-line notes instead of embedding \n directly.
+# Outlook's `note` field accepts newlines but the AppleScript source cannot
+# contain a raw newline inside a quoted string. The bridge uses `linefeed &`
+# concatenation (LF, matching modern macOS line endings) for multi-line notes
+# instead of embedding \n directly. Using `return` (CR) here causes some mac
+# apps to render the whole note as one long line.
 _NOTES_TRUNCATE = 5000
 
 
 def _notes_to_applescript_expr(text: str) -> str:
-    """Build an AppleScript expression that concatenates quoted lines with `return`.
+    """Build an AppleScript expression that concatenates quoted lines with `linefeed`.
 
-    Example: "hello\nworld" -> "\"hello\" & return & \"world\""
+    Example: "hello\nworld" -> "\"hello\" & linefeed & \"world\""
     Empty text returns "\"\"" for safe assignment.
     """
     if not text:
@@ -248,7 +263,7 @@ def _notes_to_applescript_expr(text: str) -> str:
     text = text[:_NOTES_TRUNCATE]
     lines = text.splitlines() or [""]
     parts = [f'"{_escape_for_applescript(line)}"' for line in lines]
-    return " & return & ".join(parts)
+    return " & linefeed & ".join(parts)
 
 
 def upsert_contact(
@@ -286,27 +301,41 @@ def upsert_contact(
     esc_street = _escape_for_applescript(payload.get("business_address_street", "") or "")
     notes_expr = _notes_to_applescript_expr(payload.get("notes", "") or "")
 
-    # Locate or create
+    # Locate or create. When a tracked id is provided AND the contact still
+    # exists but no longer carries the category, honor the user's "untag to
+    # remove from sync" escape hatch: return {skipped_untagged: true} so the
+    # orchestrator can clear the DB pointer instead of creating a duplicate.
     if outlook_id:
         esc_id = _escape_for_applescript(str(outlook_id))
-        # Look up contact by stored id. If not found, fall through to create.
         locator = f'''
     set targetContact to missing value
-    try
-        repeat with c in (every contact)
-            try
-                if ((id of c) as text) is "{esc_id}" then
-                    set targetContact to c
+    set allContacts to every contact
+    repeat with c in allContacts
+        try
+            if ((id of (contents of c)) as text) is "{esc_id}" then
+                set targetContact to contents of c
+                exit repeat
+            end if
+        end try
+    end repeat
+    if targetContact is not missing value then
+        set hasPdbCat to false
+        try
+            set catList to get categories of (contents of targetContact)
+            repeat with cat in catList
+                if (name of cat) as text is "{esc_cat}" then
+                    set hasPdbCat to true
                     exit repeat
                 end if
-            end try
-        end repeat
-    end try
-    if targetContact is missing value then
+            end repeat
+        end try
+        if not hasPdbCat then
+            return "{{\\"ok\\":true,\\"outlook_id\\":\\"{esc_id}\\",\\"skipped_untagged\\":true}}"
+        end if
+        set wasCreated to false
+    else
         set targetContact to make new contact with properties {{first name:"{esc_first}", last name:"{esc_last}"}}
         set wasCreated to true
-    else
-        set wasCreated to false
     end if
 '''
     else:
@@ -337,11 +366,10 @@ tell application "Microsoft Outlook"
     end try
     if "{esc_email}" is not "" then
         try
-            set email addresses of targetContact to {{{{address:"{esc_email}"}}}}
-        on error
-            try
-                set email address of targetContact to "{esc_email}"
-            end try
+            -- Outlook requires both `address` and `type class` in the record;
+            -- providing only `address` fails with -1700 "Contact e-mail address
+            -- is incorrect (one or more fields may be missing)."
+            set email addresses of targetContact to {{{{address:"{esc_email}", type class:work}}}}
         end try
     else
         try
@@ -349,38 +377,41 @@ tell application "Microsoft Outlook"
         end try
     end if
     try
-        set business phone of targetContact to "{esc_biz_phone}"
+        set business phone number of targetContact to "{esc_biz_phone}"
     end try
     try
-        set mobile phone of targetContact to "{esc_mob_phone}"
+        set mobile number of targetContact to "{esc_mob_phone}"
     end try
     try
-        set notes of targetContact to ({notes_expr})
+        set note of targetContact to ({notes_expr})
     end try
     if "{esc_street}" is not "" then
         try
-            set business address of targetContact to {{{{street:"{esc_street}"}}}}
+            set business street address of targetContact to "{esc_street}"
         end try
     end if
     try
         set pdbCat to missing value
-        repeat with cat in categories
-            if name of cat is "{esc_cat}" then
-                set pdbCat to cat
+        set allCats to get categories
+        repeat with cat in allCats
+            if (name of cat) as text is "{esc_cat}" then
+                set pdbCat to contents of cat
                 exit repeat
             end if
         end repeat
         if pdbCat is not missing value then
-            set existingCats to categories of targetContact
+            set existingCats to get categories of (contents of targetContact)
             set alreadyTagged to false
             repeat with ec in existingCats
-                if name of ec is "{esc_cat}" then
+                if (name of ec) as text is "{esc_cat}" then
                     set alreadyTagged to true
                     exit repeat
                 end if
             end repeat
             if not alreadyTagged then
-                set categories of targetContact to (existingCats & pdbCat)
+                -- Concatenate as list-of-one; `existingCats & pdbCat` fails
+                -- with a coercion error when existingCats is empty.
+                set categories of targetContact to (existingCats & {{pdbCat}})
             end if
         end if
     end try
@@ -417,23 +448,23 @@ def delete_contact(outlook_id: str, category_name: str = DEFAULT_CATEGORY) -> di
     script = f'''
 tell application "Microsoft Outlook"
     set targetContact to missing value
-    try
-        repeat with c in (every contact)
-            try
-                if ((id of c) as text) is "{esc_id}" then
-                    set targetContact to c
-                    exit repeat
-                end if
-            end try
-        end repeat
-    end try
+    set allContacts to every contact
+    repeat with c in allContacts
+        try
+            if ((id of (contents of c)) as text) is "{esc_id}" then
+                set targetContact to contents of c
+                exit repeat
+            end if
+        end try
+    end repeat
     if targetContact is missing value then
         return "{{\\"ok\\":true,\\"deleted\\":false,\\"reason\\":\\"not_found\\"}}"
     end if
     set hasPdb to false
     try
-        repeat with cat in (categories of targetContact)
-            if name of cat is "{esc_cat}" then
+        set catList to get categories of targetContact
+        repeat with cat in catList
+            if (name of cat) as text is "{esc_cat}" then
                 set hasPdb to true
                 exit repeat
             end if

--- a/src/policydb/web/routes/settings.py
+++ b/src/policydb/web/routes/settings.py
@@ -517,7 +517,13 @@ def email_sync_folder_toggle(
     include: int = Form(...),
     conn=Depends(get_db),
 ):
-    """Flip include_in_crawl for a single folder. Called from the settings UI toggle."""
+    """Flip include_in_crawl for a single folder.
+
+    Returns ONLY the affected row (outerHTML-swapped by HTMX) so the
+    surrounding table isn't re-rendered — that swap reset the browser's
+    scroll position and yanked the user away from the folder they were
+    working on.
+    """
     include_val = 1 if include else 0
     conn.execute(
         """UPDATE outlook_folder_sync
@@ -526,7 +532,20 @@ def email_sync_folder_toggle(
         (include_val, folder_path),
     )
     conn.commit()
-    return _render_folder_rows(request, conn)
+
+    row = conn.execute(
+        """SELECT folder_path, folder_kind, include_in_crawl,
+                  last_synced_at, message_count, match_count, last_error
+           FROM outlook_folder_sync WHERE folder_path = ?""",
+        (folder_path,),
+    ).fetchone()
+    if row is None:
+        # Row vanished between click and handler — fall back to full rebuild
+        return _render_folder_rows(request, conn)
+    return templates.TemplateResponse(
+        "settings/_email_sync_folder_row.html",
+        {"request": request, "f": dict(row)},
+    )
 
 
 @router.post("/email-sync/toggle-comprehensive", response_class=HTMLResponse)

--- a/src/policydb/web/templates/settings/_email_sync_folder_row.html
+++ b/src/policydb/web/templates/settings/_email_sync_folder_row.html
@@ -1,0 +1,55 @@
+{#
+  Single folder row + (optional) error sub-row. Used both by the full rows
+  partial and by the folder-toggle endpoint so a toggle click swaps only the
+  affected row in place — preserves the user's scroll position instead of
+  re-rendering the whole table and bouncing the viewport to the top.
+#}
+<tr id="email-sync-folder-{{ f.folder_path | replace('/', '__') | replace(' ', '_') }}"
+    class="{% if not f.include_in_crawl %}text-gray-400{% endif %}">
+  <td class="py-1 pr-2 font-mono" title="{{ f.folder_path }}">
+    {% set parts = f.folder_path.split('/') %}
+    {% if parts|length > 1 %}
+      <span class="text-gray-300">{{ parts[:-1] | join('/') }}/</span>{{ parts[-1] }}
+    {% else %}
+      {{ f.folder_path }}
+    {% endif %}
+  </td>
+  <td class="py-1 px-2">
+    {% set kind_color = {
+      'inbox': 'bg-blue-50 text-blue-700',
+      'sent': 'bg-green-50 text-green-700',
+      'archive': 'bg-amber-50 text-amber-700',
+      'drafts': 'bg-gray-100 text-gray-500',
+      'system': 'bg-gray-100 text-gray-500',
+      'custom': 'bg-slate-50 text-slate-600',
+    }.get(f.folder_kind, 'bg-gray-100 text-gray-500') %}
+    <span class="px-1.5 py-0.5 rounded {{ kind_color }} text-xs">{{ f.folder_kind or 'custom' }}</span>
+  </td>
+  <td class="py-1 px-2 text-right tabular-nums">{{ f.message_count or 0 }}</td>
+  <td class="py-1 px-2 text-right tabular-nums">{{ f.match_count or 0 }}</td>
+  <td class="py-1 px-2 text-gray-500">
+    {% if f.last_synced_at %}{{ f.last_synced_at[:16] }}{% else %}—{% endif %}
+  </td>
+  <td class="py-1 pl-2 text-center">
+    {# Per-row swap keeps the user's scroll position. hx-target="closest tr"
+       with outerHTML replaces only this row; the surrounding table is
+       untouched, so the browser doesn't reflow and jump to the top. #}
+    <label class="toggle-switch align-middle"
+           title="{% if f.include_in_crawl %}Crawling — click to exclude{% else %}Excluded — click to include{% endif %}">
+      <input type="checkbox"
+             {% if f.include_in_crawl %}checked{% endif %}
+             hx-post="/settings/email-sync/folder-toggle"
+             hx-vals='js:{folder_path: {{ f.folder_path | tojson }}, include: event.target.checked ? 1 : 0}'
+             hx-target="closest tr"
+             hx-swap="outerHTML"
+             hx-trigger="change"
+             aria-label="{% if f.include_in_crawl %}Exclude folder from crawl{% else %}Include folder in crawl{% endif %}">
+      <span class="toggle-track"></span>
+    </label>
+  </td>
+</tr>
+{% if f.last_error %}
+<tr class="text-red-500">
+  <td colspan="6" class="py-0.5 px-2 text-xs italic">⚠ {{ f.last_error }}</td>
+</tr>
+{% endif %}

--- a/src/policydb/web/templates/settings/_email_sync_folders_rows.html
+++ b/src/policydb/web/templates/settings/_email_sync_folders_rows.html
@@ -17,55 +17,7 @@
   </thead>
   <tbody class="divide-y divide-gray-100">
     {% for f in outlook_folders %}
-    <tr class="{% if not f.include_in_crawl %}text-gray-400{% endif %}">
-      <td class="py-1 pr-2 font-mono" title="{{ f.folder_path }}">
-        {% set parts = f.folder_path.split('/') %}
-        {% if parts|length > 1 %}
-          <span class="text-gray-300">{{ parts[:-1] | join('/') }}/</span>{{ parts[-1] }}
-        {% else %}
-          {{ f.folder_path }}
-        {% endif %}
-      </td>
-      <td class="py-1 px-2">
-        {% set kind_color = {
-          'inbox': 'bg-blue-50 text-blue-700',
-          'sent': 'bg-green-50 text-green-700',
-          'archive': 'bg-amber-50 text-amber-700',
-          'drafts': 'bg-gray-100 text-gray-500',
-          'system': 'bg-gray-100 text-gray-500',
-          'custom': 'bg-slate-50 text-slate-600',
-        }.get(f.folder_kind, 'bg-gray-100 text-gray-500') %}
-        <span class="px-1.5 py-0.5 rounded {{ kind_color }} text-xs">{{ f.folder_kind or 'custom' }}</span>
-      </td>
-      <td class="py-1 px-2 text-right tabular-nums">{{ f.message_count or 0 }}</td>
-      <td class="py-1 px-2 text-right tabular-nums">{{ f.match_count or 0 }}</td>
-      <td class="py-1 px-2 text-gray-500">
-        {% if f.last_synced_at %}{{ f.last_synced_at[:16] }}{% else %}—{% endif %}
-      </td>
-      <td class="py-1 pl-2 text-center">
-        {# CSS toggle-switch — standard project pattern for boolean state.
-           hx-vals uses `js:{}` mode so HTMX evaluates folder_path as a JS
-           expression (resistant to apostrophes in mailbox paths, which
-           would otherwise break a single-quoted attr). #}
-        <label class="toggle-switch align-middle"
-               title="{% if f.include_in_crawl %}Crawling — click to exclude{% else %}Excluded — click to include{% endif %}">
-          <input type="checkbox"
-                 {% if f.include_in_crawl %}checked{% endif %}
-                 hx-post="/settings/email-sync/folder-toggle"
-                 hx-vals='js:{folder_path: {{ f.folder_path | tojson }}, include: event.target.checked ? 1 : 0}'
-                 hx-target="#email-sync-folder-rows"
-                 hx-swap="innerHTML"
-                 hx-trigger="change"
-                 aria-label="{% if f.include_in_crawl %}Exclude folder from crawl{% else %}Include folder in crawl{% endif %}">
-          <span class="toggle-track"></span>
-        </label>
-      </td>
-    </tr>
-    {% if f.last_error %}
-    <tr class="text-red-500">
-      <td colspan="6" class="py-0.5 px-2 text-xs italic">⚠ {{ f.last_error }}</td>
-    </tr>
-    {% endif %}
+      {% include "settings/_email_sync_folder_row.html" %}
     {% endfor %}
   </tbody>
 </table>

--- a/tests/test_outlook_contacts_compile.py
+++ b/tests/test_outlook_contacts_compile.py
@@ -1,0 +1,141 @@
+"""Compile-only smoke test for the Outlook contact AppleScript bridges.
+
+AppleScript try/end try blocks only catch RUNTIME errors. A bad property
+name (e.g. `business phone` vs `business phone number`) is a COMPILE error
+that aborts the whole script before any try runs. Before the April 2026 bug
+hunt, outlook_contacts.py had five such errors and contact sync never
+worked. This test prevents regressions by shelling out to `osacompile` on
+every script that outlook_contacts.py produces.
+
+Skipped automatically when osacompile isn't available (non-mac CI).
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# The worktree's src/ must beat the editable-installed main repo copy so we
+# test the code on THIS branch rather than whatever's installed globally.
+_WORKTREE_SRC = Path(__file__).resolve().parent.parent / "src"
+if str(_WORKTREE_SRC) not in sys.path:
+    sys.path.insert(0, str(_WORKTREE_SRC))
+
+# Force-reimport in case policydb was already loaded from the install path
+for mod_name in list(sys.modules):
+    if mod_name == "policydb" or mod_name.startswith("policydb."):
+        del sys.modules[mod_name]
+
+from policydb import outlook_contacts  # noqa: E402
+
+HAS_OSACOMPILE = shutil.which("osacompile") is not None
+
+
+def _capture_scripts(fn, *args, **kwargs) -> list[str]:
+    """Invoke fn and return every AppleScript string it would have run."""
+    captured: list[str] = []
+
+    real_run = subprocess.run
+
+    def fake_run(cmd, *a, **kw):
+        if cmd and cmd[0] == "osascript" and "-e" in cmd:
+            captured.append(cmd[cmd.index("-e") + 1])
+        class _R:
+            returncode = 0
+            stdout = "[]"
+            stderr = ""
+        return _R()
+
+    with patch.object(outlook_contacts, "is_outlook_available", return_value=True):
+        with patch("subprocess.run", side_effect=fake_run):
+            fn(*args, **kwargs)
+
+    # Restore — patch context handles this, but be defensive for long test runs
+    subprocess.run = real_run
+    return captured
+
+
+def _assert_compiles(script: str, label: str) -> None:
+    """osacompile must accept the script, or we fail with the compiler diag."""
+    with tempfile.NamedTemporaryFile(suffix=".applescript", mode="w", delete=False) as tmp:
+        tmp.write(script)
+        src = Path(tmp.name)
+    dst = src.with_suffix(".scpt")
+    try:
+        r = subprocess.run(
+            ["osacompile", "-o", str(dst), str(src)],
+            capture_output=True, text=True,
+        )
+        if r.returncode != 0:
+            pytest.fail(
+                f"{label} AppleScript failed to compile:\n"
+                f"  stderr: {r.stderr.strip()}\n"
+                f"  script length: {len(script)} chars\n"
+                f"  (first 500 chars): {script[:500]}"
+            )
+    finally:
+        src.unlink(missing_ok=True)
+        if dst.exists():
+            dst.unlink()
+
+
+@pytest.mark.skipif(not HAS_OSACOMPILE, reason="osacompile not available (non-mac)")
+def test_ensure_pdb_category_compiles():
+    scripts = _capture_scripts(outlook_contacts.ensure_pdb_category, "PDB")
+    assert scripts, "no AppleScript captured"
+    _assert_compiles(scripts[-1], "ensure_pdb_category")
+
+
+@pytest.mark.skipif(not HAS_OSACOMPILE, reason="osacompile not available (non-mac)")
+def test_list_pdb_contacts_compiles():
+    scripts = _capture_scripts(outlook_contacts.list_pdb_contacts, "PDB")
+    assert scripts, "no AppleScript captured"
+    _assert_compiles(scripts[-1], "list_pdb_contacts")
+
+
+@pytest.mark.skipif(not HAS_OSACOMPILE, reason="osacompile not available (non-mac)")
+def test_upsert_contact_create_compiles():
+    payload = {
+        "first_name": "Jane", "last_name": "Doe", "display_name": "Jane Doe",
+        "company": "ACME Inc.", "job_title": "CFO",
+        "email": "jane@acme.com",
+        "business_phone": "555-111-2222", "mobile_phone": "555-333-4444",
+        "notes": "line one\nline two\nline three",
+        "business_address_street": "123 Main St",
+    }
+    scripts = _capture_scripts(outlook_contacts.upsert_contact, payload, outlook_id=None)
+    assert scripts, "no AppleScript captured"
+    _assert_compiles(scripts[-1], "upsert_contact(create)")
+
+
+@pytest.mark.skipif(not HAS_OSACOMPILE, reason="osacompile not available (non-mac)")
+def test_upsert_contact_update_compiles():
+    payload = {"first_name": "Jane", "last_name": "Doe", "email": "jane@acme.com"}
+    scripts = _capture_scripts(outlook_contacts.upsert_contact, payload, outlook_id="42")
+    assert scripts, "no AppleScript captured"
+    _assert_compiles(scripts[-1], "upsert_contact(update)")
+
+
+@pytest.mark.skipif(not HAS_OSACOMPILE, reason="osacompile not available (non-mac)")
+def test_delete_contact_compiles():
+    scripts = _capture_scripts(outlook_contacts.delete_contact, "42")
+    assert scripts, "no AppleScript captured"
+    _assert_compiles(scripts[-1], "delete_contact")
+
+
+@pytest.mark.skipif(not HAS_OSACOMPILE, reason="osacompile not available (non-mac)")
+def test_upsert_contact_escapes_embedded_quotes():
+    """Names/notes with double-quotes must not break the generated AppleScript."""
+    payload = {
+        "first_name": 'John "JD"', "last_name": "O'Brien",
+        "notes": 'He said: "hello" and she replied: "world"',
+        "business_address_street": "42 \"Quoted\" Ave",
+    }
+    scripts = _capture_scripts(outlook_contacts.upsert_contact, payload, outlook_id=None)
+    assert scripts, "no AppleScript captured"
+    _assert_compiles(scripts[-1], "upsert_contact(escaped quotes)")


### PR DESCRIPTION
## Summary
- Repairs Outlook contact sync — 5 invalid AppleScript property names failed at compile time (before `try` could catch them), so sync never worked since shipping
- Fixes 8 other AppleScript compile/runtime issues uncovered during end-to-end verification (category color enum, nested reference deref, var shadowing, empty-list coercion, email record fields, line-ending encoding, etc.)
- Honors the "untag to exclude" escape hatch — `upsert_contact` now returns `skipped_untagged` on tracked-but-untagged contacts; orchestrator clears the DB pointer instead of creating a duplicate
- Adds ambiguous-email bootstrap guard — refuses to act when one PolicyDB contact's email matches multiple PDB-tagged Outlook contacts
- Fixes Settings folder-toggle scroll jump — per-row `outerHTML` swap instead of full-table re-render
- New `tests/test_outlook_contacts_compile.py` shells out to `osacompile` on every AppleScript the bridge produces, preventing this class of bug from recurring

## Test plan
- [x] `pytest tests/test_outlook_contacts_compile.py` — all 6 tests pass (osacompile on each of 5 scripts + escaped-quotes case)
- [x] End-to-end live against Legacy Outlook: create → list → update → delete cycle all succeed, category properly applied, email/phone/note/street round-trip
- [x] Untag escape hatch verified: programmatically untagging a contact causes next sync to return `skipped_untagged` and clear pointer, not create duplicate
- [x] Folder-toggle endpoint seeded and POST confirmed to return single `<tr>` fragment (no `<table>`), DB row updated
- [ ] Manual UI verification of folder-toggle scroll preservation in actual browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)