### PR TITLE
fix(contacts): AI import review panel silently fails at /contacts

### DIFF
--- a/src/policydb/web/templates/contacts/list.html
+++ b/src/policydb/web/templates/contacts/list.html
@@ -62,6 +62,8 @@
 
   {# AI Import container (slideover panel loads here) #}
   <div id="ai-import-container"></div>
+  {# AI Import review result renders here after parse #}
+  <div id="ai-contact-import-result" class="mb-4"></div>
 
   {# Merge panel (unchanged functionality) #}
   <div id="merge-panel" class="hidden card p-4 mt-3 bg-amber-50/30 border-amber-200">


### PR DESCRIPTION
## Summary
- Adds missing `#ai-contact-import-result` div to `contacts/list.html`
- Without it, `submitAiImport()` found no DOM target, silently dropped the parsed result, and called `closeAiImport()` — making the import appear to do nothing
- Matches the pattern already used in `clients/_tab_contacts.html`

## Test plan
- [ ] Navigate to `/contacts`, click AI Import
- [ ] Copy prompt, paste a JSON contact array in step 2, click Import & Review
- [ ] Confirm the diff/review panel now renders below the header
- [ ] Accept contacts and verify they appear in the directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)