### PR TITLE
fix(review): program grouping, issue slideover, activity detail, location context

### DIFF
--- a/src/policydb/queries.py
+++ b/src/policydb/queries.py
@@ -5425,16 +5425,39 @@ def get_review_section_items(conn: sqlite3.Connection, section_key: str) -> list
 
     if section_key == "upcoming_renewals":
         window = cfg.get("review_renewal_window_days", 120)
-        return [dict(r) for r in conn.execute(
-            """SELECT p.*, c.name as client_name
+        # Standalone policies (not part of any program)
+        standalone = [dict(r) for r in conn.execute(
+            """SELECT p.*, c.name as client_name, 'policy' as _item_type
                FROM policies p
                JOIN clients c ON p.client_id = c.id
                WHERE p.expiration_date IS NOT NULL
                  AND p.expiration_date BETWEEN date('now') AND date('now', '+' || ? || ' days')
                  AND (p.is_opportunity = 0 OR p.is_opportunity IS NULL)
+                 AND p.program_id IS NULL
                ORDER BY p.expiration_date ASC""",
             (window,),
         ).fetchall()]
+        # Programs with at least one child policy expiring in window
+        programs = [dict(r) for r in conn.execute(
+            """SELECT pr.id, pr.program_uid, pr.name, c.name as client_name,
+                      pr.renewal_status, pr.line_of_business,
+                      MIN(p.expiration_date) as expiration_date,
+                      COUNT(p.id) as policy_count,
+                      'program' as _item_type
+               FROM programs pr
+               JOIN clients c ON pr.client_id = c.id
+               JOIN policies p ON p.program_id = pr.id
+               WHERE p.expiration_date IS NOT NULL
+                 AND p.expiration_date BETWEEN date('now') AND date('now', '+' || ? || ' days')
+                 AND (p.is_opportunity = 0 OR p.is_opportunity IS NULL)
+                 AND p.archived = 0
+               GROUP BY pr.id
+               ORDER BY MIN(p.expiration_date) ASC""",
+            (window,),
+        ).fetchall()]
+        combined = standalone + programs
+        combined.sort(key=lambda x: x.get("expiration_date") or "9999-99-99")
+        return combined
 
     if section_key == "open_issues":
         stale_days = cfg.get("review_stale_issue_days", 14)

--- a/src/policydb/web/routes/review.py
+++ b/src/policydb/web/routes/review.py
@@ -41,6 +41,7 @@ router = APIRouter(prefix="/review")
 
 _REVIEW_ROW_SQL = """
     SELECT p.*, c.name AS client_name, c.id AS client_id,
+           pg.name AS program_name, pg.program_uid AS parent_program_uid,
            CASE WHEN p.is_opportunity = 1 THEN NULL
                 ELSE CAST(julianday(p.expiration_date) - julianday('now') AS INTEGER)
            END AS days_to_renewal,
@@ -54,7 +55,9 @@ _REVIEW_ROW_SQL = """
            CASE WHEN p.last_reviewed_at IS NULL THEN 9999
                 ELSE CAST(julianday('now') - julianday(p.last_reviewed_at) AS INTEGER)
            END AS days_since_review
-    FROM policies p JOIN clients c ON c.id = p.client_id
+    FROM policies p
+    JOIN clients c ON c.id = p.client_id
+    LEFT JOIN programs pg ON pg.id = p.program_id
     WHERE p.policy_uid = ?
 """
 
@@ -144,24 +147,11 @@ def _get_policy_review_context(conn, uid: str) -> dict | None:
     from policydb.anomaly_engine import get_review_gate_status
     gate = get_review_gate_status(conn, "policy", policy_id)
 
-    # Follow-up info
-    active_fu = None
-    if policy_id:
-        fu_row = conn.execute("""
-            SELECT follow_up_date, subject, activity_type
-            FROM activity_log
-            WHERE policy_id = ? AND follow_up_done = 0 AND follow_up_date IS NOT NULL
-            ORDER BY follow_up_date ASC LIMIT 1
-        """, (policy_id,)).fetchone()
-        if fu_row:
-            active_fu = dict(fu_row)
-
     return {
         "p": row,
         "policy_contacts": policy_contacts,
         "primary_client_contact": primary_client_contact,
         "gate": gate,
-        "active_followup": active_fu,
     }
 
 
@@ -1081,6 +1071,204 @@ def accept_profile(
         "review/_policy_row.html",
         _policy_row_context(request, r, suggestions=suggestions),
     )
+
+
+# ── Program Review Slideover ─────────────────────────────────────────────────
+
+@router.get("/programs/{program_uid}/slideover", response_class=HTMLResponse)
+def program_slideover(request: Request, program_uid: str, conn=Depends(get_db)):
+    """Return the program review slideover — shows all child policies."""
+    prog = conn.execute(
+        """SELECT pr.*, c.name AS client_name, c.id AS client_id
+           FROM programs pr
+           JOIN clients c ON c.id = pr.client_id
+           WHERE pr.program_uid = ?""",
+        (program_uid,),
+    ).fetchone()
+    if not prog:
+        return HTMLResponse("")
+    prog = dict(prog)
+
+    # Child policies with key renewal info
+    child_policies = [dict(r) for r in conn.execute(
+        """SELECT p.id, p.policy_uid, p.policy_type, p.carrier, p.expiration_date,
+                  p.renewal_status, p.premium, p.limit_amount,
+                  CAST(julianday(p.expiration_date) - julianday('now') AS INTEGER) AS days_to_renewal,
+                  CASE WHEN julianday(p.expiration_date) - julianday('now') <= 0 THEN 'EXPIRED'
+                       WHEN julianday(p.expiration_date) - julianday('now') <= 90 THEN 'URGENT'
+                       WHEN julianday(p.expiration_date) - julianday('now') <= 120 THEN 'WARNING'
+                       WHEN julianday(p.expiration_date) - julianday('now') <= 180 THEN 'UPCOMING'
+                       ELSE 'OK'
+                  END AS urgency
+           FROM policies p
+           WHERE p.program_id = ? AND p.archived = 0
+           ORDER BY p.expiration_date ASC""",
+        (prog["id"],),
+    ).fetchall()]
+
+    # Recent activity across all child policies
+    policy_ids = [p["id"] for p in child_policies]
+    recent_activity: list[dict] = []
+    if policy_ids:
+        placeholders = ",".join("?" * len(policy_ids))
+        recent_activity = [dict(r) for r in conn.execute(
+            f"""SELECT a.id, a.activity_date, a.activity_type, a.subject, a.details,
+                       a.duration_hours, p.policy_uid, p.policy_type
+                FROM activity_log a
+                JOIN policies p ON a.policy_id = p.id
+                WHERE a.policy_id IN ({placeholders}) AND a.item_kind != 'issue'
+                ORDER BY a.activity_date DESC, a.id DESC
+                LIMIT 8""",
+            policy_ids,
+        ).fetchall()]
+
+    # Open issues across all child policies
+    open_issues: list[dict] = []
+    if policy_ids:
+        placeholders = ",".join("?" * len(policy_ids))
+        open_issues = [dict(r) for r in conn.execute(
+            f"""SELECT a.id, a.issue_uid, a.subject, a.issue_severity, a.issue_status,
+                       CAST(julianday('now') - julianday(a.activity_date) AS INTEGER) AS days_open,
+                       p.policy_uid, p.policy_type
+                FROM activity_log a
+                JOIN policies p ON a.policy_id = p.id
+                WHERE a.policy_id IN ({placeholders}) AND a.item_kind = 'issue'
+                  AND a.issue_status NOT IN ('Resolved', 'Closed')
+                ORDER BY CASE a.issue_severity WHEN 'Critical' THEN 1 WHEN 'High' THEN 2 ELSE 3 END""",
+            policy_ids,
+        ).fetchall()]
+
+    return templates.TemplateResponse("review/_program_review_slideover.html", {
+        "request": request,
+        "prog": prog,
+        "child_policies": child_policies,
+        "recent_activity": recent_activity,
+        "open_issues": open_issues,
+        "renewal_statuses": cfg.get("renewal_statuses", []),
+        "today": date.today().isoformat(),
+    })
+
+
+@router.post("/programs/{program_uid}/slideover/reviewed", response_class=HTMLResponse)
+def program_slideover_mark_reviewed(
+    request: Request,
+    program_uid: str,
+    conn=Depends(get_db),
+):
+    """Mark the program + all child policies reviewed."""
+    prog = conn.execute(
+        "SELECT id FROM programs WHERE program_uid = ?", (program_uid,)
+    ).fetchone()
+    if not prog:
+        return HTMLResponse("")
+
+    conn.execute(
+        "UPDATE programs SET last_reviewed_at = CURRENT_TIMESTAMP WHERE program_uid = ?",
+        (program_uid,),
+    )
+    conn.execute(
+        "UPDATE policies SET last_reviewed_at = CURRENT_TIMESTAMP WHERE program_id = ?",
+        (prog["id"],),
+    )
+    conn.commit()
+
+    import json as _json
+    footer_html = """
+    <div id="review-slideover-footer" hx-swap-oob="innerHTML:#review-slideover-footer">
+      <div class="flex items-center justify-center gap-2 text-green-600">
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+        </svg>
+        <span class="font-semibold text-sm">Program Reviewed — all policies updated</span>
+      </div>
+    </div>
+    """
+
+    resp = HTMLResponse(footer_html)
+    resp.headers["HX-Trigger"] = _json.dumps({
+        "refreshReviewStats": True,
+        "reviewRowCleared": f"#review-walkthrough-program-{program_uid}",
+    })
+    return resp
+
+
+# ── Issue Review Slideover ───────────────────────────────────────────────────
+
+@router.get("/issues/{issue_id}/slideover", response_class=HTMLResponse)
+def issue_slideover(request: Request, issue_id: int, conn=Depends(get_db)):
+    """Return the issue review slideover — full context for reviewing an open issue."""
+    issue = conn.execute(
+        """SELECT a.*, c.name AS client_name, c.id AS client_id,
+                  p.policy_uid, p.policy_type, p.carrier, p.expiration_date,
+                  p.renewal_status, p.premium,
+                  CAST(julianday('now') - julianday(a.activity_date) AS INTEGER) AS days_open,
+                  CAST(julianday(p.expiration_date) - julianday('now') AS INTEGER) AS days_to_renewal
+           FROM activity_log a
+           LEFT JOIN clients c ON a.client_id = c.id
+           LEFT JOIN policies p ON a.policy_id = p.id
+           WHERE a.id = ? AND a.item_kind = 'issue'""",
+        (issue_id,),
+    ).fetchone()
+    if not issue:
+        return HTMLResponse("")
+    issue = dict(issue)
+
+    # Recent activity on the same policy (for context)
+    related_activity: list[dict] = []
+    if issue.get("policy_id"):
+        related_activity = [dict(r) for r in conn.execute(
+            """SELECT a.id, a.activity_date, a.activity_type, a.subject, a.details
+               FROM activity_log a
+               WHERE a.policy_id = ? AND a.item_kind != 'issue' AND a.id != ?
+               ORDER BY a.activity_date DESC, a.id DESC
+               LIMIT 5""",
+            (issue["policy_id"], issue_id),
+        ).fetchall()]
+
+    # Other open issues on the same policy
+    sibling_issues: list[dict] = []
+    if issue.get("policy_id"):
+        sibling_issues = [dict(r) for r in conn.execute(
+            """SELECT a.id, a.subject, a.issue_severity, a.issue_status,
+                      CAST(julianday('now') - julianday(a.activity_date) AS INTEGER) AS days_open
+               FROM activity_log a
+               WHERE a.policy_id = ? AND a.item_kind = 'issue'
+                 AND a.issue_status NOT IN ('Resolved', 'Closed') AND a.id != ?
+               ORDER BY CASE a.issue_severity WHEN 'Critical' THEN 1 WHEN 'High' THEN 2 ELSE 3 END""",
+            (issue["policy_id"], issue_id),
+        ).fetchall()]
+
+    issue_statuses = cfg.get("issue_statuses", ["Open", "In Progress", "Pending", "Resolved", "Closed"])
+
+    return templates.TemplateResponse("review/_issue_review_slideover.html", {
+        "request": request,
+        "issue": issue,
+        "related_activity": related_activity,
+        "sibling_issues": sibling_issues,
+        "issue_statuses": issue_statuses,
+        "today": date.today().isoformat(),
+    })
+
+
+@router.post("/issues/{issue_id}/status", response_class=HTMLResponse)
+def issue_update_status(
+    request: Request,
+    issue_id: int,
+    status: str = Form(...),
+    conn=Depends(get_db),
+):
+    """Update issue status from the review slideover."""
+    conn.execute(
+        "UPDATE activity_log SET issue_status = ? WHERE id = ? AND item_kind = 'issue'",
+        (status, issue_id),
+    )
+    conn.commit()
+    if status in ("Resolved", "Closed"):
+        import json as _json
+        resp = HTMLResponse('<div id="review-slideover-footer" hx-swap-oob="innerHTML:#review-slideover-footer"><div class="flex items-center justify-center gap-2 text-green-600 py-2"><svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg><span class="font-semibold text-sm">Issue Closed</span></div></div>')
+        resp.headers["HX-Trigger"] = _json.dumps({"refreshReviewStats": True})
+        return resp
+    return issue_slideover(request, issue_id, conn)
 
 
 # ── Bulk accept all profile suggestions ──────────────────────────────────────

--- a/src/policydb/web/templates/review/_issue_review_slideover.html
+++ b/src/policydb/web/templates/review/_issue_review_slideover.html
@@ -1,0 +1,188 @@
+{# Issue Review Slideover — full context for reviewing an open issue.
+   Context: issue, related_activity, sibling_issues, issue_statuses, today
+#}
+
+{# ── Backdrop ── #}
+<div id="review-slideover-backdrop"
+     class="fixed inset-0 bg-black/30 z-40"
+     onclick="closeReviewSlideover()"></div>
+
+{# ── Panel ── #}
+<div id="review-slideover-panel"
+     class="fixed top-0 right-0 bottom-0 w-[560px] max-sm:w-full bg-white shadow-xl z-50 flex flex-col review-slideover-enter">
+
+  {# ── Header ── #}
+  <div class="shrink-0 border-b bg-white">
+    <div class="flex items-center justify-between px-5 pt-4 pb-3">
+      <div class="min-w-0 flex-1">
+        <div class="flex items-center gap-2 flex-wrap">
+          {% if issue.issue_severity %}
+          <span class="shrink-0 text-xs px-2 py-0.5 rounded-full font-semibold
+            {% if issue.issue_severity == 'Critical' %}bg-red-100 text-red-700
+            {% elif issue.issue_severity == 'High' %}bg-orange-100 text-orange-700
+            {% else %}bg-yellow-100 text-yellow-700{% endif %}">
+            {{ issue.issue_severity }}
+          </span>
+          {% endif %}
+          <a href="/clients/{{ issue.client_id }}" class="text-sm font-semibold text-marsh hover:underline truncate">{{ issue.client_name or 'Unknown' }}</a>
+          {% if issue.policy_uid %}
+          <span class="text-gray-300">&middot;</span>
+          <a href="/policies/{{ issue.policy_uid }}" class="text-xs font-mono text-gray-400 hover:text-marsh hover:underline">{{ issue.policy_uid }}</a>
+          {% endif %}
+        </div>
+        <div class="mt-1 text-sm font-semibold text-gray-900">{{ issue.subject }}</div>
+        <div class="flex items-center gap-2 mt-0.5 text-xs text-gray-500 flex-wrap">
+          {% if issue.issue_uid %}
+          <span class="font-mono text-gray-400">{{ issue.issue_uid }}</span>
+          {% endif %}
+          <span>Open {{ issue.days_open }}d</span>
+          {% if issue.due_date %}
+          <span class="text-gray-400">&middot;</span>
+          <span class="{% if issue.due_date < today %}text-red-500{% else %}text-gray-500{% endif %}">
+            Due {{ issue.due_date }}
+          </span>
+          {% endif %}
+          {% if issue.is_renewal_issue %}
+          <span class="text-amber-600 bg-amber-50 px-1.5 py-0.5 rounded font-medium">Renewal Issue</span>
+          {% endif %}
+        </div>
+      </div>
+      <button onclick="closeReviewSlideover()"
+              class="text-gray-400 hover:text-gray-600 transition-colors p-1 shrink-0 ml-3"
+              aria-label="Close panel">
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+        </svg>
+      </button>
+    </div>
+  </div>
+
+  {# ── Scrollable Content ── #}
+  <div class="flex-1 overflow-y-auto">
+
+    {# ── Issue Details ── #}
+    {% if issue.details %}
+    <div class="px-5 py-4 border-b border-gray-100">
+      <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Details</h3>
+      <p class="text-sm text-gray-700 leading-relaxed whitespace-pre-line">{{ issue.details }}</p>
+    </div>
+    {% endif %}
+
+    {# ── Related Policy Context ── #}
+    {% if issue.policy_uid %}
+    <div class="px-5 py-4 border-b border-gray-100">
+      <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Policy</h3>
+      <div class="grid grid-cols-3 gap-3 text-center">
+        <div>
+          <div class="text-[10px] text-gray-400 uppercase">Type</div>
+          <div class="text-xs font-medium text-gray-700">{{ issue.policy_type or '—' }}</div>
+        </div>
+        <div>
+          <div class="text-[10px] text-gray-400 uppercase">Carrier</div>
+          <div class="text-xs font-medium text-gray-700">{{ issue.carrier or '—' }}</div>
+        </div>
+        <div>
+          <div class="text-[10px] text-gray-400 uppercase">Expiration</div>
+          <div class="text-xs font-medium {% if issue.days_to_renewal is not none and issue.days_to_renewal <= 90 %}text-red-600{% else %}text-gray-700{% endif %}">
+            {{ issue.expiration_date or '—' }}
+            {% if issue.days_to_renewal is not none %}
+            <span class="text-gray-400">({{ issue.days_to_renewal }}d)</span>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+      {% if issue.renewal_status %}
+      <div class="mt-2 text-xs text-gray-500">Status: <span class="font-medium text-gray-700">{{ issue.renewal_status }}</span></div>
+      {% endif %}
+    </div>
+    {% endif %}
+
+    {# ── Other Open Issues on Same Policy ── #}
+    {% if sibling_issues %}
+    <div class="px-5 py-4 border-b border-gray-100">
+      <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Other Open Issues on This Policy</h3>
+      <div class="space-y-1.5">
+        {% for sib in sibling_issues %}
+        <div class="flex items-center gap-2 text-xs">
+          <span class="shrink-0 px-1.5 py-0.5 rounded-full font-medium
+            {% if sib.issue_severity == 'Critical' %}bg-red-100 text-red-700
+            {% elif sib.issue_severity == 'High' %}bg-orange-100 text-orange-700
+            {% else %}bg-yellow-100 text-yellow-700{% endif %}">
+            {{ sib.issue_severity or 'Normal' }}
+          </span>
+          <button type="button"
+                  hx-get="/review/issues/{{ sib.id }}/slideover"
+                  hx-target="#review-slideover-container" hx-swap="innerHTML"
+                  class="text-marsh hover:underline truncate text-left">{{ sib.subject }}</button>
+          <span class="text-gray-400 shrink-0">{{ sib.days_open }}d</span>
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+    {% endif %}
+
+    {# ── Recent Activity on Related Policy ── #}
+    {% if related_activity %}
+    <div class="px-5 py-4 border-b border-gray-100">
+      <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Recent Policy Activity</h3>
+      <div class="space-y-2">
+        {% for a in related_activity %}
+        <div class="text-xs py-1 {% if not loop.last %}border-b border-gray-50{% endif %}">
+          <div class="flex items-center gap-2">
+            <span class="text-gray-400 w-16 shrink-0 tabular-nums">{{ a.activity_date }}</span>
+            <span class="px-1.5 py-0.5 rounded bg-gray-100 text-gray-500 text-[10px] shrink-0">{{ a.activity_type }}</span>
+            <span class="text-gray-700 truncate flex-1 font-medium">{{ a.subject }}</span>
+          </div>
+          {% if a.details %}
+          <div class="mt-0.5 ml-[72px] text-gray-400 line-clamp-2">{{ a.details }}</div>
+          {% endif %}
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+    {% endif %}
+
+    {# ── Change Status ── #}
+    <div class="px-5 py-4">
+      <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Update Status</h3>
+      <div class="flex flex-wrap gap-2">
+        {% for s in issue_statuses %}
+        <button type="button"
+                hx-post="/review/issues/{{ issue.id }}/status"
+                hx-vals='{"status": "{{ s }}"}'
+                hx-target="#review-slideover-container"
+                hx-swap="innerHTML"
+                class="text-xs px-3 py-1.5 rounded-full border transition-colors
+                  {% if issue.issue_status == s %}
+                    bg-marsh text-white border-marsh
+                  {% else %}
+                    bg-white text-gray-600 border-gray-200 hover:border-marsh hover:text-marsh
+                  {% endif %}">
+          {{ s }}
+        </button>
+        {% endfor %}
+      </div>
+    </div>
+
+  </div>
+
+  {# ── Footer ── #}
+  <div id="review-slideover-footer" class="shrink-0 border-t bg-white px-5 py-3">
+    <div class="flex items-center justify-between">
+      <div class="text-xs text-gray-400">{{ issue.issue_status }}</div>
+      <div class="flex items-center gap-3">
+        {% if issue.policy_uid %}
+        <a href="/policies/{{ issue.policy_uid }}/edit" class="text-xs text-gray-400 hover:underline">View Policy</a>
+        {% endif %}
+        <button type="button"
+                hx-post="/review/issues/{{ issue.id }}/status"
+                hx-vals='{"status": "Resolved"}'
+                hx-target="#review-slideover-container"
+                hx-swap="innerHTML"
+                class="text-sm bg-green-600 text-white px-4 py-2 rounded-lg hover:bg-green-700 transition-colors font-medium">
+          Mark Resolved
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/policydb/web/templates/review/_policy_review_activity.html
+++ b/src/policydb/web/templates/review/_policy_review_activity.html
@@ -5,14 +5,22 @@
 
 {# Recent activity list #}
 {% if activities %}
-<div class="space-y-1 mb-3">
+<div class="space-y-2 mb-3">
   {% for a in activities %}
-  <div class="flex items-center gap-2 text-xs py-1 {% if not loop.last %}border-b border-gray-50{% endif %}">
-    <span class="text-gray-400 w-16 shrink-0 tabular-nums">{{ a.activity_date }}</span>
-    <span class="px-1.5 py-0.5 rounded bg-gray-100 text-gray-500 text-[10px] shrink-0">{{ a.activity_type }}</span>
-    <span class="text-gray-700 truncate flex-1">{{ a.subject }}</span>
-    {% if a.duration_hours %}
-    <span class="text-gray-400 shrink-0 tabular-nums">{{ a.duration_hours | format_hours }}</span>
+  <div class="text-xs py-1.5 {% if not loop.last %}border-b border-gray-50{% endif %}">
+    <div class="flex items-center gap-2">
+      <span class="text-gray-400 w-16 shrink-0 tabular-nums">{{ a.activity_date }}</span>
+      <span class="px-1.5 py-0.5 rounded bg-gray-100 text-gray-500 text-[10px] shrink-0">{{ a.activity_type }}</span>
+      <span class="text-gray-700 truncate flex-1 font-medium">{{ a.subject }}</span>
+      {% if a.duration_hours %}
+      <span class="text-gray-400 shrink-0 tabular-nums">{{ a.duration_hours | format_hours }}</span>
+      {% endif %}
+    </div>
+    {% if a.details %}
+    <div class="mt-0.5 ml-[72px] text-gray-400 leading-relaxed line-clamp-2">{{ a.details }}</div>
+    {% endif %}
+    {% if a.contact_name %}
+    <div class="mt-0.5 ml-[72px] text-gray-400 italic">{{ a.contact_name }}</div>
     {% endif %}
   </div>
   {% endfor %}
@@ -53,8 +61,6 @@
     </div>
     {% endif %}
     <div class="flex items-center gap-2">
-      <input type="date" name="follow_up_date" class="text-xs border border-gray-200 rounded px-2 py-1.5 focus:ring-1 focus:ring-marsh"
-             placeholder="Follow-up">
       <input type="text" name="duration_hours" placeholder="Hours" inputmode="decimal"
              class="w-16 text-xs border border-gray-200 rounded px-2 py-1.5 focus:ring-1 focus:ring-marsh text-right">
       <button type="submit" class="text-xs bg-marsh text-white px-3 py-1.5 rounded hover:bg-marsh-light transition-colors ml-auto">Log</button>

--- a/src/policydb/web/templates/review/_policy_review_slideover.html
+++ b/src/policydb/web/templates/review/_policy_review_slideover.html
@@ -1,5 +1,5 @@
 {# Policy Review Slideover — full-context review workspace.
-   Context: p, policy_contacts, primary_client_contact, gate, active_followup,
+   Context: p, policy_contacts, primary_client_contact, gate,
             renewal_statuses, cycle_labels, milestone_profiles, suggestions,
             today, queue_uids
 #}
@@ -52,6 +52,20 @@
           </span>
           {% endif %}
         </div>
+        {% if p.get('project_name') or p.get('program_name') %}
+        <div class="flex items-center gap-2 mt-0.5 flex-wrap">
+          {% if p.project_name %}
+          <span class="text-xs text-gray-400">
+            <svg class="w-3 h-3 inline-block mr-0.5 -mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"/></svg>{{ p.project_name }}
+          </span>
+          {% endif %}
+          {% if p.program_name %}
+          <span class="inline-flex items-center gap-1 text-xs bg-indigo-50 text-indigo-600 px-1.5 py-0.5 rounded font-medium">
+            Program: {{ p.program_name }}
+          </span>
+          {% endif %}
+        </div>
+        {% endif %}
       </div>
       <div class="flex items-center gap-2 shrink-0 ml-3">
         {# Prev/Next nav #}
@@ -160,28 +174,6 @@
           <div class="text-[10px] text-gray-400 uppercase">Limit</div>
           <div class="text-xs font-medium text-gray-700">{{ p.limit_amount | currency_short if p.limit_amount else '—' }}</div>
         </div>
-      </div>
-
-      {# Follow-up #}
-      <div class="flex items-center gap-2 mb-2">
-        <span class="text-xs text-gray-500 w-16 shrink-0">Follow-up:</span>
-        {% if active_followup %}
-          <span class="text-xs font-medium {% if active_followup.follow_up_date < today %}text-red-600{% else %}text-gray-700{% endif %}">
-            {{ active_followup.follow_up_date }}
-          </span>
-          <span class="text-xs text-gray-400">{{ active_followup.subject }}</span>
-        {% else %}
-          <span class="text-xs text-gray-300">No active follow-up</span>
-        {% endif %}
-        <form class="inline-flex items-center gap-1 ml-auto"
-              hx-post="/review/policies/{{ p.policy_uid }}/slideover/field"
-              hx-swap="innerHTML" hx-target="#fu-save-status">
-          <input type="hidden" name="field" value="follow_up_date">
-          <input type="date" name="value" class="text-xs border border-gray-200 rounded px-1.5 py-1 focus:ring-1 focus:ring-marsh"
-                 min="{{ today }}" value="">
-          <button type="submit" class="text-xs text-marsh hover:underline">Set</button>
-        </form>
-        <span id="fu-save-status"></span>
       </div>
 
       {# Milestone profile + checklist #}

--- a/src/policydb/web/templates/review/_program_review_slideover.html
+++ b/src/policydb/web/templates/review/_program_review_slideover.html
@@ -1,0 +1,171 @@
+{# Program Review Slideover — shows all child policies for a program.
+   Context: prog, child_policies, recent_activity, open_issues, renewal_statuses, today
+#}
+
+{# ── Backdrop ── #}
+<div id="review-slideover-backdrop"
+     class="fixed inset-0 bg-black/30 z-40"
+     onclick="closeReviewSlideover()"></div>
+
+{# ── Panel ── #}
+<div id="review-slideover-panel"
+     class="fixed top-0 right-0 bottom-0 w-[580px] max-sm:w-full bg-white shadow-xl z-50 flex flex-col review-slideover-enter">
+
+  {# ── Header ── #}
+  <div class="shrink-0 border-b bg-white">
+    <div class="flex items-center justify-between px-5 pt-4 pb-2">
+      <div class="min-w-0 flex-1">
+        <div class="flex items-center gap-2 flex-wrap">
+          <span class="inline-flex items-center text-xs font-medium bg-indigo-50 text-indigo-700 px-2 py-0.5 rounded">Program</span>
+          <a href="/clients/{{ prog.client_id }}" class="font-semibold text-marsh hover:underline text-sm truncate">{{ prog.client_name }}</a>
+        </div>
+        <div class="mt-1 text-base font-semibold text-gray-900">{{ prog.name }}</div>
+        <div class="flex items-center gap-2 mt-0.5 flex-wrap text-xs text-gray-500">
+          <span class="font-mono text-gray-400">{{ prog.program_uid }}</span>
+          {% if prog.line_of_business %}
+            <span class="text-gray-400">&middot;</span>
+            <span>{{ prog.line_of_business }}</span>
+          {% endif %}
+          {% if child_policies %}
+            <span class="text-gray-400">&middot;</span>
+            <span>{{ child_policies | length }} {{ 'policy' if child_policies | length == 1 else 'policies' }}</span>
+          {% endif %}
+        </div>
+      </div>
+      <button onclick="closeReviewSlideover()"
+              class="text-gray-400 hover:text-gray-600 transition-colors p-1 shrink-0 ml-3"
+              aria-label="Close panel">
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+        </svg>
+      </button>
+    </div>
+  </div>
+
+  {# ── Scrollable Content ── #}
+  <div class="flex-1 overflow-y-auto">
+
+    {# ── Open Issues ── #}
+    {% if open_issues %}
+    <div class="px-5 py-4 border-b border-gray-100 bg-amber-50">
+      <h3 class="text-xs font-semibold text-amber-700 uppercase tracking-wide mb-2">
+        {{ open_issues | length }} Open {{ 'Issue' if open_issues | length == 1 else 'Issues' }}
+      </h3>
+      <div class="space-y-1.5">
+        {% for issue in open_issues %}
+        <div class="flex items-center justify-between text-xs">
+          <div class="flex items-center gap-2 min-w-0">
+            <span class="shrink-0 px-1.5 py-0.5 rounded-full font-medium
+              {% if issue.issue_severity == 'Critical' %}bg-red-100 text-red-700
+              {% elif issue.issue_severity == 'High' %}bg-orange-100 text-orange-700
+              {% else %}bg-yellow-100 text-yellow-700{% endif %}">
+              {{ issue.issue_severity or 'Normal' }}
+            </span>
+            <span class="text-gray-700 truncate">{{ issue.subject }}</span>
+          </div>
+          <span class="text-gray-400 shrink-0 ml-2">{{ issue.policy_type }} &middot; {{ issue.days_open }}d</span>
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+    {% endif %}
+
+    {# ── Child Policies ── #}
+    <div class="px-5 py-4 border-b border-gray-100">
+      <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">Policies in Program</h3>
+      {% if child_policies %}
+      <div class="space-y-2">
+        {% for pol in child_policies %}
+        <div class="flex items-center justify-between text-xs py-1.5 border-b border-gray-50 last:border-0">
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2 flex-wrap">
+              <a href="/policies/{{ pol.policy_uid }}" class="font-medium text-marsh hover:underline font-mono">{{ pol.policy_uid }}</a>
+              <span class="text-gray-600">{{ pol.policy_type }}</span>
+              {% if pol.carrier %}
+                <span class="text-gray-400">&middot;</span>
+                <span class="text-gray-500">{{ pol.carrier }}</span>
+              {% endif %}
+              <span class="{{ pol.urgency | urgency_class }} font-semibold px-1.5 py-0.5 rounded text-[10px]">
+                {% if pol.days_to_renewal <= 0 %}Expired{% else %}{{ pol.days_to_renewal }}d{% endif %}
+              </span>
+            </div>
+            <div class="flex items-center gap-3 mt-0.5 text-gray-400">
+              <span>Exp {{ pol.expiration_date }}</span>
+              {% if pol.renewal_status %}<span>{{ pol.renewal_status }}</span>{% endif %}
+              {% if pol.premium %}<span>{{ pol.premium | currency_short }}</span>{% endif %}
+            </div>
+          </div>
+          <a href="/review/policies/{{ pol.policy_uid }}/slideover"
+             hx-get="/review/policies/{{ pol.policy_uid }}/slideover"
+             hx-target="#review-slideover-container" hx-swap="innerHTML"
+             class="shrink-0 ml-2 text-gray-400 hover:text-marsh text-[10px] hover:underline">
+            Open
+          </a>
+        </div>
+        {% endfor %}
+      </div>
+      {% else %}
+      <p class="text-xs text-gray-300">No active policies in this program.</p>
+      {% endif %}
+    </div>
+
+    {# ── Recent Activity ── #}
+    <div class="px-5 py-4 border-b border-gray-100">
+      <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Recent Activity</h3>
+      {% if recent_activity %}
+      <div class="space-y-2">
+        {% for a in recent_activity %}
+        <div class="text-xs py-1 {% if not loop.last %}border-b border-gray-50{% endif %}">
+          <div class="flex items-center gap-2">
+            <span class="text-gray-400 w-16 shrink-0 tabular-nums">{{ a.activity_date }}</span>
+            <span class="px-1.5 py-0.5 rounded bg-gray-100 text-gray-500 text-[10px] shrink-0">{{ a.activity_type }}</span>
+            <span class="text-gray-700 truncate flex-1 font-medium">{{ a.subject }}</span>
+            <span class="text-gray-400 shrink-0 text-[10px]">{{ a.policy_type }}</span>
+          </div>
+          {% if a.details %}
+          <div class="mt-0.5 ml-[72px] text-gray-400 line-clamp-2">{{ a.details }}</div>
+          {% endif %}
+        </div>
+        {% endfor %}
+      </div>
+      {% else %}
+      <p class="text-xs text-gray-300">No recent activity on this program.</p>
+      {% endif %}
+    </div>
+
+    {# ── Program Notes ── #}
+    {% if prog.notes or prog.working_notes %}
+    <div class="px-5 py-4">
+      <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Notes</h3>
+      {% if prog.notes %}
+      <p class="text-xs text-gray-600 leading-relaxed">{{ prog.notes }}</p>
+      {% endif %}
+      {% if prog.working_notes %}
+      <p class="text-xs text-gray-500 italic mt-1 leading-relaxed">{{ prog.working_notes }}</p>
+      {% endif %}
+    </div>
+    {% endif %}
+
+  </div>
+
+  {# ── Footer ── #}
+  <div id="review-slideover-footer" class="shrink-0 border-t bg-white px-5 py-3">
+    <div class="flex items-center justify-between">
+      <div class="text-xs text-gray-400">
+        {% if prog.last_reviewed_at %}
+          Last reviewed {{ prog.last_reviewed_at[:10] }}
+        {% else %}
+          Never reviewed
+        {% endif %}
+      </div>
+      <div class="flex items-center gap-3">
+        <a href="/programs/{{ prog.program_uid }}" class="text-xs text-gray-400 hover:underline">Full Page</a>
+        <button hx-post="/review/programs/{{ prog.program_uid }}/slideover/reviewed"
+                hx-target="body" hx-swap="none"
+                class="text-sm bg-marsh text-white px-4 py-2 rounded-lg hover:bg-marsh-light transition-colors font-medium">
+          Mark Program Reviewed
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/policydb/web/templates/review/_walkthrough_section.html
+++ b/src/policydb/web/templates/review/_walkthrough_section.html
@@ -39,6 +39,33 @@
   {% if items %}
   <div class="space-y-2">
     {% for item in items %}
+    {% if item.get('_item_type') == 'program' %}
+    <div id="review-walkthrough-program-{{ item.program_uid }}" class="flex items-center justify-between py-2 px-3 rounded-lg hover:bg-gray-50 border border-gray-100 border-l-4 border-l-indigo-200">
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center gap-2">
+          <span class="text-xs font-medium bg-indigo-50 text-indigo-700 px-1.5 py-0.5 rounded">Program</span>
+          <span class="text-sm font-medium text-gray-800">{{ item.name }}</span>
+          {% if item.client_name %}
+            <span class="text-xs text-gray-400">&middot;</span>
+            <span class="text-xs text-gray-500">{{ item.client_name }}</span>
+          {% endif %}
+        </div>
+        <div class="text-xs text-gray-500 mt-0.5">
+          {{ item.policy_count }} {{ 'policy' if item.policy_count == 1 else 'policies' }}
+          {% if item.line_of_business %} &middot; {{ item.line_of_business }}{% endif %}
+          &middot; Earliest expiry {{ item.expiration_date }}
+        </div>
+      </div>
+      <div class="shrink-0 ml-3">
+        <button hx-get="/review/programs/{{ item.program_uid }}/slideover"
+                hx-target="#review-slideover-container"
+                hx-swap="innerHTML"
+                class="text-xs bg-indigo-50 text-indigo-700 px-3 py-1 rounded hover:bg-indigo-100 transition-colors font-medium">
+          Review Program
+        </button>
+      </div>
+    </div>
+    {% else %}
     <div id="review-walkthrough-policy-{{ item.policy_uid }}" class="flex items-center justify-between py-2 px-3 rounded-lg hover:bg-gray-50 border border-gray-100">
       <div class="flex-1 min-w-0">
         <div class="flex items-center gap-2">
@@ -48,6 +75,10 @@
           {% if item.client_name %}
             <span class="text-xs text-gray-400">&middot;</span>
             <span class="text-xs text-gray-500">{{ item.client_name }}</span>
+          {% endif %}
+          {% if item.project_name %}
+            <span class="text-xs text-gray-400">&middot;</span>
+            <span class="text-xs text-gray-400">{{ item.project_name }}</span>
           {% endif %}
         </div>
         <div class="text-xs text-gray-500 mt-0.5">Expires {{ item.expiration_date }}</div>
@@ -61,6 +92,7 @@
         </button>
       </div>
     </div>
+    {% endif %}
     {% endfor %}
   </div>
   {% else %}
@@ -73,33 +105,35 @@
     {% for item in items %}
     <div class="flex items-center justify-between py-2 px-3 rounded-lg hover:bg-gray-50 border border-gray-100">
       <div class="flex-1 min-w-0">
-        <div class="flex items-center gap-2">
-          <span class="text-sm font-medium text-gray-800 truncate">{{ item.subject or 'Issue' }}</span>
+        <div class="flex items-center gap-2 flex-wrap">
           {% if item.issue_severity %}
-            <span class="text-xs px-1.5 py-0.5 rounded-full font-medium
+            <span class="text-xs px-1.5 py-0.5 rounded-full font-medium shrink-0
               {% if item.issue_severity == 'Critical' %}bg-red-100 text-red-700
               {% elif item.issue_severity == 'High' %}bg-orange-100 text-orange-700
               {% else %}bg-yellow-100 text-yellow-700{% endif %}">
               {{ item.issue_severity }}
             </span>
           {% endif %}
+          <span class="text-sm font-medium text-gray-800 truncate">{{ item.subject or 'Issue' }}</span>
         </div>
-        <div class="flex items-center gap-2 text-xs text-gray-500 mt-0.5">
+        <div class="flex items-center gap-2 text-xs text-gray-500 mt-0.5 flex-wrap">
           {% if item.client_name %}<span>{{ item.client_name }}</span>{% endif %}
+          {% if item.renewal_expiring_soon %}
+            <span class="text-xs font-medium text-amber-600 bg-amber-50 px-1 py-0.5 rounded">Renewal soon</span>
+          {% endif %}
           {% if item.activity_date %}
             <span class="text-gray-400">&middot;</span>
-            <span>Last activity {{ item.activity_date }}</span>
+            <span>{{ item.activity_date }}</span>
           {% endif %}
         </div>
       </div>
       <div class="shrink-0 ml-3">
         <button type="button"
-                hx-get="/issues/{{ item.id }}/edit-slideover"
-                hx-target="#fu-edit-content"
+                hx-get="/review/issues/{{ item.id }}/slideover"
+                hx-target="#review-slideover-container"
                 hx-swap="innerHTML"
-                hx-on::after-request="openFollowupEdit()"
                 class="text-xs bg-gray-100 text-gray-600 px-3 py-1 rounded hover:bg-gray-200 transition-colors font-medium">
-          Edit
+          Review
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- **Program grouping in Upcoming Renewals** — child policies are now collapsed under a single program row; clicking "Review Program" opens a slideover showing all child policies, cross-policy activity, and open issues; marking the program reviewed cascades `last_reviewed_at` to all children atomically
- **Issue review slideover** — the "Edit" button in Open Issues is replaced with a "Review" button that opens a rich slideover with issue details, related policy context (type/carrier/expiration), sibling open issues on the same policy, recent policy activity, and status change pill buttons
- **Location/program context in policy review header** — project name (with location pin) and program badge now appear below the carrier/expiration badges when set
- **Richer activity detail** — activity rows show the `details` field (email body, meeting notes) in muted text below the subject with `line-clamp-2`
- **Remove retired follow-up date field** — the broken "Set" follow-up form in Status & Key Dates (field was dropped in migration 150) and the `follow_up_date` input in the quick-log form are removed

## Test plan

- [ ] Upcoming Renewals: policies with `program_id` show as program rows; standalone policies show individually with project name
- [ ] "Review Program" button opens program slideover; "Mark Program Reviewed" stamps timestamp on program + all child policies
- [ ] Open Issues: "Review" button opens issue slideover with full context; status pills update correctly; Resolved/Closed fires `refreshReviewStats`
- [ ] Policy review slideover header shows location/program badges when present
- [ ] Activity rows show details text when populated
- [ ] No follow-up date field visible in status section or quick-log form

🤖 Generated with [Claude Code](https://claude.com/claude-code)