### PR TITLE
feat(prompt-builder): richer data, Open Items Report, template form fixes

### DIFF
--- a/src/policydb/db.py
+++ b/src/policydb/db.py
@@ -2110,6 +2110,24 @@ def _init_db_inner(conn: sqlite3.Connection, db_path: Path) -> None:
         conn.commit()
         logger.info("Migration 156: added recurring_events month_pattern + nth_weekday_* columns")
 
+    if 157 not in applied:
+        conn.executescript((_MIGRATIONS_DIR / "157_open_items_template.sql").read_text())
+        conn.execute(
+            "INSERT INTO schema_version (version, description) VALUES (?, ?)",
+            (157, "Add Client Open Items Report built-in prompt template"),
+        )
+        conn.commit()
+        logger.info("Migration 157: added Client Open Items Report prompt template")
+
+    if 158 not in applied:
+        conn.executescript((_MIGRATIONS_DIR / "158_issue_depth_overrides.sql").read_text())
+        conn.execute(
+            "INSERT INTO schema_version (version, description) VALUES (?, ?)",
+            (158, "Set issues DEPTH_FULL on Renewal Status Email, Open Items Call Agenda, Stewardship Report Shell"),
+        )
+        conn.commit()
+        logger.info("Migration 158: set issues depth_overrides on 3 built-in templates")
+
     # Data hygiene: fix 'None' string corruption in text fields (runs every startup, fast no-op if clean)
     conn.execute("UPDATE clients SET cn_number = NULL WHERE cn_number = 'None'")
 

--- a/src/policydb/migrations/157_open_items_template.sql
+++ b/src/policydb/migrations/157_open_items_template.sql
@@ -1,0 +1,110 @@
+-- Migration 157: Client Open Items Report built-in prompt template
+
+INSERT INTO prompt_templates (
+    name, deliverable_type, description,
+    system_prompt, closing_instruction,
+    required_record_types, depth_overrides,
+    is_builtin
+)
+VALUES (
+    'Client Open Items Report',
+    'report',
+    'Pre-meeting briefing: open issues, pending actions, accountability by party, and meeting prep snapshot',
+
+    'You are a senior insurance account manager preparing a pre-meeting briefing for internal broker use. Your job is to synthesize the PolicyDB context block into a tight, accountable open-items report the broker team can use to run a client meeting. This is the internal version — candid about risks, gaps, and commitments. The broker decides what to adapt or forward to the client. Every item you surface must have a named owner, a specific action, and a due date or urgency signal. Do not pad, speculate, or summarize what the data already says plainly. If a field is empty or absent, omit it rather than noting the absence.',
+
+    'Using the context block above, produce a **Client Open Items Report** structured exactly as follows. Prioritize by urgency: overdue items first, then due within 7 days, then due within 30 days, then waiting/monitoring items. Omit any section that has no items.
+
+**Before writing any section:** scan the Recent Activity list (up to 15 entries). For each activity, read the details field (notes) and email snippet. Extract: (a) any commitment made — "I will send...", "we agreed to...", "following up on..."; (b) any open question that was asked but not answered in a later activity; (c) any timeline mentioned. These extracted facts are your primary source for the Context and Latest fields throughout the report. Do not rely on structured fields alone — the activity notes are where most of what happened last time actually lives.
+
+---
+
+### IMMEDIATE ACTION REQUIRED
+*(Overdue items or items due within 7 days — highest urgency)*
+
+For each item:
+- **[OWNER: Broker / Client / Carrier / Third Party]** — [Specific action required] — **Due: [date or "Overdue since DATE"]**
+  - Context: [1 sentence from activity notes, email snippet, or scratchpad explaining why this matters or where it stands — cite the activity date if drawing from a specific entry]
+
+---
+
+### DUE WITHIN 30 DAYS
+
+For each item:
+- **[OWNER]** — [Action] — **Due: [date]**
+  - Context: [1 sentence — prefer activity notes over structured fields when both are available]
+
+---
+
+### WAITING ON RESPONSE
+*(Items sent, no reply yet — broker should nudge if aging)*
+
+For each item:
+- **[OWNER: who we are waiting on]** — [What we sent / what we need back] — **Sent: [date] | Waiting [N] days**
+  - Contact: [name + email if available]
+
+---
+
+### OPEN ISSUES
+*(Active issues from the issues tracker, by severity)*
+
+For each issue:
+- **[SEVERITY: Critical/High/Medium/Low]** — [Issue subject] `[issue_uid]`
+  - Status: [current status] | Open [N] days [| SLA: N days remaining if set]
+  - Action needed: [who does what by when]
+  - Latest: [most recent activity note or email snippet for this issue, 2 sentences max — paraphrase to the key fact; do not quote verbatim]
+
+---
+
+### RENEWAL & MILESTONE WATCH
+*(Policies with upcoming expirations or overdue milestones)*
+
+For each item:
+- **[Policy name / LOB]** — Expires [date] ([N] days) | Renewal status: [status]
+  - Milestone: [specific milestone that is overdue or at risk, if any]
+  - Action: [who does what]
+
+---
+
+### OPPORTUNITIES IN PROGRESS
+*(Active prospect policies being tracked)*
+
+For each opportunity:
+- **[Opportunity name]** — [Status / next step]
+  - Owner: [broker name if set] | Target: [target date if set]
+  - Key point: [The single most important fact from the opportunity notes or description — timeline pressure, blocker, or decision pending. Omit if notes/description are empty.]
+
+---
+
+### MEETING PREP SNAPSHOT
+*(Lead with this section in the output — place it FIRST in the final document)*
+
+**Client:** [name] | **Industry:** [industry] | **Date:** [today''s date]
+
+**Bottom line — what needs to happen today:**
+[3–5 bullets, one sentence each, ranked by urgency. These are the items the broker must confirm, send, or escalate before the meeting ends. Draw from the activity history — if a commitment was made in the last logged activity and has not been acted on, it belongs here. No elaboration — just the action, the owner, and the deadline.]
+
+**Relationship flags:**
+[Only include if relationship_risk or growth_opportunities fields are populated. One sentence each.]
+
+**Contacts on call:**
+[List names, roles, and best phone number for contacts expected on this meeting.]
+
+---
+
+**Output rules:**
+- Place the MEETING PREP SNAPSHOT section first in the document, even though it appears last in these instructions.
+- Use owner labels consistently: Broker, Client, Carrier, [Carrier name], [Third party name], or [Person name] when a specific name is known from contacts.
+- When a follow-up disposition is "Awaiting Response" or "Sent Email," place the item in WAITING ON RESPONSE, not in action-required sections.
+- When a follow-up disposition is "Client Action Required," the owner is Client.
+- Do not invent due dates. If no date is available, write "No date set" rather than omitting the item if it is high-severity.
+- If an issue has resolution notes, include them in the Latest field — resolution context is as useful as open-item context.
+- Cap each context/latest field at 2 sentences.
+- If scratchpad notes exist, extract any open items or commitments and include them under the appropriate section, attributed as "(from scratchpad)."
+- When drawing context from activity history, prefer the most recent entry that contains a commitment or open question — not just the most recent entry regardless of content.
+- End the document with a one-line count: Total open items: [N] | Immediate: [N] | Waiting: [N] | Issues: [N]',
+
+    '["client","issues","follow_ups","recent_activity_log","contacts","focus_items","opportunities"]',
+    '{"issues": 1}',
+    1
+);

--- a/src/policydb/migrations/158_issue_depth_overrides.sql
+++ b/src/policydb/migrations/158_issue_depth_overrides.sql
@@ -1,0 +1,8 @@
+-- Migration 158: Set issues to DEPTH_FULL on templates that include issues
+-- but had no depth override, so checklists and activity history are surfaced.
+
+UPDATE prompt_templates
+SET depth_overrides = '{"issues": 1}'
+WHERE is_builtin = 1
+  AND name IN ('Renewal Status Email', 'Open Items Call Agenda', 'Stewardship Report Shell')
+  AND (depth_overrides IS NULL OR depth_overrides = '');

--- a/src/policydb/prompt_assembler.py
+++ b/src/policydb/prompt_assembler.py
@@ -185,6 +185,22 @@ def assemble_client(conn: sqlite3.Connection, record_id: int, depth: int = DEPTH
         if sp_row["updated_at"]:
             lines.append(f"\n*Updated: {_fmt_date(sp_row['updated_at'][:10])}*\n")
 
+    # Location (project) scratchpads for this client
+    proj_sps = conn.execute(
+        """SELECT pr.name, ps.content, ps.updated_at
+           FROM project_scratchpad ps
+           JOIN projects pr ON pr.id = ps.project_id
+           WHERE pr.client_id = ?
+             AND ps.content IS NOT NULL AND TRIM(ps.content) != ''
+           ORDER BY pr.name""",
+        (record_id,),
+    ).fetchall()
+    if proj_sps:
+        lines.append("\n### Location Scratchpads\n")
+        for ps in proj_sps:
+            lines.append(f"\n**{ps['name']}:**\n")
+            lines.append(ps["content"].strip() + "\n")
+
     # Recent saved notes (scope='client'). scope_id is TEXT so bind as string.
     notes = conn.execute(
         """SELECT content, created_at FROM saved_notes
@@ -356,6 +372,18 @@ def assemble_policy(conn: sqlite3.Connection, record_id: int, depth: int = DEPTH
         lines.append(sp_row["content"].strip() + "\n")
         if sp_row["updated_at"]:
             lines.append(f"\n*Updated: {_fmt_date(sp_row['updated_at'][:10])}*\n")
+
+    # Project (location) scratchpad for this policy's linked location
+    if r.get("project_id"):
+        proj_sp = conn.execute(
+            "SELECT content, updated_at FROM project_scratchpad WHERE project_id = ?",
+            (r["project_id"],),
+        ).fetchone()
+        if proj_sp and (proj_sp["content"] or "").strip():
+            lines.append("\n### Location Scratchpad\n")
+            lines.append(proj_sp["content"].strip() + "\n")
+            if proj_sp["updated_at"]:
+                lines.append(f"\n*Updated: {_fmt_date(proj_sp['updated_at'][:10])}*\n")
 
     # Recent saved notes (scope='policy', scope_id=policy_uid)
     if r.get("policy_uid"):
@@ -613,6 +641,17 @@ def assemble_issue(conn: sqlite3.Connection, record_id: int, depth: int = DEPTH_
             mark = "x" if item["completed"] else " "
             lines.append(f"- [{mark}] {item['label']}\n")
 
+    # Issue scratchpad (working notes)
+    sp_row = conn.execute(
+        "SELECT content, updated_at FROM issue_scratchpad WHERE issue_id = ?",
+        (record_id,),
+    ).fetchone()
+    if sp_row and (sp_row["content"] or "").strip():
+        lines.append("\n### Issue Scratchpad\n")
+        lines.append(sp_row["content"].strip() + "\n")
+        if sp_row["updated_at"]:
+            lines.append(f"\n*Updated: {_fmt_date(sp_row['updated_at'][:10])}*\n")
+
     return "".join(lines)
 
 
@@ -732,17 +771,17 @@ def assemble_issues_for_record(conn: sqlite3.Connection, record_id: int, depth: 
 
     lines = ["## Issues\n"]
 
-    # Open issues at tier 2
+    # Open issues — full detail at DEPTH_FULL, one-liner otherwise
     for r in open_issues:
-        if depth <= DEPTH_SUMMARY:
+        if depth == DEPTH_FULL:
+            lines.append(assemble_issue(conn, r["id"], DEPTH_FULL))
+        else:
             line = f"- **{r['issue_uid']}:** {r['subject']} [{r['issue_status']}]"
             if r["issue_severity"]:
                 line += f" — {r['issue_severity']}"
             if r["due_date"]:
                 line += f" — Due: {_fmt_date(r['due_date'])}"
             lines.append(line + "\n")
-        elif depth == DEPTH_FULL:
-            lines.append(assemble_issue(conn, r["id"], DEPTH_SUMMARY))
 
     # Closed issues at tier 3 (reference only, capped)
     if closed_issues:
@@ -765,7 +804,7 @@ def assemble_followups(conn: sqlite3.Connection, record_id: int, depth: int = DE
     issue_id = kwargs.get("issue_id")
     if issue_id:
         rows = conn.execute(
-            """SELECT activity_date, subject, follow_up_date, follow_up_done, disposition,
+            """SELECT activity_date, subject, details, follow_up_date, follow_up_done, disposition,
                       activity_type, contact_person
                FROM activity_log
                WHERE issue_id = ? AND item_kind != 'issue' AND follow_up_date IS NOT NULL
@@ -774,7 +813,7 @@ def assemble_followups(conn: sqlite3.Connection, record_id: int, depth: int = DE
         ).fetchall()
     else:
         rows = conn.execute(
-            """SELECT activity_date, subject, follow_up_date, follow_up_done, disposition,
+            """SELECT activity_date, subject, details, follow_up_date, follow_up_done, disposition,
                       activity_type, contact_person
                FROM activity_log
                WHERE client_id = ? AND follow_up_date IS NOT NULL AND item_kind != 'issue'
@@ -792,6 +831,13 @@ def assemble_followups(conn: sqlite3.Connection, record_id: int, depth: int = DE
         line = f"- {_fmt_date(r['follow_up_date'])} — {r['subject']} [{status}]"
         if r["disposition"]:
             line += f" ({r['disposition']})"
+        if r.get("contact_person"):
+            line += f" — contact: {r['contact_person']}"
+        if r.get("details") and r["details"].strip():
+            details_text = r["details"].strip()
+            if len(details_text) > 300:
+                details_text = details_text[:300] + "…"
+            line += f"\n  > {details_text}"
         items.append(line + "\n")
 
     total = len(items)
@@ -872,7 +918,7 @@ def assemble_contacts(conn: sqlite3.Connection, record_id: int, depth: int = DEP
     policy_id = kwargs.get("policy_id")
     if policy_id:
         raw_rows = conn.execute(
-            """SELECT co.name, co.email, co.phone, cpa.role, cpa.is_placement_colleague
+            """SELECT co.name, co.email, co.phone, co.mobile, cpa.role, cpa.is_placement_colleague
                FROM contact_policy_assignments cpa
                JOIN contacts co ON cpa.contact_id = co.id
                WHERE cpa.policy_id = ?""",
@@ -880,7 +926,7 @@ def assemble_contacts(conn: sqlite3.Connection, record_id: int, depth: int = DEP
         ).fetchall()
     else:
         raw_rows = conn.execute(
-            """SELECT co.name, co.email, co.phone, cca.role, cca.contact_type, cca.is_primary
+            """SELECT co.name, co.email, co.phone, co.mobile, cca.role, cca.contact_type, cca.is_primary
                FROM contact_client_assignments cca
                JOIN contacts co ON cca.contact_id = co.id
                WHERE cca.client_id = ?
@@ -897,28 +943,74 @@ def assemble_contacts(conn: sqlite3.Connection, record_id: int, depth: int = DEP
 
     lines = ["## Contacts\n"]
 
+    def _contact_line(c: dict, bold: bool = True) -> str:
+        role = c.get("role") or ("Placement Colleague" if c.get("is_placement_colleague") else "Contact")
+        name = f"**{c['name']}**" if bold else c['name']
+        parts = []
+        if c.get("email"):
+            parts.append(c["email"])
+        if c.get("phone"):
+            parts.append(c["phone"])
+        if c.get("mobile") and c.get("mobile") != c.get("phone"):
+            parts.append(f"mobile: {c['mobile']}")
+        suffix = f" ({' | '.join(parts)})" if parts else ""
+        return f"- {name} — {role}{suffix}\n"
+
     if len(rows) <= 5:
         for c in rows:
-            role = c.get("role") or ("Placement Colleague" if c.get("is_placement_colleague") else "Contact")
-            line = f"- **{c['name']}** — {role}"
-            if c.get("email"):
-                line += f" ({c['email']})"
-            lines.append(line + "\n")
+            lines.append(_contact_line(c))
     else:
         # Primary at tier 2, rest at tier 3
         primary = [c for c in rows if c.get("is_primary") or c.get("is_placement_colleague")]
         primary_ids = {id(c) for c in primary}
         others = [c for c in rows if id(c) not in primary_ids]
         for c in primary:
-            role = c.get("role") or "Primary Contact"
-            line = f"- **{c['name']}** — {role}"
-            if c.get("email"):
-                line += f" ({c['email']})"
-            lines.append(line + "\n")
+            lines.append(_contact_line(c))
         ref_items = [f"- {c['name']} — {c.get('role') or 'Contact'}\n" for c in others]
         ref_items = _truncated_list(ref_items, 5, "contacts")
         for item in ref_items:
             lines.append(item)
+
+    return "".join(lines)
+
+
+@register("opportunities")
+def assemble_opportunities(conn: sqlite3.Connection, record_id: int, depth: int = DEPTH_SUMMARY) -> str:
+    """Assemble opportunity-flagged policies for a client. record_id is client_id."""
+    rows = conn.execute(
+        """SELECT id, policy_uid, policy_type, carrier, premium,
+                  target_effective_date, opportunity_status, description, notes
+           FROM policies
+           WHERE client_id = ? AND is_opportunity = 1 AND archived = 0
+           ORDER BY target_effective_date, policy_type""",
+        (record_id,),
+    ).fetchall()
+    if not rows:
+        return ""
+
+    lines = ["## Opportunities\n"]
+    for p in rows:
+        if depth == DEPTH_REFERENCE:
+            lines.append(f"- {p['policy_uid']} — {p['policy_type']} [{p['opportunity_status'] or 'Prospect'}]\n")
+            continue
+        line = f"- **{p['policy_uid']}** — {p['policy_type']}"
+        if p["carrier"]:
+            line += f" | {p['carrier']}"
+        if p["premium"]:
+            line += f" | {_fmt_currency(p['premium'])}"
+        if p["target_effective_date"]:
+            line += f" | Target: {_fmt_date(p['target_effective_date'])}"
+        if p["opportunity_status"]:
+            line += f" [{p['opportunity_status']}]"
+        lines.append(line + "\n")
+        if depth == DEPTH_FULL:
+            if p["description"]:
+                lines.append(f"  Description: {p['description']}\n")
+            if p["notes"] and p["notes"].strip():
+                notes_text = p["notes"].strip()
+                if len(notes_text) > 300:
+                    notes_text = notes_text[:300] + "…"
+                lines.append(f"  Notes: {notes_text}\n")
 
     return "".join(lines)
 
@@ -1327,14 +1419,14 @@ def assemble_recent_activity_log(
         return ""
 
     rows = conn.execute(
-        f"""SELECT a.activity_date, a.activity_type, a.subject, a.disposition,
+        f"""SELECT a.activity_date, a.activity_type, a.subject, a.details, a.disposition,
                    a.contact_person, a.email_from, a.email_to, a.email_snippet,
                    a.policy_id, p.policy_uid
             FROM activity_log a
             LEFT JOIN policies p ON p.id = a.policy_id
             WHERE a.item_kind != 'issue' AND {where}
             ORDER BY a.activity_date DESC, a.id DESC
-            LIMIT 10""",
+            LIMIT 15""",
         params,
     ).fetchall()
 
@@ -1351,6 +1443,11 @@ def assemble_recent_activity_log(
         if r["contact_person"]:
             line += f" (contact: {r['contact_person']})"
         line += "\n"
+        if r.get("details") and r["details"].strip():
+            details_text = r["details"].strip().replace("\r", " ")
+            if len(details_text) > 500:
+                details_text = details_text[:500] + "…"
+            line += f"  > Notes: {details_text}\n"
         if r["email_from"]:
             line += f"  > From {r['email_from']}"
             if r["email_to"]:
@@ -1358,8 +1455,8 @@ def assemble_recent_activity_log(
             line += "\n"
         if r["email_snippet"]:
             snippet = r["email_snippet"].strip().replace("\r", " ").replace("\n", " ")
-            if len(snippet) > 160:
-                snippet = snippet[:160] + "…"
+            if len(snippet) > 400:
+                snippet = snippet[:400] + "…"
             line += f"  > \"{snippet}\"\n"
         lines.append(line)
 
@@ -1474,7 +1571,7 @@ def _assemble_related_block(
         rid = keys.get("policy_id")
     elif record_type == "issue":
         rid = keys.get("issue_id")
-    elif record_type in ("policies", "renewals"):
+    elif record_type in ("policies", "renewals", "opportunities"):
         rid = keys.get("client_id")
     elif record_type == "issues":
         rid = keys.get("client_id")

--- a/src/policydb/web/templates/prompt_builder/_template_form.html
+++ b/src/policydb/web/templates/prompt_builder/_template_form.html
@@ -40,7 +40,9 @@
     </div>
 
     <div>
-      <label class="text-xs font-medium text-gray-600">System Prompt</label>
+      <label class="text-xs font-medium text-gray-600">System Prompt
+        <span class="ml-1 font-normal text-gray-400">(sets the LLM's role and behavior — appears before the data)</span>
+      </label>
       <div class="flex flex-wrap gap-1.5 mt-1 mb-1.5">
         <span class="text-[10px] text-gray-400 leading-relaxed self-center mr-1">Start from:</span>
         <button type="button" class="px-2 py-0.5 text-[10px] rounded-full border border-gray-200 text-gray-600 hover:bg-gray-50 transition-colors"
@@ -61,7 +63,9 @@
     </div>
 
     <div>
-      <label class="text-xs font-medium text-gray-600">Closing Instruction</label>
+      <label class="text-xs font-medium text-gray-600">Closing Instruction
+        <span class="ml-1 font-normal text-gray-400">(what the LLM should produce — appears after the data block)</span>
+      </label>
       <div class="flex flex-wrap gap-1.5 mt-1 mb-1.5">
         <span class="text-[10px] text-gray-400 leading-relaxed self-center mr-1">Start from:</span>
         <button type="button" class="px-2 py-0.5 text-[10px] rounded-full border border-gray-200 text-gray-600 hover:bg-gray-50 transition-colors"
@@ -103,7 +107,7 @@
       <label class="text-xs font-medium text-gray-600 mb-2 block">Include Related Data</label>
       <p class="text-[10px] text-gray-400 mb-2">Select which related data to include in the assembled prompt.</p>
       <div class="flex flex-wrap gap-2" id="pb-related-pills-{{ form_uid }}">
-        {% set all_related = ['client','policies','renewals','issues','follow_ups','milestones','contacts'] %}
+        {% set all_related = ['client','policies','renewals','issues','follow_ups','milestones','contacts','opportunities','recent_activity_log','focus_items','deliverables_due','pending_emails'] %}
         {% for rt in all_related %}
         <label class="cursor-pointer">
           <input type="checkbox" name="pb_related_{{ rt }}" value="{{ rt }}" class="peer sr-only"
@@ -124,7 +128,7 @@
       <div class="space-y-1.5" id="pb-depth-rows-{{ form_uid }}">
         {% for rt in all_related %}
         <div class="pb-depth-row flex items-center gap-3 {% if rt not in related %}hidden{% endif %}" data-type="{{ rt }}" id="pb-depth-row-{{ form_uid }}-{{ rt }}">
-          <span class="text-xs text-gray-600 w-24">{{ rt | replace('_',' ') | capitalize }}</span>
+          <span class="text-xs text-gray-600 w-36">{{ rt | replace('_',' ') | capitalize }}</span>
           <div class="flex rounded-md overflow-hidden border border-gray-200 text-[11px]">
             <label class="cursor-pointer">
               <input type="radio" name="pb_depth_{{ rt }}" value="1" class="peer sr-only"
@@ -147,6 +151,93 @@
           </div>
         </div>
         {% endfor %}
+      </div>
+    </div>
+
+    <!-- Data Field Reference — collapsible help for prompt authors -->
+    <div class="border border-gray-200 rounded-lg overflow-hidden">
+      <button type="button"
+              class="w-full flex items-center justify-between px-4 py-2.5 bg-gray-50 hover:bg-gray-100 transition-colors text-left"
+              onclick="this.nextElementSibling.classList.toggle('hidden'); this.querySelector('svg').classList.toggle('rotate-180')">
+        <span class="text-xs font-medium text-gray-600">Data Field Reference — what each type provides</span>
+        <svg class="w-4 h-4 text-gray-400 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+        </svg>
+      </button>
+      <div class="hidden px-4 py-3 text-[11px] text-gray-600 space-y-3 bg-white">
+
+        <p class="text-gray-400 italic">The LLM receives: <strong>System Prompt</strong> → data block → <strong>Closing Instruction</strong>. Write your system prompt to set the role and tone. Write your closing instruction to specify what to produce and how to structure it. Reference the fields below in your closing instruction so the LLM knows what to look for.</p>
+
+        <div class="grid grid-cols-1 gap-2">
+
+          <div class="rounded bg-gray-50 px-3 py-2">
+            <div class="font-semibold text-gray-700 mb-1">client <span class="font-normal text-gray-400">— primary or related</span></div>
+            <div>Name, CN number, FEIN, industry, business description, address, website, account executive, broker fee, renewal month, preferred contact method. Strategy: account priorities, renewal strategy, growth opportunities, relationship risk, service model. Client scratchpad. Location scratchpads (one per project/site). Recent saved notes.</div>
+          </div>
+
+          <div class="rounded bg-gray-50 px-3 py-2">
+            <div class="font-semibold text-gray-700 mb-1">policy / renewal <span class="font-normal text-gray-400">— primary</span></div>
+            <div>Policy UID, line of business, carrier, policy number, first named insured, effective/expiration dates, premium, prior premium, rate change %, limit, deductible, coverage form, layer position. Exposure block (linked locations + amounts). Policy scratchpad. Location scratchpad (linked site). Recent saved notes. Policy contacts (name, role, email). <em>renewal</em> adds: days to renewal, urgency flag, renewal timeline milestones, milestone checklist.</div>
+          </div>
+
+          <div class="rounded bg-gray-50 px-3 py-2">
+            <div class="font-semibold text-gray-700 mb-1">issue <span class="font-normal text-gray-400">— primary</span></div>
+            <div>Issue UID, subject, details, status, severity, SLA days, due date, days open, resolution type/notes, root cause. Activity history (dated entries with notes + email from/to/snippet). Issue checklist ([ ] / [x] items). Issue scratchpad. Linked policies.</div>
+          </div>
+
+          <div class="rounded bg-gray-50 px-3 py-2">
+            <div class="font-semibold text-gray-700 mb-1">issues <span class="font-normal text-gray-400">— related</span></div>
+            <div><strong>Summary (default):</strong> one-liner per open issue — UID, subject, status, severity, due date. Closed issues listed briefly. <strong>Full depth:</strong> full issue detail per open issue (same as issue primary, above) — includes activity history, checklist, and scratchpad.</div>
+          </div>
+
+          <div class="rounded bg-gray-50 px-3 py-2">
+            <div class="font-semibold text-gray-700 mb-1">follow_ups <span class="font-normal text-gray-400">— related</span></div>
+            <div>Pending follow-up date, subject, status (Pending/Done), disposition (e.g. "Awaiting Response", "Client Action Required", "Sent Email"), contact person, activity notes/details.</div>
+          </div>
+
+          <div class="rounded bg-gray-50 px-3 py-2">
+            <div class="font-semibold text-gray-700 mb-1">recent_activity_log <span class="font-normal text-gray-400">— related</span></div>
+            <div>Last 15 activities — date, activity type, subject, full notes (up to 500 chars), email from/to, email snippet (up to 400 chars), policy UID if applicable. This is where commitments, call notes, and email threads live.</div>
+          </div>
+
+          <div class="rounded bg-gray-50 px-3 py-2">
+            <div class="font-semibold text-gray-700 mb-1">contacts <span class="font-normal text-gray-400">— related</span></div>
+            <div>Name, role, email, phone, mobile. Client contacts ordered by primary first. Policy contacts include placement colleagues.</div>
+          </div>
+
+          <div class="rounded bg-gray-50 px-3 py-2">
+            <div class="font-semibold text-gray-700 mb-1">focus_items <span class="font-normal text-gray-400">— related</span></div>
+            <div>All open action items bucketed by timing: <strong>Overdue</strong>, <strong>Today</strong>, <strong>This Week</strong>, <strong>Waiting on External</strong>, <strong>Scheduled</strong>. Each item includes date, kind (followup/issue/milestone), days overdue, disposition, and contact. Good for "what needs attention right now" sections.</div>
+          </div>
+
+          <div class="rounded bg-gray-50 px-3 py-2">
+            <div class="font-semibold text-gray-700 mb-1">opportunities <span class="font-normal text-gray-400">— related</span></div>
+            <div>Prospect/opportunity-flagged policies — type, carrier, premium, target effective date, opportunity status, description, notes.</div>
+          </div>
+
+          <div class="rounded bg-gray-50 px-3 py-2">
+            <div class="font-semibold text-gray-700 mb-1">policies / renewals <span class="font-normal text-gray-400">— related</span></div>
+            <div><strong>policies:</strong> all active policies — UID, LOB, carrier, premium, expiration, renewal status. <strong>renewals:</strong> policies within 180-day renewal window with days-to-renewal.</div>
+          </div>
+
+          <div class="rounded bg-gray-50 px-3 py-2">
+            <div class="font-semibold text-gray-700 mb-1">milestones <span class="font-normal text-gray-400">— related</span></div>
+            <div>Policy timeline milestones — name, target date, projected date, health (on_track/at_risk/behind), accountability, waiting_on. Plus policy checklist items ([ ] / [x]).</div>
+          </div>
+
+          <div class="rounded bg-gray-50 px-3 py-2">
+            <div class="font-semibold text-gray-700 mb-1">deliverables_due <span class="font-normal text-gray-400">— related</span></div>
+            <div>Upcoming deadlines bucketed Overdue / Due This Week / Coming Up. Includes timeline milestones and open RFI bundles with item counts.</div>
+          </div>
+
+          <div class="rounded bg-gray-50 px-3 py-2">
+            <div class="font-semibold text-gray-700 mb-1">pending_emails <span class="font-normal text-gray-400">— related</span></div>
+            <div>Follow-ups with email-type dispositions (Awaiting Response, Sent Email, Follow Up Email) — recipient, subject, due date.</div>
+          </div>
+
+        </div>
+
+        <p class="text-gray-400 italic text-[10px]">Depth: <strong>Full</strong> = all fields + sub-records. <strong>Summary</strong> = key fields only (default). <strong>Reference</strong> = name + status, one line.</p>
       </div>
     </div>
 
@@ -197,7 +288,7 @@ var _pbClosings = {
 function pbInsertRole(btn, fieldName) {
   var label = btn.textContent.trim();
   var text = _pbRoles[label] || '';
-  var ta = btn.closest('div').querySelector('textarea[name="' + fieldName + '"]');
+  var ta = btn.closest('form').querySelector('textarea[name="' + fieldName + '"]');
   if (ta && text) {
     ta.value = text;
     ta.focus();
@@ -212,7 +303,7 @@ function pbInsertRole(btn, fieldName) {
 function pbInsertClosing(btn, fieldName) {
   var label = btn.textContent.trim();
   var text = _pbClosings[label] || '';
-  var ta = btn.closest('div').querySelector('textarea[name="' + fieldName + '"]');
+  var ta = btn.closest('form').querySelector('textarea[name="' + fieldName + '"]');
   if (ta && text) {
     ta.value = text;
     ta.focus();


### PR DESCRIPTION
## Summary

- **Bug fix:** Template form role/closing preset pills were broken (`btn.closest('div')` doesn't reach the textarea sibling — fixed to `btn.closest('form')`)
- **Data enrichment:** Activity log now includes full notes + 400-char email snippets; follow-ups include details + contact; contacts include phone/mobile; issue scratchpad, policy/client location scratchpads all surfaced
- **New assembler:** `opportunities` — surfaces prospect policies with description, notes, target date, status
- **Fixed bug:** `assemble_issues_for_record` DEPTH_FULL branch was unreachable (preceding `depth <= 2` guard swallowed it); full issue detail (checklist, activity history, scratchpad) now correctly returned at depth=1
- **New template (migration 157):** *Client Open Items Report* — pre-meeting briefing with activity log mining instructions, disposition-based ownership routing, scratchpad extraction, and Meeting Prep Snapshot section
- **Migration 158:** `{"issues": 1}` depth override added to Renewal Status Email, Open Items Call Agenda, and Stewardship Report Shell so checklists + activity history appear in those templates
- **UI:** 5 previously hidden assembler types exposed as pills; collapsible Data Field Reference panel added to template form; field labels clarified

## Test plan

- [ ] Start server, open Prompt Builder → Manage Templates → New Template — verify role/closing preset pills populate textareas
- [ ] Confirm new pill options appear: Opportunities, Recent activity log, Focus items, Deliverables due, Pending emails
- [ ] Expand "Data Field Reference" panel — verify all 12 types listed with descriptions
- [ ] Builder tab: select Client, pick a client with issues/follow-ups, run *Client Open Items Report* — verify output includes activity notes, issue checklists, scratchpad content
- [ ] Run *Open Items Call Agenda* on same client — confirm issues now show full detail instead of one-liners
- [ ] Confirm migrations 157 + 158 run cleanly on fresh server start (check logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)