### PR TITLE
Recurring schedules: nth-weekday patterns + 3 bug fixes

### DIFF
--- a/src/policydb/config.py
+++ b/src/policydb/config.py
@@ -94,8 +94,16 @@ _DEFAULTS: dict[str, Any] = {
         "In Progress",
         "Pending Bind",
         "Bound",
+        "Lost",
+        "Non-Renewed",
+        "Declined",
+        "Not Tracked",
     ],
-    "renewal_statuses_excluded": [],
+    # Statuses silenced from alerts, renewal pipeline, suggested follow-ups,
+    # AND renewal-issue auto-create. The generator also hard-skips Lost /
+    # Non-Renewed / Declined / Not Tracked via renewal_issues._renewal_skip_statuses,
+    # so clearing this list does not re-enable those cases.
+    "renewal_statuses_excluded": ["Lost", "Non-Renewed", "Declined", "Not Tracked"],
     "opportunity_statuses": [
         "Prospecting",
         "Quoting",

--- a/src/policydb/db.py
+++ b/src/policydb/db.py
@@ -2090,6 +2090,26 @@ def _init_db_inner(conn: sqlite3.Connection, db_path: Path) -> None:
         conn.commit()
         logger.info("Migration 155: created renewal_batches table")
 
+    if 156 not in applied:
+        # Idempotent: ALTER TABLE ADD COLUMN is one-shot; skip columns already present.
+        _re_cols = {r[1] for r in conn.execute("PRAGMA table_info(recurring_events)").fetchall()}
+        _migration_sql = (_MIGRATIONS_DIR / "156_recurring_nth_weekday.sql").read_text()
+        _filtered_lines = []
+        for _line in _migration_sql.splitlines():
+            _stripped = _line.strip().rstrip(";")
+            if _stripped.startswith("ALTER TABLE recurring_events ADD COLUMN "):
+                _col = _stripped.split()[-2]  # "ADD COLUMN <name> <type>"
+                if _col in _re_cols:
+                    continue
+            _filtered_lines.append(_line)
+        conn.executescript("\n".join(_filtered_lines))
+        conn.execute(
+            "INSERT INTO schema_version (version, description) VALUES (?, ?)",
+            (156, "Recurring events: add month_pattern + nth_weekday_n/dow for 'last Monday'-style rules"),
+        )
+        conn.commit()
+        logger.info("Migration 156: added recurring_events month_pattern + nth_weekday_* columns")
+
     # Data hygiene: fix 'None' string corruption in text fields (runs every startup, fast no-op if clean)
     conn.execute("UPDATE clients SET cn_number = NULL WHERE cn_number = 'None'")
 

--- a/src/policydb/migrations/156_recurring_nth_weekday.sql
+++ b/src/policydb/migrations/156_recurring_nth_weekday.sql
@@ -1,0 +1,18 @@
+-- 156: Extend recurring_events with "nth weekday of month" pattern support.
+--
+-- Before this migration a Monthly/Quarterly/etc. schedule could only repeat on
+-- a fixed day-of-month (e.g. "the 15th"). This migration adds an alternative
+-- month_pattern='nth_weekday' that expresses rules like "the last Monday of
+-- every month" or "the 2nd Tuesday of every quarter".
+--
+--   month_pattern    : NULL | 'day_of_month' | 'nth_weekday'
+--                      NULL is treated as 'day_of_month' for backward compat.
+--   nth_weekday_n    : 1..4 for first..fourth, -1 for "last"
+--   nth_weekday_dow  : 0=Mon .. 6=Sun (matches existing day_of_week convention)
+--
+-- Only consulted when cadence is Monthly/Quarterly/Semi-Annual/Annual AND
+-- month_pattern = 'nth_weekday'. Weekly/Biweekly continue to use day_of_week.
+
+ALTER TABLE recurring_events ADD COLUMN month_pattern TEXT;
+ALTER TABLE recurring_events ADD COLUMN nth_weekday_n INTEGER;
+ALTER TABLE recurring_events ADD COLUMN nth_weekday_dow INTEGER;

--- a/src/policydb/recurring_events.py
+++ b/src/policydb/recurring_events.py
@@ -106,12 +106,54 @@ def _add_months(d: date, months: int, day_of_month: int | None) -> date:
     return date(y, m, min(target_day, last_day))
 
 
+def _month_shift(d: date, months: int) -> tuple[int, int]:
+    """Return (year, month) after shifting d by `months`."""
+    total = d.month - 1 + months
+    return d.year + total // 12, total % 12 + 1
+
+
+def _nth_weekday_of_month(year: int, month: int, n: int, dow: int) -> date:
+    """Return the Nth weekday of a given month.
+
+    n: 1..4 for first..fourth, -1 for "last". dow: 0=Mon..6=Sun.
+    Falls back to the last occurrence when n=5 in a 4-occurrence month.
+    """
+    if n == -1:
+        last_day = monthrange(year, month)[1]
+        last_date = date(year, month, last_day)
+        offset = (last_date.weekday() - dow) % 7
+        return last_date - timedelta(days=offset)
+
+    n = max(1, min(4, int(n)))
+    first = date(year, month, 1)
+    offset = (dow - first.weekday()) % 7
+    return first + timedelta(days=offset + 7 * (n - 1))
+
+
+def _resolve_monthly(
+    anchor: date,
+    months: int,
+    month_pattern: str | None,
+    day_of_month: int | None,
+    nth_weekday_n: int | None,
+    nth_weekday_dow: int | None,
+) -> date:
+    """Land on the configured day within the month `months` ahead of `anchor`."""
+    if month_pattern == "nth_weekday" and nth_weekday_n is not None and nth_weekday_dow is not None:
+        y, m = _month_shift(anchor, months)
+        return _nth_weekday_of_month(y, m, int(nth_weekday_n), int(nth_weekday_dow))
+    return _add_months(anchor, months, day_of_month)
+
+
 def _advance(
     anchor: date,
     cadence: str,
     interval_n: int,
     day_of_week: int | None,
     day_of_month: int | None,
+    month_pattern: str | None = None,
+    nth_weekday_n: int | None = None,
+    nth_weekday_dow: int | None = None,
 ) -> date:
     """Advance anchor by exactly one cadence step."""
     n = max(1, int(interval_n or 1))
@@ -123,14 +165,22 @@ def _advance(
         return _snap_dow(anchor + timedelta(weeks=n), day_of_week)
     if cadence_norm == "Biweekly":
         return _snap_dow(anchor + timedelta(weeks=2 * n), day_of_week)
-    if cadence_norm == "Monthly":
-        return _add_months(anchor, 1 * n, day_of_month)
-    if cadence_norm == "Quarterly":
-        return _add_months(anchor, 3 * n, day_of_month)
-    if cadence_norm == "Semi-Annual":
-        return _add_months(anchor, 6 * n, day_of_month)
-    if cadence_norm == "Annual":
-        return _add_months(anchor, 12 * n, day_of_month)
+
+    month_steps = {
+        "Monthly": 1,
+        "Quarterly": 3,
+        "Semi-Annual": 6,
+        "Annual": 12,
+    }
+    if cadence_norm in month_steps:
+        return _resolve_monthly(
+            anchor,
+            month_steps[cadence_norm] * n,
+            month_pattern,
+            day_of_month,
+            nth_weekday_n,
+            nth_weekday_dow,
+        )
 
     logger.warning("Unknown cadence %r; defaulting to +7 days", cadence_norm)
     return anchor + timedelta(days=7)
@@ -223,6 +273,10 @@ def _materialize_template(
     if next_occ < start_date:
         next_occ = start_date
 
+    month_pattern = r.get("month_pattern")
+    nth_n = r.get("nth_weekday_n")
+    nth_dow = r.get("nth_weekday_dow")
+
     # Collapse catch-up: if many occurrences are in the past, fast-forward
     # the pointer to the most recent one <= today and emit only one row.
     if mode == "collapse" and next_occ < today:
@@ -233,6 +287,9 @@ def _materialize_template(
                 r["interval_n"],
                 r.get("day_of_week"),
                 r.get("day_of_month"),
+                month_pattern,
+                nth_n,
+                nth_dow,
             )
             if candidate > today:
                 break
@@ -289,6 +346,9 @@ def _materialize_template(
             r["interval_n"],
             r.get("day_of_week"),
             r.get("day_of_month"),
+            month_pattern,
+            nth_n,
+            nth_dow,
         )
 
     # Persist advanced pointer and last_generated_date
@@ -334,12 +394,29 @@ def compute_initial_next_occurrence(
     cadence: str,
     day_of_week: int | None,
     day_of_month: int | None,
+    month_pattern: str | None = None,
+    nth_weekday_n: int | None = None,
+    nth_weekday_dow: int | None = None,
 ) -> date:
-    """Snap start_date forward to the first valid occurrence based on DOW/DOM."""
+    """Snap start_date forward to the first valid occurrence based on the
+    configured pattern. Handles both day_of_month and nth_weekday rules."""
     cadence_norm = (cadence or "").strip()
+    monthly_cadences = ("Monthly", "Quarterly", "Semi-Annual", "Annual")
+
     if cadence_norm in ("Weekly", "Biweekly") and day_of_week is not None:
         return _snap_dow(start_date, day_of_week)
-    if cadence_norm in ("Monthly", "Quarterly", "Semi-Annual", "Annual") and day_of_month:
+
+    if cadence_norm in monthly_cadences and month_pattern == "nth_weekday" \
+            and nth_weekday_n is not None and nth_weekday_dow is not None:
+        this_month = _nth_weekday_of_month(
+            start_date.year, start_date.month, int(nth_weekday_n), int(nth_weekday_dow)
+        )
+        if this_month >= start_date:
+            return this_month
+        y, m = _month_shift(start_date, 1)
+        return _nth_weekday_of_month(y, m, int(nth_weekday_n), int(nth_weekday_dow))
+
+    if cadence_norm in monthly_cadences and day_of_month:
         last_day = monthrange(start_date.year, start_date.month)[1]
         target = date(start_date.year, start_date.month, min(day_of_month, last_day))
         if target < start_date:

--- a/src/policydb/renewal_issues.py
+++ b/src/policydb/renewal_issues.py
@@ -18,6 +18,26 @@ logger = logging.getLogger("policydb.renewal_issues")
 
 # ── Health → Severity mapping ────────────────────────────────────────────────
 
+# Statuses that should never spawn a renewal issue, regardless of whether the
+# user has added them to `renewal_statuses_excluded`. "Bound" is intentionally
+# omitted — it's handled by auto_resolve_renewal_issue on the current term,
+# and a freshly-bound policy needs a new issue for the next cycle.
+_TERMINAL_SKIP_STATUSES = ("Lost", "Non-Renewed", "Declined", "Not Tracked")
+
+
+def _renewal_skip_statuses() -> set[str]:
+    """Merge configured terminal statuses with the hard-coded skip list.
+
+    Callers union this with ``renewal_statuses_excluded`` so policies marked
+    Lost / Not Tracked / Non-Renewed / Declined never produce a renewal issue.
+    """
+    configured = cfg.get("renewal_terminal_statuses", []) or []
+    # Bound is treated as terminal for the current cycle but should not block
+    # a future-term renewal issue, so drop it here even if the user included it
+    # in the terminal-statuses config.
+    return {s for s in configured if s and s != "Bound"} | set(_TERMINAL_SKIP_STATUSES)
+
+
 _HEALTH_SEVERITY = {
     "critical": "Critical",
     "at_risk": "High",
@@ -97,20 +117,39 @@ def ensure_renewal_issues(conn, policy_uid: str | None = None) -> None:
         policy_rows = conn.execute("""
             SELECT p.policy_uid, p.expiration_date, p.policy_type, p.id AS policy_id,
                    c.name AS client_name, p.client_id, p.program_id,
-                   pr.name AS location_name
+                   pr.name AS location_name, p.renewal_status, p.is_opportunity, p.archived
             FROM policies p
             JOIN clients c ON c.id = p.client_id
             LEFT JOIN projects pr ON pr.id = p.project_id
             WHERE p.policy_uid = ?
         """, (policy_uid,)).fetchall()
+        # Apply the same skip filter on single-policy triggers (e.g. inline
+        # status changes) so flipping a policy to Lost/Not Tracked doesn't
+        # immediately re-spawn the renewal issue.
+        skip_statuses = set(cfg.get("renewal_statuses_excluded", []) or [])
+        skip_statuses.update(_renewal_skip_statuses())
+        policy_rows = [
+            r for r in policy_rows
+            if (r["is_opportunity"] or 0) == 0
+            and (r["archived"] or 0) == 0
+            and r["expiration_date"]
+            and r["expiration_date"] >= today.isoformat()
+            and r["expiration_date"] <= horizon.isoformat()
+            and (r["renewal_status"] is None or r["renewal_status"] not in skip_statuses)
+        ]
     else:
-        excluded_statuses = cfg.get("renewal_statuses_excluded", [])
+        # Exclude any renewal_status the user has silenced for alerts/pipeline
+        # AND any terminal status (Lost / Non-Renewed / Declined / Not Tracked).
+        # Union so that terminal statuses are always blocked from spawning a
+        # fresh renewal issue even if the user has cleared the excluded list.
+        excluded_statuses = set(cfg.get("renewal_statuses_excluded", []) or [])
+        excluded_statuses.update(_renewal_skip_statuses())
         excl_sql = ""
         excl_params: list = [today.isoformat(), horizon.isoformat()]
         if excluded_statuses:
             ph = ",".join("?" * len(excluded_statuses))
             excl_sql = f" AND (p.renewal_status IS NULL OR p.renewal_status NOT IN ({ph}))"
-            excl_params.extend(excluded_statuses)
+            excl_params.extend(sorted(excluded_statuses))
         policy_rows = conn.execute(f"""
             SELECT p.policy_uid, p.expiration_date, p.policy_type, p.id AS policy_id,
                    c.name AS client_name, p.client_id, p.program_id,
@@ -151,7 +190,19 @@ def ensure_renewal_issues(conn, policy_uid: str | None = None) -> None:
     # GROUP BY gives us one row per program with the right expiration, which
     # reads cleaner than four repeated correlated subqueries.
     if not policy_uid:
-        program_rows = conn.execute("""
+        # Exclude terminal-status children from program expiration derivation —
+        # otherwise a program where every child is Lost/Not Tracked still
+        # produces a renewal issue for the program.
+        skip_statuses = set(cfg.get("renewal_statuses_excluded", []) or [])
+        skip_statuses.update(_renewal_skip_statuses())
+        child_excl_sql = ""
+        child_params: list = []
+        if skip_statuses:
+            ph = ",".join("?" * len(skip_statuses))
+            child_excl_sql = f" AND (renewal_status IS NULL OR renewal_status NOT IN ({ph}))"
+            child_params = sorted(skip_statuses)
+
+        program_rows = conn.execute(f"""
             SELECT pg.id, pg.program_uid, d.expiration_date,
                    pg.line_of_business,
                    pg.name AS program_name, c.name AS client_name, pg.client_id,
@@ -166,13 +217,14 @@ def ensure_renewal_issues(conn, policy_uid: str | None = None) -> None:
                   AND archived = 0
                   AND (is_opportunity = 0 OR is_opportunity IS NULL)
                   AND (expiration_date IS NULL OR expiration_date >= date('now'))
+                  {child_excl_sql}
                 GROUP BY program_id
                 HAVING MAX(expiration_date) IS NOT NULL
             ) d ON d.program_id = pg.id
             WHERE (pg.archived = 0 OR pg.archived IS NULL)
               AND d.expiration_date >= ?
               AND d.expiration_date <= ?
-        """, (today.isoformat(), horizon.isoformat())).fetchall()
+        """, (*child_params, today.isoformat(), horizon.isoformat())).fetchall()
 
         for pgm in program_rows:
             term_key = f"program:{pgm['program_uid']}"

--- a/src/policydb/web/routes/clients.py
+++ b/src/policydb/web/routes/clients.py
@@ -7642,12 +7642,10 @@ async def exposure_cell(request: Request, client_id: int, exposure_id: int, conn
         conn.commit()
         from policydb.exposures import recalc_exposure_rate
         recalc_exposure_rate(conn, exposure_id=exposure_id)
-        # Format and calculate YoY
+        # Format without currency symbols — the matrix uses plain number
+        # formatting regardless of unit, so long values don't wrap.
         row = get_exposure_by_id(conn, exposure_id)
-        if row and row.get("unit") == "currency":
-            formatted = "${:,.0f}".format(amount)
-        else:
-            formatted = "{:,.0f}".format(amount)
+        formatted = "{:,.0f}".format(amount)
         # Calculate YoY
         prior = conn.execute(
             """SELECT amount FROM client_exposures

--- a/src/policydb/web/routes/recurring_events.py
+++ b/src/policydb/web/routes/recurring_events.py
@@ -51,6 +51,36 @@ def _parse_int(value, default: Optional[int] = None) -> Optional[int]:
         return default
 
 
+_MONTHLY_CADENCES = {"Monthly", "Quarterly", "Semi-Annual", "Annual"}
+
+
+def _normalize_month_pattern(
+    cadence: str,
+    month_pattern: str,
+    nth_weekday_n: str,
+    nth_weekday_dow: str,
+) -> tuple[Optional[str], Optional[int], Optional[int]]:
+    """Validate + coerce the form's monthly-pattern fields.
+
+    Returns (pattern, nth_n, nth_dow). When the cadence isn't monthly, or the
+    nth-weekday fields are missing/invalid, all three are None — which
+    preserves the legacy day_of_month code path.
+    """
+    if (cadence or "").strip() not in _MONTHLY_CADENCES:
+        return None, None, None
+    if (month_pattern or "").strip() != "nth_weekday":
+        return None, None, None
+    nth_n = _parse_int(nth_weekday_n)
+    nth_dow = _parse_int(nth_weekday_dow)
+    if nth_n is None or nth_dow is None:
+        return None, None, None
+    if nth_n != -1 and (nth_n < 1 or nth_n > 4):
+        return None, None, None
+    if nth_dow < 0 or nth_dow > 6:
+        return None, None, None
+    return "nth_weekday", nth_n, nth_dow
+
+
 def _get_template(conn, recurring_id: int) -> Optional[dict]:
     row = conn.execute(
         "SELECT * FROM recurring_events WHERE id = ?", (recurring_id,)
@@ -139,6 +169,9 @@ def create_template(
     interval_n: int = Form(1),
     day_of_week: str = Form(""),
     day_of_month: str = Form(""),
+    month_pattern: str = Form(""),
+    nth_weekday_n: str = Form(""),
+    nth_weekday_dow: str = Form(""),
     lead_days: int = Form(0),
     end_date: str = Form(""),
     default_severity: str = Form("Normal"),
@@ -154,7 +187,12 @@ def create_template(
     end = _parse_date(end_date)
     dow = _parse_int(day_of_week)
     dom = _parse_int(day_of_month)
-    next_occ = compute_initial_next_occurrence(start, cadence, dow, dom)
+    pattern, nth_n, nth_dow = _normalize_month_pattern(
+        cadence, month_pattern, nth_weekday_n, nth_weekday_dow
+    )
+    next_occ = compute_initial_next_occurrence(
+        start, cadence, dow, dom, pattern, nth_n, nth_dow
+    )
 
     uid = next_recurring_uid(conn)
     conn.execute(
@@ -162,10 +200,11 @@ def create_template(
         INSERT INTO recurring_events (
             recurring_uid, client_id, policy_id, event_type, name,
             subject_template, details_template, default_severity,
-            cadence, interval_n, day_of_week, day_of_month, lead_days,
+            cadence, interval_n, day_of_week, day_of_month,
+            month_pattern, nth_weekday_n, nth_weekday_dow, lead_days,
             start_date, end_date, next_occurrence,
             account_exec, active, catch_up_mode, notes
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
         """,
         (
             uid,
@@ -180,6 +219,9 @@ def create_template(
             max(1, int(interval_n or 1)),
             dow,
             dom,
+            pattern,
+            nth_n,
+            nth_dow,
             max(0, int(lead_days or 0)),
             start.isoformat(),
             end.isoformat() if end else None,
@@ -212,6 +254,9 @@ def update_template(
     interval_n: int = Form(1),
     day_of_week: str = Form(""),
     day_of_month: str = Form(""),
+    month_pattern: str = Form(""),
+    nth_weekday_n: str = Form(""),
+    nth_weekday_dow: str = Form(""),
     lead_days: int = Form(0),
     end_date: str = Form(""),
     default_severity: str = Form("Normal"),
@@ -233,12 +278,17 @@ def update_template(
     dom = _parse_int(day_of_month)
     end = _parse_date(end_date)
     start = _parse_date(start_date) or _parse_date(template.get("start_date")) or date.today()
+    pattern, nth_n, nth_dow = _normalize_month_pattern(
+        cadence, month_pattern, nth_weekday_n, nth_weekday_dow
+    )
 
     conn.execute(
         """
         UPDATE recurring_events
         SET name = ?, policy_id = ?, event_type = ?, cadence = ?, interval_n = ?,
-            day_of_week = ?, day_of_month = ?, lead_days = ?, start_date = ?,
+            day_of_week = ?, day_of_month = ?,
+            month_pattern = ?, nth_weekday_n = ?, nth_weekday_dow = ?,
+            lead_days = ?, start_date = ?,
             end_date = ?, default_severity = ?, subject_template = ?,
             details_template = ?, account_exec = ?, catch_up_mode = ?, notes = ?
         WHERE id = ?
@@ -251,6 +301,9 @@ def update_template(
             max(1, int(interval_n or 1)),
             dow,
             dom,
+            pattern,
+            nth_n,
+            nth_dow,
             max(0, int(lead_days or 0)),
             start.isoformat(),
             end.isoformat() if end else None,
@@ -321,6 +374,9 @@ def advance_template(recurring_id: int, request: Request, conn=Depends(get_db)):
         template.get("interval_n") or 1,
         template.get("day_of_week"),
         template.get("day_of_month"),
+        template.get("month_pattern"),
+        template.get("nth_weekday_n"),
+        template.get("nth_weekday_dow"),
     )
     conn.execute(
         "UPDATE recurring_events SET next_occurrence = ? WHERE id = ?",

--- a/src/policydb/web/templates/base.html
+++ b/src/policydb/web/templates/base.html
@@ -554,7 +554,7 @@ function initClientAutocomplete(inputId, hiddenId, opts) {
   input.addEventListener('blur', function() { setTimeout(rmDD, 150); });
 
   function doSearch(q) {
-    fetch('/api/client-search?q=' + encodeURIComponent(q))
+    fetch('/charts/api/client-search?q=' + encodeURIComponent(q))
       .then(function(r) { return r.json(); })
       .then(function(results) {
         rmDD();

--- a/src/policydb/web/templates/clients/_exposure_matrix.html
+++ b/src/policydb/web/templates/clients/_exposure_matrix.html
@@ -42,9 +42,9 @@
   <div class="overflow-x-auto">
     <table class="w-full text-sm table-fixed">
       <colgroup>
-        <col style="width:12%"><col style="width:5%"><col style="width:11%"><col style="width:10%">
-        <col style="width:10%"><col style="width:6%"><col style="width:14%">
-        <col style="width:14%"><col style="width:3%"><col style="width:7%"><col style="width:28px">
+        <col style="width:12%"><col style="width:5%"><col style="width:10%"><col style="width:12%">
+        <col style="width:12%"><col style="width:6%"><col style="width:13%">
+        <col style="width:13%"><col style="width:3%"><col style="width:7%"><col style="width:28px">
       </colgroup>
       <thead>
         <tr class="text-left text-xs text-gray-400 uppercase tracking-wide border-b border-gray-100 bg-gray-50">
@@ -115,7 +115,8 @@
         var rateCell = rowEl.querySelector('[data-field="rate"]');
         if (rateCell) {
           var cls = resp.is_primary ? 'bg-green-50 text-green-700' : 'text-gray-400';
-          rateCell.innerHTML = '<span class="text-xs font-semibold px-2 py-0.5 rounded ' + cls + '">$' + parseFloat(resp.rate).toFixed(2) + '</span>';
+          var formattedRate = parseFloat(resp.rate).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+          rateCell.innerHTML = '<span class="text-xs font-semibold tabular-nums px-2 py-0.5 rounded ' + cls + '">' + formattedRate + '</span>';
         }
       }
     }

--- a/src/policydb/web/templates/clients/_exposure_matrix_row.html
+++ b/src/policydb/web/templates/clients/_exposure_matrix_row.html
@@ -28,20 +28,18 @@
       {% else %}<span class="text-gray-300">&mdash;</span>{% endif %}
     </span>
   </td>
-  {# Prior Year (read-only) #}
-  <td class="px-3 py-2.5 text-right">
+  {# Prior Year (read-only) — plain number format, no currency symbol #}
+  <td class="px-3 py-2.5 text-right whitespace-nowrap">
     {% if e.prior_amount is not none %}
-    <span class="text-gray-400 text-xs">
-      {% if e.unit == 'currency' %}{{ e.prior_amount | currency }}{% else %}{{ "{:,.0f}".format(e.prior_amount) }}{% endif %}
-    </span>
+    <span class="text-gray-400 text-xs tabular-nums">{{ "{:,.0f}".format(e.prior_amount) }}</span>
     {% else %}<span class="text-gray-300 text-xs">&mdash;</span>{% endif %}
   </td>
-  {# Current Year (editable) #}
-  <td class="px-3 py-2.5 text-right">
+  {# Current Year (editable) — plain number format, no currency symbol #}
+  <td class="px-3 py-2.5 text-right whitespace-nowrap">
     <div contenteditable="true"
-         class="matrix-cell-editable outline-none text-gray-800 text-xs font-semibold rounded px-1 -mx-1 border border-dashed border-blue-200 bg-blue-50/30"
+         class="matrix-cell-editable outline-none text-gray-800 text-xs font-semibold tabular-nums rounded px-1 -mx-1 border border-dashed border-blue-200 bg-blue-50/30"
          data-field="amount"
-         data-placeholder="Enter value...">{% if e.amount is not none %}{% if e.unit == 'currency' %}{{ e.amount | currency }}{% else %}{{ "{:,.0f}".format(e.amount) }}{% endif %}{% endif %}</div>
+         data-placeholder="Enter value...">{% if e.amount is not none %}{{ "{:,.0f}".format(e.amount) }}{% endif %}</div>
   </td>
   {# YoY Δ (auto-calculated) #}
   <td class="px-3 py-2.5 text-center" data-field="yoy">
@@ -78,12 +76,12 @@
     </button>
     {% else %}<span class="text-gray-200 text-sm">&mdash;</span>{% endif %}
   </td>
-  {# Rate (auto-calculated) #}
-  <td class="px-3 py-2.5 text-right" data-field="rate">
+  {# Rate (auto-calculated) — plain number, no currency symbol #}
+  <td class="px-3 py-2.5 text-right whitespace-nowrap" data-field="rate">
     {% if e.link_rate is not none %}
-    <span class="text-xs font-semibold px-2 py-0.5 rounded
+    <span class="text-xs font-semibold tabular-nums px-2 py-0.5 rounded
       {% if e.link_is_primary %}bg-green-50 text-green-700{% else %}text-gray-400{% endif %}">
-      ${{ "{:,.2f}".format(e.link_rate) }}
+      {{ "{:,.2f}".format(e.link_rate) }}
     </span>
     {% elif e.link_policy_uid %}<span class="text-gray-300 text-xs">&mdash;</span>
     {% else %}<span class="text-gray-200 text-xs"></span>{% endif %}

--- a/src/policydb/web/templates/clients/_recurring_slideover.html
+++ b/src/policydb/web/templates/clients/_recurring_slideover.html
@@ -1,18 +1,23 @@
 {# Create / edit recurring event schedule — rendered inside #recurring-slideover-content #}
 {% set is_edit = template is not none %}
 {% set t = template or {} %}
+{% set monthly_cadences = ['Monthly', 'Quarterly', 'Semi-Annual', 'Annual'] %}
+{% set weekly_cadences = ['Weekly', 'Biweekly'] %}
+{% set current_cadence = t.cadence if is_edit else 'Weekly' %}
+{% set current_pattern = (t.month_pattern if is_edit else '') or 'day_of_month' %}
 <div>
   <div class="flex items-center justify-between mb-4">
-    <h2 class="text-base font-semibold text-gray-900">
+    <h2 class="text-base font-semibold text-[#000F47]" style="font-family:'DM Serif Display',serif;">
       {% if is_edit %}Edit Recurring Schedule{% else %}New Recurring Schedule{% endif %}
     </h2>
-    <button type="button" onclick="closeRecurringSlideover()" class="text-gray-400 hover:text-gray-600 text-xl leading-none">&times;</button>
+    <button type="button" onclick="closeRecurringSlideover()"
+      class="text-[#8F8B83] hover:text-[#000F47] text-xl leading-none">&times;</button>
   </div>
 
-  <div class="text-xs text-gray-500 mb-4">
+  <div class="text-xs text-[#6B6860] mb-4">
     Schedule a repeating touchpoint for
-    <span class="font-medium text-gray-700">{{ client.name }}</span>.
-    Each occurrence is materialized as an issue on its due date.
+    <span class="font-medium text-[#3D3C37]">{{ client.name }}</span>.
+    Each occurrence is materialized as an issue on its due date and flows into the Focus Queue.
   </div>
 
   <form
@@ -24,7 +29,9 @@
     hx-target="#client-recurring-tab"
     hx-swap="outerHTML"
     onsubmit="setTimeout(closeRecurringSlideover, 100);"
-    class="space-y-4">
+    class="space-y-4"
+    id="recurring-event-form"
+    data-current-cadence="{{ current_cadence }}">
 
     {% if not is_edit %}
     <input type="hidden" name="client_id" value="{{ client.id }}">
@@ -32,18 +39,18 @@
 
     {# Name #}
     <div>
-      <label class="block text-xs font-medium text-gray-600 mb-1">Name <span class="text-red-500">*</span></label>
+      <label class="field-label">Name <span class="text-red-500">*</span></label>
       <input type="text" name="name" required
         value="{{ t.name or '' }}"
-        placeholder="e.g. Weekly open items call"
-        class="w-full rounded border-gray-300 text-sm px-3 py-1.5">
+        placeholder="e.g. Monthly loss run review"
+        class="form-input">
     </div>
 
     {# Event type + severity #}
     <div class="grid grid-cols-2 gap-3">
       <div>
-        <label class="block text-xs font-medium text-gray-600 mb-1">Type</label>
-        <select name="event_type" class="w-full rounded border-gray-300 text-sm px-2 py-1.5">
+        <label class="field-label">Type</label>
+        <select name="event_type" class="form-select">
           <option value="">—</option>
           {% for opt in event_types %}
           <option value="{{ opt }}" {% if t.event_type == opt %}selected{% endif %}>{{ opt }}</option>
@@ -51,8 +58,8 @@
         </select>
       </div>
       <div>
-        <label class="block text-xs font-medium text-gray-600 mb-1">Severity</label>
-        <select name="default_severity" class="w-full rounded border-gray-300 text-sm px-2 py-1.5">
+        <label class="field-label">Severity</label>
+        <select name="default_severity" class="form-select">
           {% for sev in severities %}
           <option value="{{ sev.label }}" {% if t.default_severity == sev.label or (not t.default_severity and sev.label == 'Normal') %}selected{% endif %}>
             {{ sev.label }} ({{ sev.sla_days }}d SLA)
@@ -62,73 +69,135 @@
       </div>
     </div>
 
-    {# Cadence + interval #}
-    <div class="grid grid-cols-3 gap-3">
-      <div class="col-span-2">
-        <label class="block text-xs font-medium text-gray-600 mb-1">Cadence <span class="text-red-500">*</span></label>
-        <select name="cadence" required class="w-full rounded border-gray-300 text-sm px-2 py-1.5">
-          {% for c in cadences %}
-          <option value="{{ c }}" {% if t.cadence == c %}selected{% endif %}>{{ c }}</option>
-          {% endfor %}
-        </select>
-      </div>
-      <div>
-        <label class="block text-xs font-medium text-gray-600 mb-1">Every</label>
-        <input type="number" name="interval_n" min="1" max="52"
-          value="{{ t.interval_n or 1 }}"
-          class="w-full rounded border-gray-300 text-sm px-2 py-1.5">
-      </div>
-    </div>
+    {# ── Repeat rule ─────────────────────────────────────────── #}
+    <div class="rounded-lg border border-[#E8E2D9] bg-[#FBF8F3] p-3 space-y-3">
+      <div class="text-[11px] uppercase tracking-wide text-[#8F8B83] font-semibold">Repeat rule</div>
 
-    {# Day of week / day of month (both always shown; relevant one used based on cadence) #}
-    <div class="grid grid-cols-2 gap-3">
-      <div>
-        <label class="block text-xs font-medium text-gray-600 mb-1">Day of week (Weekly/Biweekly)</label>
-        <select name="day_of_week" class="w-full rounded border-gray-300 text-sm px-2 py-1.5">
-          <option value="">Any</option>
+      {# Cadence + interval #}
+      <div class="grid grid-cols-3 gap-3">
+        <div class="col-span-2">
+          <label class="field-label">Cadence <span class="text-red-500">*</span></label>
+          <select name="cadence" id="re-cadence" required class="form-select" onchange="recurringRuleChanged()">
+            {% for c in cadences %}
+            <option value="{{ c }}" {% if t.cadence == c %}selected{% endif %}>{{ c }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div>
+          <label class="field-label">Every</label>
+          <input type="number" name="interval_n" min="1" max="52"
+            value="{{ t.interval_n or 1 }}"
+            oninput="recurringRuleChanged()"
+            class="form-input">
+        </div>
+      </div>
+
+      {# Weekly: day of week #}
+      <div id="re-weekly-group" class="hidden">
+        <label class="field-label">Day of week</label>
+        <select name="day_of_week" id="re-dow" class="form-select" onchange="recurringRuleChanged()">
+          <option value="">Any (same weekday as start)</option>
           {% set dows = [('0','Monday'),('1','Tuesday'),('2','Wednesday'),('3','Thursday'),('4','Friday'),('5','Saturday'),('6','Sunday')] %}
           {% for v, label in dows %}
           <option value="{{ v }}" {% if t.day_of_week is not none and t.day_of_week|string == v %}selected{% endif %}>{{ label }}</option>
           {% endfor %}
         </select>
       </div>
-      <div>
-        <label class="block text-xs font-medium text-gray-600 mb-1">Day of month (Monthly+)</label>
-        <input type="number" name="day_of_month" min="1" max="31"
-          value="{{ t.day_of_month or '' }}"
-          placeholder="e.g. 15"
-          class="w-full rounded border-gray-300 text-sm px-3 py-1.5">
+
+      {# Monthly+: pattern segmented control #}
+      <div id="re-monthly-group" class="hidden space-y-3">
+        <div>
+          <label class="field-label">Pattern</label>
+          <div class="flex bg-[#EDEAE4] rounded-lg overflow-hidden text-[13px] p-0.5" role="tablist">
+            <button type="button" id="re-pattern-dom"
+              class="flex-1 px-3 py-1.5 rounded-md transition-colors"
+              onclick="setMonthPattern('day_of_month')">
+              On day of month
+            </button>
+            <button type="button" id="re-pattern-nth"
+              class="flex-1 px-3 py-1.5 rounded-md transition-colors"
+              onclick="setMonthPattern('nth_weekday')">
+              On the Nth weekday
+            </button>
+          </div>
+          <input type="hidden" name="month_pattern" id="re-month-pattern" value="{{ current_pattern }}">
+        </div>
+
+        {# Day of month #}
+        <div id="re-dom-group">
+          <label class="field-label">Day of month</label>
+          <input type="number" name="day_of_month" id="re-dom" min="1" max="31"
+            value="{{ t.day_of_month or '' }}"
+            placeholder="e.g. 15"
+            oninput="recurringRuleChanged()"
+            class="form-input">
+          <p class="text-[11px] text-[#8F8B83] mt-1">
+            Days 29–31 clamp to month-end in shorter months (e.g. 31 becomes Feb 28).
+          </p>
+        </div>
+
+        {# Nth weekday #}
+        <div id="re-nth-group" class="hidden grid grid-cols-2 gap-3">
+          <div>
+            <label class="field-label">Which</label>
+            <select name="nth_weekday_n" id="re-nth-n" class="form-select" onchange="recurringRuleChanged()">
+              {% set nths = [('1','First'),('2','Second'),('3','Third'),('4','Fourth'),('-1','Last')] %}
+              {% for v, label in nths %}
+              <option value="{{ v }}"
+                {% if t.nth_weekday_n is not none and t.nth_weekday_n|string == v %}selected
+                {% elif t.nth_weekday_n is none and v == '-1' %}selected{% endif %}>{{ label }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div>
+            <label class="field-label">Weekday</label>
+            <select name="nth_weekday_dow" id="re-nth-dow" class="form-select" onchange="recurringRuleChanged()">
+              {% for v, label in dows %}
+              <option value="{{ v }}"
+                {% if t.nth_weekday_dow is not none and t.nth_weekday_dow|string == v %}selected
+                {% elif t.nth_weekday_dow is none and v == '0' %}selected{% endif %}>{{ label }}</option>
+              {% endfor %}
+            </select>
+          </div>
+        </div>
+      </div>
+
+      {# Live preview #}
+      <div class="text-xs text-[#3D3C37] bg-white border border-[#E8E2D9] rounded px-2.5 py-1.5 font-medium">
+        <span class="text-[#8F8B83] font-normal">Summary:</span>
+        <span id="re-summary">—</span>
       </div>
     </div>
 
     {# Start / end date #}
     <div class="grid grid-cols-2 gap-3">
       <div>
-        <label class="block text-xs font-medium text-gray-600 mb-1">Start date <span class="text-red-500">*</span></label>
+        <label class="field-label">Start date <span class="text-red-500">*</span></label>
         <input type="date" name="start_date" required
           value="{{ t.start_date or today_iso }}"
-          class="w-full rounded border-gray-300 text-sm px-3 py-1.5">
+          oninput="recurringRuleChanged()"
+          class="form-input">
       </div>
       <div>
-        <label class="block text-xs font-medium text-gray-600 mb-1">End date (optional)</label>
+        <label class="field-label">End date (optional)</label>
         <input type="date" name="end_date"
           value="{{ t.end_date or '' }}"
-          class="w-full rounded border-gray-300 text-sm px-3 py-1.5">
+          class="form-input">
       </div>
     </div>
 
     {# Lead days + catch-up mode #}
     <div class="grid grid-cols-2 gap-3">
       <div>
-        <label class="block text-xs font-medium text-gray-600 mb-1">Lead days</label>
+        <label class="field-label">Lead days</label>
         <input type="number" name="lead_days" min="0" max="60"
           value="{{ t.lead_days or 0 }}"
-          class="w-full rounded border-gray-300 text-sm px-3 py-1.5"
+          class="form-input"
           title="Materialize the issue N days before its due date">
       </div>
       <div>
-        <label class="block text-xs font-medium text-gray-600 mb-1">If missed</label>
-        <select name="catch_up_mode" class="w-full rounded border-gray-300 text-sm px-2 py-1.5">
+        <label class="field-label">If missed</label>
+        <select name="catch_up_mode" class="form-select">
           <option value="collapse" {% if (t.catch_up_mode or 'collapse') == 'collapse' %}selected{% endif %}>Collapse (1 catch-up)</option>
           <option value="materialize_all" {% if t.catch_up_mode == 'materialize_all' %}selected{% endif %}>Fire every missed</option>
         </select>
@@ -137,8 +206,8 @@
 
     {# Optional policy scoping #}
     <div>
-      <label class="block text-xs font-medium text-gray-600 mb-1">Link to policy (optional)</label>
-      <select name="policy_id" class="w-full rounded border-gray-300 text-sm px-2 py-1.5">
+      <label class="field-label">Link to policy (optional)</label>
+      <select name="policy_id" class="form-select">
         <option value="0">— Client-level only —</option>
         {% for p in policies %}
         <option value="{{ p.id }}" {% if t.policy_id == p.id %}selected{% endif %}>
@@ -150,41 +219,125 @@
 
     {# Subject + details templates #}
     <div>
-      <label class="block text-xs font-medium text-gray-600 mb-1">Subject template</label>
+      <label class="field-label">Subject template</label>
       <input type="text" name="subject_template"
         value="{{ t.subject_template or '' }}"
         placeholder="Leave blank to use the name above"
-        class="w-full rounded border-gray-300 text-sm px-3 py-1.5">
+        class="form-input">
     </div>
     <div>
-      <label class="block text-xs font-medium text-gray-600 mb-1">Details template</label>
+      <label class="field-label">Details template</label>
       <textarea name="details_template" rows="3"
         placeholder="Optional — copied to each instance"
-        class="w-full rounded border-gray-300 text-sm px-3 py-1.5">{{ t.details_template or '' }}</textarea>
+        class="form-input">{{ t.details_template or '' }}</textarea>
     </div>
 
     {# Account exec #}
     <div>
-      <label class="block text-xs font-medium text-gray-600 mb-1">Account exec (optional)</label>
+      <label class="field-label">Account exec (optional)</label>
       <input type="text" name="account_exec"
         value="{{ t.account_exec or '' }}"
-        class="w-full rounded border-gray-300 text-sm px-3 py-1.5">
+        class="form-input">
     </div>
 
     {# Notes #}
     <div>
-      <label class="block text-xs font-medium text-gray-600 mb-1">Internal notes</label>
-      <textarea name="notes" rows="2" class="w-full rounded border-gray-300 text-sm px-3 py-1.5">{{ t.notes or '' }}</textarea>
+      <label class="field-label">Internal notes</label>
+      <textarea name="notes" rows="2" class="form-input">{{ t.notes or '' }}</textarea>
     </div>
 
     {# Buttons #}
-    <div class="flex items-center justify-end gap-2 pt-2 border-t">
+    <div class="flex items-center justify-end gap-2 pt-3 border-t border-[#E8E2D9]">
       <button type="button" onclick="closeRecurringSlideover()"
-        class="text-xs text-gray-500 hover:text-gray-700 px-3 py-1.5">Cancel</button>
+        class="text-xs text-[#6B6860] hover:text-[#3D3C37] px-3 py-1.5">Cancel</button>
       <button type="submit"
-        class="text-xs bg-marsh text-white px-4 py-1.5 rounded font-medium hover:bg-marsh-light transition-colors">
+        class="btn-primary text-xs px-4 py-1.5">
         {% if is_edit %}Save changes{% else %}Create schedule{% endif %}
       </button>
     </div>
   </form>
 </div>
+
+<script>
+(function () {
+  const MONTHLY = new Set(['Monthly', 'Quarterly', 'Semi-Annual', 'Annual']);
+  const WEEKLY = new Set(['Weekly', 'Biweekly']);
+  const DOW_NAMES = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+  const NTH_NAMES = {'1': 'first', '2': 'second', '3': 'third', '4': 'fourth', '-1': 'last'};
+
+  function byId(id) { return document.getElementById(id); }
+
+  function visibleCadenceGroups() {
+    const cad = (byId('re-cadence') || {}).value || '';
+    const weekly = byId('re-weekly-group');
+    const monthly = byId('re-monthly-group');
+    if (WEEKLY.has(cad)) { weekly.classList.remove('hidden'); } else { weekly.classList.add('hidden'); }
+    if (MONTHLY.has(cad)) { monthly.classList.remove('hidden'); } else { monthly.classList.add('hidden'); }
+  }
+
+  window.setMonthPattern = function (pattern) {
+    byId('re-month-pattern').value = pattern;
+    const domGroup = byId('re-dom-group');
+    const nthGroup = byId('re-nth-group');
+    const dom = byId('re-pattern-dom');
+    const nth = byId('re-pattern-nth');
+    if (pattern === 'nth_weekday') {
+      domGroup.classList.add('hidden');
+      nthGroup.classList.remove('hidden');
+      nthGroup.classList.add('grid');
+      dom.className = 'flex-1 px-3 py-1.5 rounded-md transition-colors text-[#6B6860] hover:bg-[#E0DBD3]';
+      nth.className = 'flex-1 px-3 py-1.5 rounded-md transition-colors bg-[#000F47] text-white font-semibold';
+    } else {
+      domGroup.classList.remove('hidden');
+      nthGroup.classList.add('hidden');
+      nthGroup.classList.remove('grid');
+      dom.className = 'flex-1 px-3 py-1.5 rounded-md transition-colors bg-[#000F47] text-white font-semibold';
+      nth.className = 'flex-1 px-3 py-1.5 rounded-md transition-colors text-[#6B6860] hover:bg-[#E0DBD3]';
+    }
+    renderSummary();
+  };
+
+  function renderSummary() {
+    const form = byId('recurring-event-form');
+    if (!form) return;
+    const cad = (byId('re-cadence') || {}).value || '';
+    const n = parseInt((form.elements['interval_n'] || {}).value || '1', 10) || 1;
+    const every = n > 1 ? `every ${n}` : 'every';
+    let text = '—';
+
+    if (cad === 'Daily') {
+      text = n > 1 ? `Repeats every ${n} days` : 'Repeats every day';
+    } else if (WEEKLY.has(cad)) {
+      const dowRaw = (byId('re-dow') || {}).value;
+      const dowLabel = dowRaw === '' ? 'same weekday as the start date' : DOW_NAMES[parseInt(dowRaw, 10)];
+      const unit = cad === 'Weekly' ? (n > 1 ? `every ${n} weeks` : 'every week') : (n > 1 ? `every ${n * 2} weeks` : 'every other week');
+      text = `Repeats ${unit} on ${dowLabel}`;
+    } else if (MONTHLY.has(cad)) {
+      const cadenceWord = { 'Monthly': 'month', 'Quarterly': 'quarter', 'Semi-Annual': 'half year', 'Annual': 'year' }[cad];
+      const unit = n > 1 ? `${every} ${n} ${cadenceWord}s` : `every ${cadenceWord}`;
+      const pattern = byId('re-month-pattern').value;
+      if (pattern === 'nth_weekday') {
+        const nthN = (byId('re-nth-n') || {}).value || '-1';
+        const nthDow = (byId('re-nth-dow') || {}).value || '0';
+        text = `Repeats ${unit} on the ${NTH_NAMES[nthN]} ${DOW_NAMES[parseInt(nthDow, 10)]}`;
+      } else {
+        const dom = (form.elements['day_of_month'] || {}).value;
+        text = dom
+          ? `Repeats ${unit} on day ${dom} (clamped to month-end)`
+          : `Repeats ${unit} on the start date's day`;
+      }
+    }
+    byId('re-summary').textContent = text;
+  }
+
+  window.recurringRuleChanged = function () {
+    visibleCadenceGroups();
+    renderSummary();
+  };
+
+  // Initial render
+  visibleCadenceGroups();
+  setMonthPattern(byId('re-month-pattern').value || 'day_of_month');
+  renderSummary();
+})();
+</script>


### PR DESCRIPTION
## Summary
- **Feature — Recurring schedules (clients → Recurring):** new monthly pattern picker for "On day of month" vs "On the Nth weekday" (First/…/Last × Mon–Sun) — finally lets you express "last Monday of every month". Live plain-English summary under the rule. Slideover re-themed to match the rest of the app (field-label/form-input/form-select/btn-primary + warm neutrals). Cadence-aware groups hide irrelevant controls. Migration 156 adds `month_pattern`, `nth_weekday_n`, `nth_weekday_dow`.
- **Bug — Annual exposures matrix wraps / inconsistent \$:** dropped the `| currency` filter and leading `\$`; values like `12,500,000` no longer wrap thanks to `tabular-nums` + `whitespace-nowrap` + slightly wider numeric columns. Backend PATCH response no longer echoes `\$` back on save.
- **Bug — Chart Deck Builder /charts dropdown:** `initClientAutocomplete` was calling `/api/client-search` (404). Repointed at `/charts/api/client-search`.
- **Bug — Renewal issues on Lost/Not Tracked policies:** new `_renewal_skip_statuses()` unions configured `renewal_terminal_statuses` with a hard-coded `Lost / Non-Renewed / Declined / Not Tracked` skip list so the filter works regardless of user config. Applied to bulk query, single-policy fast path, and program child roll-up. Added the new statuses to `renewal_statuses` and `renewal_statuses_excluded` defaults.

## Test plan
- [x] Verified nth-weekday date math end-to-end (last Monday, first Tuesday, third Friday, quarterly, 5→4 clamp, legacy day_of_month)
- [x] Created a real "Last Monday" schedule in the browser — row persisted with `next_occurrence = 2026-05-25`, Upcoming showed `Due 2026-04-27`, Issues count bumped from 6 → 7 (Focus Queue wiring confirmed)
- [x] Round-tripped edit: Monthly / Last / Monday pre-selected, summary re-renders
- [x] Switched cadence Weekly ↔ Monthly — group toggles + summary update correctly
- [x] Exposures matrix: 32,000,000 / 38,000,000 / 8,500,000 values render clean, single-line, no `\$`; rate cell shows `0.44` not `\$0.44`
- [x] Chart Deck dropdown populates on focus (6 clients visible)
- [x] E2E flip POL-004 through `Lost → Not Tracked → In Progress` — open renewal issue count went `0 → 0 → 1` (and DB restored afterward)

🤖 Generated with [Claude Code](https://claude.com/claude-code)