### PR TITLE
feat(issues): per-policy filter chips + policy pill on activity timeline

### DIFF
--- a/src/policydb/web/routes/issues.py
+++ b/src/policydb/web/routes/issues.py
@@ -821,10 +821,16 @@ def issue_detail(
 
     # Get linked activities (threaded into this issue) — filter out open
     # follow-ups owned by the Open Tasks panel to avoid duplicate display.
+    # Join policies so each activity row carries its policy_uid / type / carrier
+    # for the multi-policy filter chips and per-row policy pill.
     activities = filter_thread_for_history([dict(r) for r in conn.execute("""
-        SELECT a.*, c.name AS contact_name
+        SELECT a.*, c.name AS contact_name,
+               p.policy_uid AS act_policy_uid,
+               p.policy_type AS act_policy_type,
+               p.carrier AS act_policy_carrier
         FROM activity_log a
         LEFT JOIN contacts c ON c.id = a.contact_id
+        LEFT JOIN policies p ON p.id = a.policy_id
         WHERE a.issue_id = ?
         ORDER BY a.activity_date DESC, a.created_at DESC
     """, (issue_id,)).fetchall()])

--- a/src/policydb/web/templates/issues/detail.html
+++ b/src/policydb/web/templates/issues/detail.html
@@ -213,10 +213,38 @@
           </div>
         </div>
 
+        {% set multi_policy = (linked_policies | length) > 1 %}
+        {% if multi_policy and activities %}
+        {# ── Per-policy filter chips (multi-policy issues only) ── #}
+        <div class="flex flex-wrap items-center gap-1.5 mb-3 no-print" id="timeline-filter-chips">
+          <span class="text-[10px] text-gray-400 uppercase tracking-wide mr-1">Filter:</span>
+          <button type="button" data-timeline-filter="__all__"
+                  class="timeline-filter-chip is-active text-[11px] px-2 py-0.5 rounded-full border border-marsh bg-marsh text-white transition-colors">
+            All ({{ activities | length }})
+          </button>
+          {% for p in linked_policies %}
+            {% set pcount = activities | selectattr('act_policy_uid', 'equalto', p.policy_uid) | list | length %}
+            {% if pcount > 0 %}
+            <button type="button" data-timeline-filter="{{ p.policy_uid }}"
+                    class="timeline-filter-chip text-[11px] px-2 py-0.5 rounded-full border border-gray-300 bg-white text-gray-700 hover:border-marsh hover:text-marsh transition-colors">
+              <span class="font-mono">{{ p.policy_uid }}</span>{% if p.policy_type %} · {{ p.policy_type }}{% endif %} ({{ pcount }})
+            </button>
+            {% endif %}
+          {% endfor %}
+          {% set unassigned = activities | rejectattr('act_policy_uid') | list | length %}
+          {% if unassigned > 0 %}
+          <button type="button" data-timeline-filter="__none__"
+                  class="timeline-filter-chip text-[11px] px-2 py-0.5 rounded-full border border-gray-300 bg-white text-gray-700 hover:border-marsh hover:text-marsh transition-colors">
+            Program-level ({{ unassigned }})
+          </button>
+          {% endif %}
+        </div>
+        {% endif %}
+
         {% if activities %}
-        <div class="border-l-2 border-gray-200 ml-1 pl-4 space-y-4">
+        <div class="border-l-2 border-gray-200 ml-1 pl-4 space-y-4" id="issue-activity-timeline">
           {% for act in activities %}
-          <div id="issue-activity-{{ act.id }}">
+          <div id="issue-activity-{{ act.id }}" class="timeline-activity" data-activity-policy-uid="{{ act.act_policy_uid or '' }}">
             <div class="flex items-start gap-2">
               <div class="flex-1 min-w-0">
               <span class="text-xs text-gray-400 w-12 flex-shrink-0">{{ act.activity_date[5:].replace('-', '/') if act.activity_date else '' }}</span>
@@ -227,6 +255,12 @@
                 {% elif atype == 'Meeting' %}bg-indigo-100 text-indigo-700
                 {% elif atype == 'Note' %}bg-pink-100 text-pink-700
                 {% else %}bg-gray-100 text-gray-600{% endif %}">{{ atype }}</span>
+              {% if multi_policy and act.act_policy_uid %}
+              <span class="text-[10px] px-1.5 py-0.5 rounded bg-indigo-50 text-indigo-700 border border-indigo-100"
+                    title="{{ act.act_policy_carrier or '' }}">
+                <span class="font-mono">{{ act.act_policy_uid }}</span>{% if act.act_policy_type %} · {{ act.act_policy_type }}{% endif %}
+              </span>
+              {% endif %}
               <span class="text-sm font-medium text-gray-800">
                 {{ act.subject or '' }}
               </span>
@@ -907,5 +941,34 @@ document.addEventListener('click', function(e) {
     document.getElementById('policy-link-results').classList.add('hidden');
   }
 });
+
+// ── Activity timeline per-policy filter chips ──
+(function() {
+  const chipContainer = document.getElementById('timeline-filter-chips');
+  if (!chipContainer) return;
+  const chips = chipContainer.querySelectorAll('.timeline-filter-chip');
+  const rows = document.querySelectorAll('#issue-activity-timeline .timeline-activity');
+  const activeCls = ['is-active', 'bg-marsh', 'text-white', 'border-marsh'];
+  const idleCls = ['bg-white', 'text-gray-700', 'border-gray-300'];
+  chips.forEach(function(chip) {
+    chip.addEventListener('click', function() {
+      const filter = chip.dataset.timelineFilter;
+      chips.forEach(function(c) {
+        c.classList.remove.apply(c.classList, activeCls);
+        c.classList.add.apply(c.classList, idleCls);
+      });
+      chip.classList.add.apply(chip.classList, activeCls);
+      chip.classList.remove.apply(chip.classList, idleCls);
+      rows.forEach(function(row) {
+        const uid = row.dataset.activityPolicyUid || '';
+        let show = false;
+        if (filter === '__all__') show = true;
+        else if (filter === '__none__') show = uid === '';
+        else show = uid === filter;
+        row.style.display = show ? '' : 'none';
+      });
+    });
+  });
+})();
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Multi-policy renewal issues now show a filter chip strip above the activity timeline (`Filter: All · POL-004 · GL (2) · POL-005 · GL (1) · … · Program-level (1)`) with per-policy counts.
- Each activity row gets a small indigo `POL-XXX · Type` pill next to its type badge, so scanning the timeline answers "what's the latest on Auto?" visually.
- Single-policy issues are unchanged — chips and pills are only rendered when `linked_policies | length > 1`.
- Pure client-side JS toggle, no HTMX round-trip. `data-activity-policy-uid` on each row wrapper drives the filter.

## Changes
- `src/policydb/web/routes/issues.py` — join `policies` in the issue-detail activity query; aliases `p.policy_uid` → `act_policy_uid`, `p.policy_type` → `act_policy_type`, `p.carrier` → `act_policy_carrier` so the activity row dict carries its policy context.
- `src/policydb/web/templates/issues/detail.html` — filter chip strip, policy pill per row, chip toggle script.

## Test plan
- [x] Multi-policy issue (seeded 208 w/ POL-004/005/006 + program-level): chips render with counts (All 5 / POL-004 2 / POL-005 1 / POL-006 1 / Program-level 1); clicking a chip hides the rest; "All" restores; "Program-level" isolates rows with no `policy_id`
- [x] Single-policy issue (2231EEB1 Towerlink, 14 activities): no chips, no pill, timeline renders identically to pre-change
- [x] No console errors beyond pre-existing Tailwind CDN / favicon warnings
- [ ] Visual check on a real program-level renewal once in daily use

🤖 Generated with [Claude Code](https://claude.com/claude-code)