### PR TITLE
fix(outlook): recursively walk subfolders during email sync

### DIFF
--- a/src/policydb/outlook.py
+++ b/src/policydb/outlook.py
@@ -161,9 +161,17 @@ def search_all_folders(
     since_date: datetime,
     category_filter: str = "",
 ) -> dict:
-    """Search ALL mail folders for emails with a specific category since a date.
+    """Search ALL mail folders (including subfolders) for emails since a date.
 
-    Returns {"ok": True, "emails": [...]} with folder name on each email.
+    Recursively walks the folder tree under the default account up to 8 levels
+    deep so emails filed in nested user folders like ``Inbox/Clients/Acme``
+    aren't silently dropped. The legacy implementation only iterated
+    ``every mail folder of default account`` (top level only) which meant a
+    reply filed into a subfolder would never be enumerated and never matched
+    against its ``[PDB:]`` ref tag.
+
+    Returns {"ok": True, "emails": [...]} with the slash-delimited folder
+    path on each email (e.g. ``"Inbox/Clients/Acme"``).
     """
     if not is_outlook_available():
         return {"ok": False, "error": "Outlook is not running."}
@@ -192,76 +200,129 @@ def search_all_folders(
                     if not hasRef then set skipMsg to true
                 end if'''
 
+    # Recursive walk: a script object carries the JSON accumulator and message
+    # counter across the recursion so we don't have to thread them through
+    # handler return values (AppleScript handlers can't return structured
+    # tuples cleanly). Depth cap of 8 prevents pathological folder trees from
+    # blowing the call stack; matches what most users would need (Phase 3D
+    # crawl is the path for genuinely deep archives). System folder names are
+    # checked at every level — Sent Items at any depth still routes through
+    # the dedicated Sent scan.
     script = f'''
-set output to "[" & return
-set totalCount to 0
+script acc
+    property out : ""
+    property cnt : 0
+end script
+
+set acc's out to "[" & return
+set acc's cnt to 0
 set myDate to date "{date_str}"
+set capLimit to 500
+
 tell application "Microsoft Outlook"
-    set allFolders to every mail folder of default account
-    repeat with f in allFolders
-        set folderName to name of f
-        -- Skip system folders we don't care about
-        if folderName is not "Deleted Items" and folderName is not "Junk Email" and folderName is not "Drafts" and folderName is not "Trash" and folderName is not "Clutter" and folderName is not "Sent Items" then
-            try
-                set folderMsgs to messages of f whose (time sent >= myDate)
-                repeat with msg in folderMsgs
-                    if totalCount >= 500 then exit repeat
-                    set skipMsg to false
-                    {cat_check}
-                    if not skipMsg then
-                        set totalCount to totalCount + 1
-                        set msgSubject to subject of msg
-                        set msgSender to ""
+    try
+        set rootFolders to mail folders of default account
+    on error
+        set rootFolders to {{}}
+    end try
+end tell
+
+repeat with rf in rootFolders
+    if acc's cnt >= capLimit then exit repeat
+    try
+        tell application "Microsoft Outlook" to set rfName to name of rf
+        my scanTree(contents of rf, rfName, myDate, capLimit, 0)
+    end try
+end repeat
+
+return (acc's out) & return & "]"
+
+on scanTree(f, folderPath, myDate, capLimit, depth)
+    if acc's cnt >= capLimit then return
+    if depth > 8 then return
+    set leafName to my leafOf(folderPath)
+    -- Skip system folders at every level (Sent Items handled separately)
+    if leafName is "Deleted Items" or leafName is "Junk Email" or leafName is "Drafts" or leafName is "Trash" or leafName is "Clutter" or leafName is "Sent Items" or leafName is "Outbox" then return
+
+    -- Scan messages in this folder
+    tell application "Microsoft Outlook"
+        try
+            set folderMsgs to (messages of f whose (time sent >= myDate))
+            repeat with msg in folderMsgs
+                if acc's cnt >= capLimit then exit repeat
+                set skipMsg to false
+                {cat_check}
+                if not skipMsg then
+                    set acc's cnt to (acc's cnt) + 1
+                    set msgSubject to subject of msg
+                    set msgSender to ""
+                    try
+                        set msgSender to address of sender of msg
+                    end try
+                    set msgDate to time sent of msg
+                    set msgId to id of msg as text
+                    set recipList to ""
+                    try
+                        repeat with r in to recipients of msg
+                            set recipList to recipList & address of email address of r & ","
+                        end repeat
+                    end try
+                    set catList to ""
+                    try
+                        set cats to categories of msg
+                        repeat with c in cats
+                            set catList to catList & (name of c) & ","
+                        end repeat
+                    end try
+                    set msgContent to ""
+                    try
+                        set msgContent to plain text content of msg
+                        if length of msgContent > 100000 then
+                            set msgContent to text 1 thru 100000 of msgContent
+                        end if
+                    on error
                         try
-                            set msgSender to address of sender of msg
-                        end try
-                        set msgDate to time sent of msg
-                        set msgId to id of msg as text
-                        set recipList to ""
-                        try
-                            repeat with r in to recipients of msg
-                                set recipList to recipList & address of email address of r & ","
-                            end repeat
-                        end try
-                        set catList to ""
-                        try
-                            set cats to categories of msg
-                            repeat with c in cats
-                                set catList to catList & (name of c) & ","
-                            end repeat
-                        end try
-                        set msgContent to ""
-                        try
-                            set msgContent to plain text content of msg
+                            set msgContent to content of msg
                             if length of msgContent > 100000 then
                                 set msgContent to text 1 thru 100000 of msgContent
                             end if
-                        on error
-                            try
-                                set msgContent to content of msg
-                                if length of msgContent > 100000 then
-                                    set msgContent to text 1 thru 100000 of msgContent
-                                end if
-                            end try
                         end try
-                        set msgSubject to my escJSON(msgSubject)
-                        set msgSender to my escJSON(msgSender)
-                        set msgContent to my escJSON(msgContent)
-                        set recipList to my escJSON(recipList)
-                        set msgId to my escJSON(msgId)
-                        set catList to my escJSON(catList)
-                        set escFolder to my escJSON(folderName)
-                        set dateStr to (year of msgDate as text) & "-" & my padNum(month of msgDate as integer) & "-" & my padNum(day of msgDate) & "T" & my padNum(hours of msgDate) & ":" & my padNum(minutes of msgDate) & ":00"
-                        set output to output & "  {{\\"message_id\\": \\"" & msgId & "\\", \\"subject\\": \\"" & msgSubject & "\\", \\"sender\\": \\"" & msgSender & "\\", \\"recipients\\": \\"" & recipList & "\\", \\"date\\": \\"" & dateStr & "\\", \\"body_snippet\\": \\"" & msgContent & "\\", \\"folder\\": \\"" & escFolder & "\\", \\"categories\\": \\"" & catList & "\\"}},"
-                    end if
-                end repeat
-            end try
-        end if
-        if totalCount >= 500 then exit repeat
+                    end try
+                    set msgSubject to my escJSON(msgSubject)
+                    set msgSender to my escJSON(msgSender)
+                    set msgContent to my escJSON(msgContent)
+                    set recipList to my escJSON(recipList)
+                    set msgId to my escJSON(msgId)
+                    set catList to my escJSON(catList)
+                    set escFolder to my escJSON(folderPath)
+                    set dateStr to (year of msgDate as text) & "-" & my padNum(month of msgDate as integer) & "-" & my padNum(day of msgDate) & "T" & my padNum(hours of msgDate) & ":" & my padNum(minutes of msgDate) & ":00"
+                    set acc's out to (acc's out) & "  {{\\"message_id\\": \\"" & msgId & "\\", \\"subject\\": \\"" & msgSubject & "\\", \\"sender\\": \\"" & msgSender & "\\", \\"recipients\\": \\"" & recipList & "\\", \\"date\\": \\"" & dateStr & "\\", \\"body_snippet\\": \\"" & msgContent & "\\", \\"folder\\": \\"" & escFolder & "\\", \\"categories\\": \\"" & catList & "\\"}},"
+                end if
+            end repeat
+        end try
+    end tell
+
+    -- Recurse into subfolders
+    set subList to {{}}
+    try
+        tell application "Microsoft Outlook" to set subList to mail folders of f
+    end try
+    repeat with sub in subList
+        if acc's cnt >= capLimit then return
+        try
+            tell application "Microsoft Outlook" to set subName to name of sub
+            my scanTree(contents of sub, folderPath & "/" & subName, myDate, capLimit, depth + 1)
+        end try
     end repeat
-end tell
-set output to output & return & "]"
-return output
+end scanTree
+
+on leafOf(p)
+    set AppleScript's text item delimiters to "/"
+    set parts to text items of p
+    set AppleScript's text item delimiters to ""
+    if (count of parts) is 0 then return p
+    return last item of parts
+end leafOf
 
 on escJSON(txt)
     set txt to my replaceText(txt, "\\\\", "\\\\\\\\")
@@ -821,30 +882,66 @@ end replaceText
 
 
 def get_flagged_emails(since_date: datetime) -> dict:
-    """Get flagged emails from Outlook.
+    """Get flagged emails from Outlook (recursive across all subfolders).
 
-    Returns {"ok": True, "emails": [...]} with flag_due_date field.
+    Walks the full folder tree under the default account up to 8 levels
+    deep so a flagged email filed into a nested user folder is still
+    captured. The legacy implementation only iterated top-level folders,
+    which silently dropped flags on emails the user had already filed.
+
+    Returns {"ok": True, "emails": [...]} with flag_due_date field and
+    slash-delimited folder path.
     """
     if not is_outlook_available():
         return {"ok": False, "error": "Outlook is not running."}
 
     date_str = since_date.strftime("%m/%d/%Y")
 
+    # Same recursive pattern as `search_all_folders`, with a smaller cap (200)
+    # because flagged scans should be tighter and the user's flag-list rarely
+    # gets that large in practice.
     script = f'''
-set output to ""
+script acc
+    property out : ""
+    property cnt : 0
+end script
+
+set acc's out to "[" & return
+set acc's cnt to 0
 set myDate to date "{date_str}"
+set capLimit to 200
+
 tell application "Microsoft Outlook"
-    -- Search all folders in default account for flagged items
-    set output to "[" & return
-    set totalCount to 0
-    set allFolders to every mail folder of default account
-    repeat with f in allFolders
+    try
+        set rootFolders to mail folders of default account
+    on error
+        set rootFolders to {{}}
+    end try
+end tell
+
+repeat with rf in rootFolders
+    if acc's cnt >= capLimit then exit repeat
+    try
+        tell application "Microsoft Outlook" to set rfName to name of rf
+        my scanFlaggedTree(contents of rf, rfName, myDate, capLimit, 0)
+    end try
+end repeat
+
+return (acc's out) & return & "]"
+
+on scanFlaggedTree(f, folderPath, myDate, capLimit, depth)
+    if acc's cnt >= capLimit then return
+    if depth > 8 then return
+    set leafName to my leafOf(folderPath)
+    if leafName is "Deleted Items" or leafName is "Junk Email" or leafName is "Drafts" or leafName is "Trash" or leafName is "Clutter" or leafName is "Outbox" then return
+
+    -- Scan flagged messages in this folder
+    tell application "Microsoft Outlook"
         try
-            set folderName to name of f
-            set folderMsgs to messages of f whose (time sent >= myDate and todo flag of it is not not flagged)
+            set folderMsgs to (messages of f whose (time sent >= myDate and todo flag of it is not not flagged))
             repeat with msg in folderMsgs
-                if totalCount >= 200 then exit repeat
-                set totalCount to totalCount + 1
+                if acc's cnt >= capLimit then exit repeat
+                set acc's cnt to (acc's cnt) + 1
                 set msgSubject to subject of msg
                 set msgSender to ""
                 try
@@ -875,16 +972,34 @@ tell application "Microsoft Outlook"
                 set msgSender to my escJSON(msgSender)
                 set msgContent to my escJSON(msgContent)
                 set msgId to my escJSON(msgId)
-                set escFolder to my escJSON(folderName)
+                set escFolder to my escJSON(folderPath)
                 set dateStr to (year of msgDate as text) & "-" & my padNum(month of msgDate as integer) & "-" & my padNum(day of msgDate) & "T" & my padNum(hours of msgDate) & ":" & my padNum(minutes of msgDate) & ":00"
-                set output to output & "  {{\\"message_id\\": \\"" & msgId & "\\", \\"subject\\": \\"" & msgSubject & "\\", \\"sender\\": \\"" & msgSender & "\\", \\"date\\": \\"" & dateStr & "\\", \\"body_snippet\\": \\"" & msgContent & "\\", \\"folder\\": \\"" & escFolder & "\\", \\"flag_due_date\\": \\"" & flagDate & "\\"}},"
+                set acc's out to (acc's out) & "  {{\\"message_id\\": \\"" & msgId & "\\", \\"subject\\": \\"" & msgSubject & "\\", \\"sender\\": \\"" & msgSender & "\\", \\"date\\": \\"" & dateStr & "\\", \\"body_snippet\\": \\"" & msgContent & "\\", \\"folder\\": \\"" & escFolder & "\\", \\"flag_due_date\\": \\"" & flagDate & "\\"}},"
             end repeat
         end try
-        if totalCount >= 200 then exit repeat
+    end tell
+
+    -- Recurse into subfolders
+    set subList to {{}}
+    try
+        tell application "Microsoft Outlook" to set subList to mail folders of f
+    end try
+    repeat with sub in subList
+        if acc's cnt >= capLimit then return
+        try
+            tell application "Microsoft Outlook" to set subName to name of sub
+            my scanFlaggedTree(contents of sub, folderPath & "/" & subName, myDate, capLimit, depth + 1)
+        end try
     end repeat
-    set output to output & return & "]"
-end tell
-return output
+end scanFlaggedTree
+
+on leafOf(p)
+    set AppleScript's text item delimiters to "/"
+    set parts to text items of p
+    set AppleScript's text item delimiters to ""
+    if (count of parts) is 0 then return p
+    return last item of parts
+end leafOf
 
 on escJSON(txt)
     set txt to my replaceText(txt, "\\\\", "\\\\\\\\")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+"""Pytest bootstrap for this worktree.
+
+The venv typically has ``policydb`` installed from the main repo path
+(``~/Documents/Projects/policydb/src``). When tests run inside a worktree,
+that installed copy wins over the worktree code unless we put the worktree
+``src`` first on ``sys.path``. This conftest does exactly that, before any
+test module is imported, so every test exercises the worktree's code.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_WORKTREE_SRC = Path(__file__).resolve().parent.parent / "src"
+if _WORKTREE_SRC.is_dir():
+    p = str(_WORKTREE_SRC)
+    if p in sys.path:
+        sys.path.remove(p)
+    sys.path.insert(0, p)

--- a/tests/test_email_sync.py
+++ b/tests/test_email_sync.py
@@ -505,3 +505,57 @@ def test_sync_outlook_refuses_empty_capture_category(conn, monkeypatch):
     results = sync_outlook(conn)
     assert called["count"] == 0
     assert any("capture category is empty" in e.lower() for e in results["errors"])
+
+
+# ── Nested-subfolder regression ─────────────────────────────────────────────
+
+
+def test_process_email_handles_nested_subfolder_path(
+    conn, seed_client, seed_policy,
+):
+    """Reply filed in ``Inbox/Clients/XYZ`` must still match its [PDB:] tag.
+
+    Production bug: a placement-colleague reply quoted the original outbound
+    email's ``[PDB:CN...-POL...]`` tags but had been filed by an Outlook rule
+    into a nested user folder. The legacy ``search_all_folders`` AppleScript
+    only iterated top-level folders so the email was silently dropped despite
+    carrying a valid ref tag (fix: recursive ``scanTree`` handler — guarded
+    by tests in ``test_outlook_search_compile.py``).
+
+    This test guards the Python side of the contract: when the bridge does
+    return a nested folder path, ``_process_email`` correctly resolves the
+    ref tag, creates the activity against the right client/policy, and
+    preserves the slash-delimited source path in the details blurb.
+    """
+    results = {
+        "auto_linked": {"sent": 0, "received": 0, "flagged": 0},
+        "suggestions": [],
+        "skipped": 0,
+        "errors": [],
+    }
+    nested_email = {
+        "message_id": "MSG-NESTED-1",
+        "subject": "RE: GL renewal [PDB:CN999000111-POL042]",
+        "sender": "broker@placementco.example",
+        "recipients": ["me@marsh.com"],
+        "date": "2026-04-15T09:00:00",
+        "body_snippet": "Quoting earlier thread with [PDB:CN999000111-POL042]",
+        "folder": "Inbox/Clients/Acme Corp/2026 Renewal",
+        "categories": [],
+    }
+
+    _process_email(conn, nested_email, results, "received")
+
+    assert results["auto_linked"]["received"] == 1
+    row = conn.execute(
+        """SELECT client_id, policy_id, details, email_direction
+           FROM activity_log WHERE outlook_message_id = ?""",
+        ("MSG-NESTED-1",),
+    ).fetchone()
+    assert row is not None, "nested-folder email should produce an activity"
+    assert row["client_id"] == seed_client
+    assert row["policy_id"] == seed_policy
+    assert row["email_direction"] == "received"
+    # Source folder path (slash-delimited) is preserved so the user can see
+    # WHERE the email was filed.
+    assert "Inbox/Clients/Acme Corp/2026 Renewal" in row["details"]

--- a/tests/test_outlook_search_compile.py
+++ b/tests/test_outlook_search_compile.py
@@ -1,0 +1,118 @@
+"""Compile + structural tests for the Outlook folder-scanning AppleScript bridges.
+
+This file exists because of a real production bug: a reply email filed by the
+user into a nested Outlook folder (e.g. ``Inbox/Clients/XYZ``) was silently
+dropped by the sync sweep even though its body carried valid ``[PDB:]`` ref
+tags. Root cause was that ``search_all_folders`` and ``get_flagged_emails``
+both iterated only ``every mail folder of default account`` (top level) and
+never descended into subfolders. The fix added a recursive ``scanTree`` /
+``scanFlaggedTree`` handler.
+
+Two safeguards live here:
+
+1. ``osacompile`` smoke test — same pattern as ``test_outlook_contacts_compile``.
+   AppleScript compile errors aren't caught by ``try`` blocks, so every script
+   string we emit must parse before it runs.
+2. Recursion regression guard — the script body must contain language that
+   walks subfolders (``mail folders of f`` reference inside the recursive
+   handler). If a future refactor accidentally drops the recursion, the
+   silent-drop bug returns; this assertion catches it before shipping.
+
+Skipped automatically when ``osacompile`` isn't available (non-mac CI).
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from policydb import outlook
+
+HAS_OSACOMPILE = shutil.which("osacompile") is not None
+
+
+def _capture_script(fn, *args, **kwargs) -> str:
+    """Invoke fn and return the AppleScript string it would have run."""
+    captured: list[str] = []
+
+    def fake_run(script: str, timeout=None):
+        captured.append(script)
+        return {"ok": True, "raw": "[]"}
+
+    with patch.object(outlook, "is_outlook_available", return_value=True):
+        with patch.object(outlook, "_run_applescript", side_effect=fake_run):
+            fn(*args, **kwargs)
+
+    assert captured, "no AppleScript was generated"
+    return captured[-1]
+
+
+def _assert_compiles(script: str, label: str) -> None:
+    """osacompile must accept the script, or we fail with the compiler diag."""
+    with tempfile.NamedTemporaryFile(suffix=".applescript", mode="w", delete=False) as tmp:
+        tmp.write(script)
+        src = Path(tmp.name)
+    dst = src.with_suffix(".scpt")
+    try:
+        r = subprocess.run(
+            ["osacompile", "-o", str(dst), str(src)],
+            capture_output=True, text=True,
+        )
+        if r.returncode != 0:
+            pytest.fail(
+                f"{label} AppleScript failed to compile:\n"
+                f"  stderr: {r.stderr.strip()}\n"
+                f"  script length: {len(script)} chars"
+            )
+    finally:
+        src.unlink(missing_ok=True)
+        if dst.exists():
+            dst.unlink()
+
+
+@pytest.mark.skipif(not HAS_OSACOMPILE, reason="osacompile not available (non-mac)")
+def test_search_all_folders_compiles_with_category():
+    script = _capture_script(outlook.search_all_folders, datetime(2026, 4, 15), "PDB")
+    _assert_compiles(script, "search_all_folders(category=PDB)")
+
+
+@pytest.mark.skipif(not HAS_OSACOMPILE, reason="osacompile not available (non-mac)")
+def test_search_all_folders_compiles_without_category():
+    script = _capture_script(outlook.search_all_folders, datetime(2026, 4, 15), "")
+    _assert_compiles(script, "search_all_folders(no category)")
+
+
+@pytest.mark.skipif(not HAS_OSACOMPILE, reason="osacompile not available (non-mac)")
+def test_get_flagged_emails_compiles():
+    script = _capture_script(outlook.get_flagged_emails, datetime(2026, 4, 15))
+    _assert_compiles(script, "get_flagged_emails")
+
+
+def test_search_all_folders_recurses_into_subfolders():
+    """Regression guard: script must descend into subfolders, not just top level.
+
+    Ref: production bug where an email filed into ``Inbox/Clients/XYZ`` was
+    silently dropped because the bridge only iterated the top-level folder
+    list. The recursive ``scanTree`` handler is what fixed it; if a future
+    refactor removes the recursion the bug returns silently.
+    """
+    script = _capture_script(outlook.search_all_folders, datetime(2026, 4, 15), "PDB")
+    # The recursive handler exists
+    assert "scanTree" in script, "scanTree handler missing — recursion was dropped"
+    # The handler reads subfolders of the current folder
+    assert "mail folders of f" in script, "subfolder enumeration removed"
+    # The handler calls itself
+    assert "my scanTree" in script, "scanTree never recurses into subfolders"
+
+
+def test_get_flagged_emails_recurses_into_subfolders():
+    """Same regression guard for the flagged-emails sweep."""
+    script = _capture_script(outlook.get_flagged_emails, datetime(2026, 4, 15))
+    assert "scanFlaggedTree" in script, "scanFlaggedTree handler missing"
+    assert "mail folders of f" in script, "subfolder enumeration removed"
+    assert "my scanFlaggedTree" in script, "scanFlaggedTree never recurses"


### PR DESCRIPTION
## Summary
- **Bug:** Replies filed into a nested Outlook folder (e.g. `Inbox/Clients/XYZ`) were silently dropped by the sync sweep — even when their body carried valid `[PDB:]` ref tags. Both `search_all_folders` and `get_flagged_emails` only iterated `every mail folder of default account` (top level) and never descended into subfolders.
- **Fix:** Both AppleScript bridges now recursively walk the folder tree (cap depth 8) via new `scanTree` / `scanFlaggedTree` handlers. Folder paths come back slash-delimited (e.g. `Inbox/Clients/Acme Corp/2026 Renewal`) so the source location is preserved on the imported activity.
- Phase 3D `crawl_folders` already handled this via `outlook_folder_sync`, but it's gated behind `outlook_use_comprehensive_crawl` (defaults `False`) and requires manual discovery. This patch fixes the default legacy path.

## Tests
- `tests/test_outlook_search_compile.py` (new): osacompile smoke tests + structural regression guards that assert the generated AppleScript still contains the recursive `scanTree` / `scanFlaggedTree` walkers — catches the silent-drop bug if a future refactor removes recursion.
- `tests/test_email_sync.py` (new test): `_process_email` correctly resolves a `[PDB:]` ref tag and creates the activity when the bridge returns an email with a deep slash-delimited folder path.
- `tests/conftest.py` (new): puts the worktree `src/` first on `sys.path` so tests exercise worktree code instead of whatever's installed in the venv.

## Test plan
- [x] `pytest tests/test_email_sync.py tests/test_outlook_search_compile.py tests/test_outlook_contacts_compile.py` — 61 passed
- [x] AppleScript compiles via `osacompile` (covered by new tests)
- [ ] Manual QA: run "Sync Outlook" with a recent reply filed into a nested client folder; confirm the activity is created against the right policy and the folder path appears in the activity details

🤖 Generated with [Claude Code](https://claude.com/claude-code)