### PR TITLE
feat(issues): per-policy activity check-in strip + activity dedup fix

### DIFF
--- a/src/policydb/web/routes/issues.py
+++ b/src/policydb/web/routes/issues.py
@@ -944,6 +944,83 @@ def issue_detail(
     return templates.TemplateResponse("issues/detail.html", ctx)
 
 
+@router.get("/issues/{issue_id}/per-policy-activity", response_class=HTMLResponse)
+def issue_per_policy_activity(issue_id: int, request: Request, conn=Depends(get_db)):
+    """Per-policy recent activity cards for the issue check-in view.
+
+    Returns one card per linked policy with its last 2 activities (subject +
+    truncated details/email snippet) and open follow-up status.  Loaded lazily
+    so the main issue page is not slowed down.
+    """
+    linked = get_linked_policies_for_issue(conn, issue_id)
+    if len(linked) < 2:
+        return HTMLResponse("")  # single-policy issues don't need the strip
+
+    policy_ids = [p["id"] for p in linked]
+    placeholders = ",".join("?" * len(policy_ids))
+    today = date.today().isoformat()
+
+    # Last 2 activities per policy (window function — SQLite 3.25+)
+    act_rows = conn.execute(
+        f"""SELECT * FROM (
+                SELECT a.id, a.policy_id, a.activity_date, a.activity_type,
+                       a.subject, a.details, a.email_snippet, a.email_from,
+                       a.email_to, a.disposition, a.contact_person,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY a.policy_id
+                           ORDER BY a.activity_date DESC, a.id DESC
+                       ) AS rn
+                FROM activity_log a
+                WHERE a.policy_id IN ({placeholders})
+                  AND a.item_kind = 'followup'
+            ) ranked WHERE rn <= 2
+            ORDER BY policy_id, rn""",  # noqa: S608
+        policy_ids,
+    ).fetchall()
+
+    # Nearest open follow-up per policy
+    fu_rows = conn.execute(
+        f"""SELECT a.policy_id, a.follow_up_date, a.disposition, a.subject
+            FROM activity_log a
+            WHERE a.policy_id IN ({placeholders})
+              AND a.follow_up_done = 0
+              AND a.follow_up_date IS NOT NULL
+              AND a.item_kind = 'followup'
+            ORDER BY a.policy_id, a.follow_up_date ASC""",  # noqa: S608
+        policy_ids,
+    ).fetchall()
+
+    # Index: policy_id → nearest open follow-up
+    open_fu_by_pid: dict[int, dict] = {}
+    for r in fu_rows:
+        pid = r["policy_id"]
+        if pid not in open_fu_by_pid:
+            fu = dict(r)
+            fu["is_overdue"] = fu["follow_up_date"] < today
+            open_fu_by_pid[pid] = fu
+
+    # Group activities by policy_id
+    acts_by_pid: dict[int, list] = {}
+    for r in act_rows:
+        acts_by_pid.setdefault(r["policy_id"], []).append(dict(r))
+
+    # Build card list preserving linked-policy order
+    cards = []
+    for pol in linked:
+        pid = pol["id"]
+        cards.append({
+            "policy": pol,
+            "activities": acts_by_pid.get(pid, []),
+            "open_followup": open_fu_by_pid.get(pid),
+        })
+
+    return templates.TemplateResponse("issues/_per_policy_activity.html", {
+        "request": request,
+        "cards": cards,
+        "today": today,
+    })
+
+
 def _issue_scratchpad_ctx(request, conn, issue_uid: str, content: str | None = None) -> dict:
     """Build context for the issues/_scratchpad.html partial."""
     issue_row = conn.execute(

--- a/src/policydb/web/routes/policies.py
+++ b/src/policydb/web/routes/policies.py
@@ -3033,6 +3033,12 @@ def policy_tab_activity(request: Request, policy_uid: str, conn=Depends(get_db))
         for xa in xrefs:
             xa["is_project_xref"] = True
         activities.extend(xrefs)
+        # Dedup — an activity can appear in both the main query (via issue coverage,
+        # policy_id IS NULL) and the xrefs query (via project_id, policy_id IS NULL).
+        # Keep the first occurrence, which preserves is_issue_xref / is_project_xref
+        # tags from whichever query found it first.
+        _seen: set[int] = set()
+        activities = [a for a in activities if not (a.get("id") in _seen or _seen.add(a["id"]))]
         # Re-sort to match original order: open follow-ups first (by fu date asc), then by activity_date desc
         def _sort_key(x):
             has_open_fu = bool(x.get("follow_up_date") and not x.get("follow_up_done"))

--- a/src/policydb/web/templates/issues/_per_policy_activity.html
+++ b/src/policydb/web/templates/issues/_per_policy_activity.html
@@ -1,0 +1,160 @@
+{# Per-policy activity check-in strip.
+ # Rendered by GET /issues/{id}/per-policy-activity and injected lazily.
+ # Shows last 2 activities per policy with content + open follow-up status.
+ #}
+{% if cards %}
+<div class="card">
+  <div class="px-4 py-2.5 bg-gray-50 border-b border-gray-200 flex items-center justify-between">
+    <span class="text-[10px] font-semibold text-gray-500 uppercase tracking-wide">Per-Policy Activity</span>
+    <span class="text-[10px] text-gray-400">{{ cards | length }} policies</span>
+  </div>
+
+  <div class="divide-y divide-gray-100">
+    {% for card in cards %}
+    {% set pol = card.policy %}
+    {% set acts = card.activities %}
+    {% set fu = card.open_followup %}
+
+    <div class="px-4 py-3">
+
+      {# ── Policy header ── #}
+      <div class="flex items-center gap-2 mb-2 flex-wrap">
+        <a href="/policies/{{ pol.policy_uid }}/edit"
+           class="font-mono text-xs font-semibold text-marsh hover:underline shrink-0">{{ pol.policy_uid }}</a>
+        {# Copy tag — pastes [PDB:POL-XXX] into email subject/body #}
+        <button type="button"
+                onclick="copyRefTag(this, '{{ pol.policy_uid }}')"
+                title="Copy [PDB:{{ pol.policy_uid }}] to clipboard"
+                class="inline-flex items-center gap-0.5 text-[9px] font-mono text-gray-400
+                       hover:text-marsh border border-gray-200 hover:border-marsh/40
+                       bg-gray-50 hover:bg-blue-50 rounded px-1.5 py-0.5
+                       transition-colors cursor-pointer shrink-0 no-print">
+          <svg class="w-2.5 h-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/>
+          </svg>
+          copy tag
+        </button>
+        {% if pol.policy_type %}
+        <span class="text-xs text-gray-700 shrink-0">{{ pol.policy_type }}</span>
+        {% endif %}
+        {% if pol.carrier %}
+        <span class="text-xs text-gray-400 shrink-0">&middot; {{ pol.carrier }}</span>
+        {% endif %}
+        {% if pol.renewal_status %}
+        <span class="ml-auto text-[10px] px-2 py-0.5 rounded-full shrink-0
+          {% if pol.renewal_status == 'Bound' %}bg-green-100 text-green-700
+          {% elif pol.renewal_status == 'In Progress' %}bg-blue-100 text-blue-700
+          {% elif pol.renewal_status == 'Not Started' %}bg-gray-100 text-gray-500
+          {% else %}bg-gray-100 text-gray-600{% endif %}">
+          {{ pol.renewal_status }}
+        </span>
+        {% endif %}
+      </div>
+
+      {# ── Activities ── #}
+      {% if acts %}
+      <div class="space-y-3">
+        {% for act in acts %}
+        {% set atype = act.activity_type or '' %}
+        {% set is_first = loop.first %}
+        <div class="{% if not loop.first %}pt-3 border-t border-gray-50{% endif %}">
+          {# Type badge + date + subject #}
+          <div class="flex items-baseline gap-2 flex-wrap mb-1">
+            <span class="text-[10px] font-medium px-1.5 py-0.5 rounded shrink-0
+              {% if atype == 'Call' %}bg-blue-100 text-blue-700
+              {% elif atype == 'Email' %}bg-amber-100 text-amber-700
+              {% elif atype == 'Meeting' %}bg-indigo-100 text-indigo-700
+              {% elif atype == 'Note' %}bg-pink-100 text-pink-700
+              {% else %}bg-gray-100 text-gray-600{% endif %}">{{ atype or 'Activity' }}</span>
+            <span class="text-[10px] text-gray-400 shrink-0">
+              {{ (act.activity_date or '')[:10][5:].replace('-', '/') }}
+            </span>
+            {% if act.contact_person %}
+            <span class="text-[10px] text-gray-400 shrink-0">&middot; {{ act.contact_person }}</span>
+            {% elif act.email_from and atype == 'Email' %}
+            <span class="text-[10px] text-gray-400 shrink-0 truncate max-w-[180px]">&middot; {{ act.email_from }}</span>
+            {% endif %}
+            {% if not is_first %}
+            <span class="text-[9px] text-gray-300 shrink-0 ml-auto italic">previous</span>
+            {% endif %}
+          </div>
+
+          {# Subject #}
+          {% if act.subject %}
+          <div class="text-sm font-medium text-gray-800 mb-1">{{ act.subject }}</div>
+          {% endif %}
+
+          {# Email metadata (From/To) for email type #}
+          {% if atype == 'Email' and (act.email_from or act.email_to) %}
+          <div class="text-[10px] text-gray-400 mb-1 space-y-0.5">
+            {% if act.email_from %}
+            <div><span class="text-gray-300">From</span> {{ act.email_from }}</div>
+            {% endif %}
+            {% if act.email_to %}
+            <div><span class="text-gray-300">To</span> {{ act.email_to }}</div>
+            {% endif %}
+          </div>
+          {% endif %}
+
+          {# Content: prefer email_snippet, fall back to details #}
+          {% set content = act.email_snippet or act.details or '' %}
+          {% if content %}
+          <div class="text-xs text-gray-600 leading-relaxed bg-gray-50 rounded px-2.5 py-2 whitespace-pre-wrap">{{ content[:400] }}{% if content | length > 400 %}<span class="text-gray-400 italic"> …</span>{% endif %}</div>
+          {% endif %}
+
+          {# Disposition badge #}
+          {% if act.disposition and is_first %}
+          <div class="mt-1">
+            <span class="text-[10px] px-1.5 py-0.5 rounded bg-amber-50 text-amber-700 border border-amber-200">
+              &#9203; {{ act.disposition }}
+            </span>
+          </div>
+          {% endif %}
+        </div>
+        {% endfor %}
+      </div>
+
+      {% else %}
+      {# No activity logged directly on this policy #}
+      <div class="flex items-center gap-1.5 text-xs text-gray-400 italic py-1">
+        <svg class="w-3.5 h-3.5 text-gray-300 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+        </svg>
+        No activity logged directly on this policy
+      </div>
+      {% endif %}
+
+      {# ── Open follow-up ── #}
+      <div class="flex items-center justify-between mt-2.5 pt-2 border-t border-gray-50">
+        {% if fu %}
+        <span class="text-[10px] flex items-center gap-1
+          {% if fu.is_overdue %}text-red-600 font-semibold{% else %}text-gray-500{% endif %}">
+          {% if fu.is_overdue %}
+          <svg class="w-3 h-3 shrink-0" fill="currentColor" viewBox="0 0 20 20">
+            <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/>
+          </svg>
+          Overdue F/U {{ fu.follow_up_date[5:].replace('-', '/') }}
+          {% else %}
+          &#9203; F/U {{ fu.follow_up_date[5:].replace('-', '/') }}
+          {% endif %}
+          {% if fu.disposition %}
+          &middot; <span class="text-gray-400 font-normal">{{ fu.disposition }}</span>
+          {% endif %}
+        </span>
+        {% else %}
+        <span class="text-[10px] text-gray-300 italic">No open follow-up</span>
+        {% endif %}
+
+        <a href="/policies/{{ pol.policy_uid }}/edit?tab=activity"
+           class="text-[10px] text-marsh hover:underline shrink-0">
+          View all activity &rarr;
+        </a>
+      </div>
+
+    </div>
+    {% endfor %}
+  </div>
+</div>
+{% endif %}

--- a/src/policydb/web/templates/issues/detail.html
+++ b/src/policydb/web/templates/issues/detail.html
@@ -416,6 +416,18 @@
       {% include "issues/_scope_rollup.html" %}
       {% endif %}
 
+      {# ── Per-Policy Activity — lazy-loaded check-in strip ── #}
+      {# Only shown when multiple policies are linked; single-policy issues return empty #}
+      {% if linked_policies | length > 1 %}
+      <div hx-get="/issues/{{ issue.id }}/per-policy-activity"
+           hx-trigger="load"
+           hx-swap="innerHTML">
+        <div class="card p-4">
+          <p class="text-xs text-gray-400 italic">Loading policy activity...</p>
+        </div>
+      </div>
+      {% endif %}
+
       {# ── Files & Attachments ── #}
       <div class="card p-4">
         <div class="text-[10px] text-gray-400 uppercase tracking-wide mb-2">Files & Attachments</div>


### PR DESCRIPTION
## Summary

- **Per-policy activity cards** on multi-policy issue detail pages — lazy-loaded section (HTMX `hx-trigger="load"`) that renders one card per linked policy with its last 2 activities (full subject + truncated notes/email content), open follow-up status, and a copy-tag button (`[PDB:POL-XXX]`) for sending targeted emails
- **Activity dedup fix** on the policy activity tab — an activity with `policy_id=NULL` + `project_id` set + `issue_id` pointing to a coverage issue could appear twice (once via OR condition 2, once via xrefs append); now deduped by row id after the extend
- **Tagging guidance clarified**: tag emails at the policy level (not issue level) — auto-link surfaces them on the issue, and they stay clean on the per-policy view

## Test plan

- [ ] Open a program renewal issue with 2+ linked policies — confirm the "Per-Policy Activity" section appears below Scope Rollup after lazy load
- [ ] Verify cards show last activity subject + content (notes or email snippet truncated at 400 chars)
- [ ] Verify overdue follow-ups render in red, active follow-ups show date + disposition
- [ ] Verify "No activity logged" state renders for policies with no direct activities
- [ ] Click "copy tag" button — confirm `[PDB:POL-XXX]` is copied to clipboard
- [ ] Single-policy issues — confirm the section does not render
- [ ] Policy activity tab with a project-xref activity that's also covered by a program issue — confirm it appears only once

🤖 Generated with [Claude Code](https://claude.com/claude-code)