### PR TITLE
feat(contacts): per-field diff view and overwrite control for AI import updates

### DIFF
--- a/src/policydb/web/routes/contacts.py
+++ b/src/policydb/web/routes/contacts.py
@@ -125,7 +125,7 @@ def contacts_ai_import_parse(
     # Check which contacts already exist globally
     for contact in contacts:
         existing = conn.execute(
-            "SELECT id, email, phone, organization FROM contacts "
+            "SELECT id, email, phone, mobile, organization, title FROM contacts "
             "WHERE LOWER(TRIM(name)) = LOWER(TRIM(?))",
             (contact["name"],),
         ).fetchone()
@@ -188,24 +188,43 @@ async def contacts_ai_import_apply(request: Request, conn=Depends(get_db)):
             if mobile:
                 mobile = format_phone(mobile)
 
-            cid = get_or_create_contact(
-                conn, name,
-                email=email or None,
-                phone=phone or None,
-                mobile=mobile or None,
-                organization=org or None,
-            )
+            contact_id_str = form.get(f"contact_id_{i}", "").strip()
 
-            # Update title if provided
-            if title:
-                conn.execute(
-                    "UPDATE contacts SET title = ? WHERE id = ? AND (title IS NULL OR title = '')",
-                    (title, cid),
-                )
-
-            if contact.get("existing_contact"):
-                updated += 1
+            if contact_id_str:
+                # Existing contact — update only fields the user opted to overwrite
+                cid = int(contact_id_str)
+                field_updates: list[str] = []
+                params: list = []
+                for field, value, flag in [
+                    ("email", email, f"overwrite_email_{i}"),
+                    ("phone", phone, f"overwrite_phone_{i}"),
+                    ("mobile", mobile, f"overwrite_mobile_{i}"),
+                    ("organization", org, f"overwrite_org_{i}"),
+                    ("title", title, f"overwrite_title_{i}"),
+                ]:
+                    if value and form.get(flag):
+                        field_updates.append(f"{field}=?")
+                        params.append(value)
+                if field_updates:
+                    field_updates.append("updated_at=CURRENT_TIMESTAMP")
+                    params.append(cid)
+                    conn.execute(
+                        f"UPDATE contacts SET {', '.join(field_updates)} WHERE id=?", params
+                    )
+                    updated += 1
             else:
+                # New contact
+                cid = get_or_create_contact(
+                    conn, name,
+                    email=email or None,
+                    phone=phone or None,
+                    mobile=mobile or None,
+                    organization=org or None,
+                )
+                if title:
+                    conn.execute(
+                        "UPDATE contacts SET title = ? WHERE id = ?", (title, cid)
+                    )
                 created += 1
         except Exception as e:
             errors.append(f"{name}: {e}")

--- a/src/policydb/web/templates/contacts/_ai_contacts_review.html
+++ b/src/policydb/web/templates/contacts/_ai_contacts_review.html
@@ -4,7 +4,40 @@
      warnings      — list of warning strings
      token         — cache token for apply step
      contact_roles — list of role options from config
+
+   For existing contacts, c.existing_contact is a dict with id, email, phone,
+   mobile, organization, title. Diff cells show current → incoming with a per-field
+   overwrite checkbox (checked by default when values differ).
 #}
+
+{# ── Macro: diff-aware field cell for existing contacts ──────────────────────
+   Renders a struck-through current value + overwrite checkbox + editable input
+   when the incoming value differs from the stored value. Falls back to a plain
+   input showing the current value when there is nothing new to show.
+#}
+{% macro diff_cell(new_val, existing_val, input_name, placeholder='') %}
+  {% set nv = (new_val or '') | trim %}
+  {% set ev = (existing_val or '') | trim %}
+  {% set changed = nv != '' and nv.lower() != ev.lower() %}
+  {% if changed %}
+  <div class="space-y-0.5">
+    {% if ev %}
+    <div class="text-[10px] text-gray-400 line-through leading-tight truncate max-w-[160px]" title="{{ ev }}">{{ ev }}</div>
+    {% endif %}
+    <label class="flex items-center gap-1 min-w-0">
+      <input type="checkbox" name="overwrite_{{ input_name }}" value="1" checked
+             class="rounded border-gray-300 text-marsh focus:ring-marsh shrink-0 w-3 h-3">
+      <input type="text" name="{{ input_name }}" value="{{ nv }}"
+             class="min-w-0 w-full border-0 bg-transparent text-xs text-indigo-700 font-medium focus:ring-1 focus:ring-marsh focus:bg-white rounded px-1 py-0.5">
+    </label>
+  </div>
+  {% else %}
+  <input type="text" name="{{ input_name }}" value="{{ ev or nv }}"
+         class="w-full border-0 bg-transparent text-xs text-gray-500 focus:ring-1 focus:ring-marsh focus:bg-white rounded px-1 py-0.5"
+         placeholder="{{ placeholder }}">
+  {% endif %}
+{% endmacro %}
+
 <div id="ai-contact-import-result" class="space-y-4">
 
   {# Summary badges #}
@@ -36,6 +69,14 @@
   </div>
   {% endif %}
 
+  {# Legend for existing contacts #}
+  {% if contacts | selectattr('existing_contact') | list %}
+  <p class="text-xs text-gray-400">
+    <span class="inline-block w-3 h-3 rounded border border-gray-300 bg-white align-middle mr-0.5"></span> checked fields will overwrite the current value.
+    Uncheck any field you want to keep as-is.
+  </p>
+  {% endif %}
+
   {# Contact list form #}
   <form id="ai-contacts-apply-form">
     <input type="hidden" name="token" value="{{ token }}">
@@ -50,7 +91,7 @@
             </th>
             <th class="px-3 py-2">Name</th>
             <th class="px-3 py-2">Email</th>
-            <th class="px-3 py-2">Phone</th>
+            <th class="px-3 py-2">Phone / Mobile</th>
             <th class="px-3 py-2">Org</th>
             <th class="px-3 py-2">Title</th>
             <th class="px-3 py-2 w-16">Status</th>
@@ -58,43 +99,83 @@
         </thead>
         <tbody class="divide-y divide-gray-100">
           {% for c in contacts %}
-          <tr class="{% if c.existing_contact %}bg-blue-50/30{% else %}hover:bg-gray-50{% endif %}">
+          {% set ex = c.existing_contact %}
+          <tr class="{% if ex %}bg-blue-50/30{% else %}hover:bg-gray-50{% endif %}">
+
+            {# Select + hidden contact ID for existing records #}
             <td class="px-3 py-2">
-              <input type="checkbox" name="select_{{ loop.index0 }}" value="1"
-                     class="ai-contact-cb rounded border-gray-300 text-marsh focus:ring-marsh"
-                     {% if not c.existing_contact %}checked{% endif %}>
+              <input type="checkbox" name="select_{{ loop.index0 }}" value="1" checked
+                     class="ai-contact-cb rounded border-gray-300 text-marsh focus:ring-marsh">
+              {% if ex %}
+              <input type="hidden" name="contact_id_{{ loop.index0 }}" value="{{ ex.id }}">
+              {% endif %}
             </td>
+
+            {# Name — read-only display for existing contacts to preserve the match key #}
             <td class="px-3 py-2">
+              {% if ex %}
+              <span class="text-sm font-medium text-gray-900">{{ c.name }}</span>
+              <input type="hidden" name="name_{{ loop.index0 }}" value="{{ c.name }}">
+              {% else %}
               <input type="text" name="name_{{ loop.index0 }}" value="{{ c.name }}"
                      class="w-full border-0 bg-transparent text-sm font-medium text-gray-900 focus:ring-1 focus:ring-marsh focus:bg-white rounded px-1 py-0.5">
+              {% endif %}
             </td>
+
+            {# Email #}
             <td class="px-3 py-2">
+              {% if ex %}
+                {{ diff_cell(c.email, ex.email, 'email_' ~ loop.index0) }}
+              {% else %}
               <input type="text" name="email_{{ loop.index0 }}" value="{{ c.email or '' }}"
                      class="w-full border-0 bg-transparent text-xs text-gray-600 focus:ring-1 focus:ring-marsh focus:bg-white rounded px-1 py-0.5">
+              {% endif %}
             </td>
-            <td class="px-3 py-2 space-y-0.5">
+
+            {# Phone + Mobile #}
+            <td class="px-3 py-2 space-y-1">
+              {% if ex %}
+                {{ diff_cell(c.phone, ex.phone, 'phone_' ~ loop.index0, 'Phone') }}
+                {{ diff_cell(c.mobile, ex.mobile, 'mobile_' ~ loop.index0, 'Mobile') }}
+              {% else %}
               <input type="text" name="phone_{{ loop.index0 }}" value="{{ c.phone or '' }}"
                      class="w-full border-0 bg-transparent text-xs text-gray-600 focus:ring-1 focus:ring-marsh focus:bg-white rounded px-1 py-0.5"
                      placeholder="Phone">
               <input type="text" name="mobile_{{ loop.index0 }}" value="{{ c.mobile or '' }}"
                      class="w-full border-0 bg-transparent text-xs text-gray-400 focus:ring-1 focus:ring-marsh focus:bg-white rounded px-1 py-0.5"
                      placeholder="Mobile">
+              {% endif %}
             </td>
+
+            {# Organization #}
             <td class="px-3 py-2">
+              {% if ex %}
+                {{ diff_cell(c.organization, ex.organization, 'org_' ~ loop.index0) }}
+              {% else %}
               <input type="text" name="org_{{ loop.index0 }}" value="{{ c.organization or '' }}"
                      class="w-full border-0 bg-transparent text-xs text-gray-600 focus:ring-1 focus:ring-marsh focus:bg-white rounded px-1 py-0.5">
+              {% endif %}
             </td>
+
+            {# Title #}
             <td class="px-3 py-2">
+              {% if ex %}
+                {{ diff_cell(c.title, ex.title, 'title_' ~ loop.index0) }}
+              {% else %}
               <input type="text" name="title_{{ loop.index0 }}" value="{{ c.title or '' }}"
                      class="w-full border-0 bg-transparent text-xs text-gray-500 focus:ring-1 focus:ring-marsh focus:bg-white rounded px-1 py-0.5">
+              {% endif %}
             </td>
+
+            {# Status badge #}
             <td class="px-3 py-2">
-              {% if c.existing_contact %}
+              {% if ex %}
               <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium bg-blue-100 text-blue-700">Exists</span>
               {% else %}
               <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium bg-gray-100 text-gray-500">New</span>
               {% endif %}
             </td>
+
           </tr>
           {% endfor %}
         </tbody>
@@ -103,7 +184,7 @@
 
     <div class="flex items-center justify-between mt-4">
       <p class="text-xs text-gray-400">
-        Uncheck contacts you don't want to import. Existing contacts will be updated with new details.
+        Uncheck a row to skip it entirely. For existing contacts, uncheck individual fields to keep current values.
       </p>
       <button type="submit"
               hx-post="/contacts/ai-import/apply"


### PR DESCRIPTION
## Summary
- Existing contacts now pre-checked (was pre-unchecked, making updates easy to miss)
- Diff view per field: struck-through current value above the incoming value with a small overwrite checkbox — checked by default when values differ, uncheck to keep the existing value
- Apply endpoint rewired for existing contacts: direct `UPDATE` by contact ID, only touching fields where the overwrite checkbox is checked
- Title guard removed — `AND (title IS NULL OR title = '')` prevented updating an existing title
- Parse step now fetches `mobile` and `title` for existing contacts so all five fields can participate in the diff

## Test plan
- [ ] AI Import at `/contacts` with JSON containing a contact already in the directory with a different phone number — confirm diff row shows old number struck through with overwrite checked
- [ ] Uncheck the phone overwrite checkbox, apply — confirm phone is unchanged in directory
- [ ] Import contact with existing title — confirm title can now be overwritten
- [ ] Import brand-new contact — confirm new contact flow unchanged (all fields editable, no diff UI)
- [ ] Import contact with identical data to what's stored — confirm no diff checkboxes appear and applying is a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)