### PR TITLE
fix(email-sync): associate imported emails with the right contact

### DIFF
--- a/src/policydb/cli.py
+++ b/src/policydb/cli.py
@@ -162,6 +162,26 @@ def db_stats():
     console.print()
 
 
+@db_group.command("backfill-email-contacts")
+def db_backfill_email_contacts():
+    """Re-resolve contact_id on historical Outlook-imported email activities."""
+    from policydb.email_sync import backfill_email_contacts
+    conn = _get_conn()
+    stats = backfill_email_contacts(conn)
+    conn.close()
+    console.print(
+        f"\nScanned: [bold]{stats['scanned']}[/bold]  "
+        f"Linked: [green]{stats['linked']}[/green]  "
+        f"Contacts created: [cyan]{stats['created_contacts']}[/cyan]  "
+        f"Unrecoverable: [yellow]{stats['unrecoverable']}[/yellow]"
+    )
+    if stats["unrecoverable"]:
+        console.print(
+            "[dim]Unrecoverable rows have no sender/recipient data — they "
+            "pre-date migration 132. Re-sync from Outlook to fully recover.[/dim]"
+        )
+
+
 # ─── CLIENT COMMANDS ─────────────────────────────────────────────────────────
 
 @main.group("client")

--- a/src/policydb/email_sync.py
+++ b/src/policydb/email_sync.py
@@ -159,6 +159,173 @@ def _is_automated_sender(address: str) -> bool:
     return False
 
 
+def _is_internal_address(address: str) -> bool:
+    """Return True if the email's domain is in ``internal_email_domains`` config."""
+    if not address or "@" not in address:
+        return False
+    domain = address.strip().lower().rsplit("@", 1)[1]
+    internal = {d.strip().lower() for d in cfg.get("internal_email_domains", []) if d}
+    return domain in internal
+
+
+def _parse_name_from_email(address: str) -> str:
+    """Parse a human-ish display name from an email local part."""
+    if not address or "@" not in address:
+        return ""
+    local = address.strip().lower().rsplit("@", 1)[0]
+    parts = re.split(r'[._]', local)
+    if len(parts) >= 2:
+        return " ".join(p.capitalize() for p in parts[:2])
+    if parts and parts[0]:
+        return parts[0].capitalize()
+    return ""
+
+
+def _find_or_create_contact(
+    conn: sqlite3.Connection,
+    email_addr: str,
+    client_id: int | None = None,
+) -> tuple[int | None, str | None]:
+    """Resolve an email address to a contact row, creating one if absent.
+
+    Returns ``(contact_id, display_name)``. Display name is the contact's
+    stored name when matched, else a best-effort parse of the email.
+
+    Auto-create conditions (all must hold):
+      - address parses and isn't automated/bounce/noreply
+      - domain isn't in ``freemail_domains``
+      - ``client_id`` is provided (we won't create orphan contacts)
+
+    Uniqueness: ``contacts(name)`` has a unique index. On collision we
+    retry with the email address appended to disambiguate.
+    """
+    if not email_addr or "@" not in email_addr:
+        return None, None
+    addr = email_addr.strip().lower()
+
+    existing = conn.execute(
+        "SELECT id, name FROM contacts WHERE LOWER(TRIM(email)) = ?",
+        (addr,),
+    ).fetchone()
+    if existing:
+        return existing["id"], existing["name"] or addr
+
+    if _is_automated_sender(addr):
+        return None, addr
+    if _is_internal_address(addr):
+        # Don't auto-create the user or their colleagues — those go through
+        # suggested_contacts for manual review (see _capture_unknown_contacts).
+        return None, addr
+    domain = addr.rsplit("@", 1)[1]
+    freemail = {d.strip().lower() for d in cfg.get("freemail_domains", []) if d}
+    if domain in freemail:
+        return None, addr
+    if not client_id:
+        return None, addr
+
+    archived_row = conn.execute(
+        "SELECT archived FROM clients WHERE id = ?", (client_id,),
+    ).fetchone()
+    if not archived_row or archived_row["archived"]:
+        return None, addr
+
+    parsed_name = _parse_name_from_email(addr) or addr
+    org = domain.rsplit(".", 1)[0].replace("-", " ").title()
+
+    try:
+        cursor = conn.execute(
+            "INSERT INTO contacts (name, email, organization) VALUES (?, ?, ?)",
+            (parsed_name, addr, org),
+        )
+        contact_id = cursor.lastrowid
+    except sqlite3.IntegrityError:
+        # Name collision with an unrelated person — append the email to keep it unique.
+        disambiguated = f"{parsed_name} ({addr})"
+        try:
+            cursor = conn.execute(
+                "INSERT INTO contacts (name, email, organization) VALUES (?, ?, ?)",
+                (disambiguated, addr, org),
+            )
+            contact_id = cursor.lastrowid
+            parsed_name = disambiguated
+        except sqlite3.IntegrityError:
+            logger.warning("Could not auto-create contact for %s (name collision)", addr)
+            return None, addr
+
+    conn.execute(
+        """INSERT OR IGNORE INTO contact_client_assignments
+               (contact_id, client_id, contact_type)
+           VALUES (?, ?, 'client')""",
+        (contact_id, client_id),
+    )
+
+    # Promote any matching suggested_contacts row so the triage list stays clean.
+    conn.execute(
+        "UPDATE suggested_contacts SET status = 'added' WHERE LOWER(TRIM(email)) = ?",
+        (addr,),
+    )
+
+    return contact_id, parsed_name
+
+
+def _resolve_contact_for_email(
+    conn: sqlite3.Connection,
+    sender: str,
+    recipients: list[str],
+    direction: str,
+    client_id: int | None = None,
+) -> tuple[int | None, str]:
+    """Pick the best external contact for an imported email.
+
+    For ``sent`` direction, the correspondent is on the recipient side —
+    iterate recipients, preferring external addresses, and fall back to
+    ``sender`` only if nothing better exists. For ``received``/``flagged``,
+    prefer ``sender`` but fall through to recipients if the sender is
+    internal or empty (e.g. sent-as-colleague).
+
+    Returns ``(contact_id, contact_person)``. ``contact_person`` is always
+    a non-empty string when possible so display pages don't show blanks.
+    """
+    sender_addr = (sender or "").strip()
+    recip_addrs = [r.strip() for r in (recipients or []) if r and "@" in r]
+
+    if direction == "sent":
+        candidates: list[str] = []
+        candidates.extend(r for r in recip_addrs if not _is_internal_address(r))
+        candidates.extend(r for r in recip_addrs if _is_internal_address(r))
+        if sender_addr:
+            candidates.append(sender_addr)
+    else:
+        candidates = []
+        if sender_addr and not _is_internal_address(sender_addr):
+            candidates.append(sender_addr)
+        candidates.extend(r for r in recip_addrs if not _is_internal_address(r))
+        if sender_addr and _is_internal_address(sender_addr):
+            candidates.append(sender_addr)
+        candidates.extend(r for r in recip_addrs if _is_internal_address(r))
+
+    seen: set[str] = set()
+    deduped = []
+    for c in candidates:
+        key = c.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(c)
+
+    for addr in deduped:
+        if _is_automated_sender(addr):
+            continue
+        contact_id, name = _find_or_create_contact(conn, addr, client_id=client_id)
+        if contact_id:
+            return contact_id, name or addr
+
+    # Nothing matched or auto-created — return the first sensible label so
+    # the activity row still has a non-blank "contact_person" for display.
+    fallback = deduped[0] if deduped else (sender_addr or "")
+    return None, fallback
+
+
 def _extract_ref_tags(text: str) -> list[str]:
     """Extract all [PDB:...] ref tags from text."""
     return _REF_TAG_RE.findall(text or "")
@@ -687,17 +854,17 @@ def _create_or_enrich_activity(
     # Create new activity
     disposition = "Sent Email" if is_sent else ""
 
-    # Resolve contact from sender email
-    contact_id = None
-    contact_person = sender
-    if sender:
-        contact = conn.execute(
-            "SELECT id, name FROM contacts WHERE LOWER(TRIM(email))=?",
-            (sender.strip().lower(),),
-        ).fetchone()
-        if contact:
-            contact_id = contact["id"]
-            contact_person = contact["name"] or sender
+    # Resolve contact — for sent emails the correspondent is on the
+    # recipient side, not the sender (which is the user).
+    contact_id, contact_person = _resolve_contact_for_email(
+        conn,
+        sender=sender,
+        recipients=email.get("recipients") or [],
+        direction=email_direction,
+        client_id=client_id or None,
+    )
+    if not contact_person:
+        contact_person = sender
 
     # Phase 3D: capture conversation_id + internet_message_id when the
     # caller's email dict supplies them (search_folder_since does;
@@ -887,16 +1054,16 @@ def _run_thread_inheritance(
                     email_to = line[4:].strip()
                     break
 
-        contact_id = None
-        contact_person = sender
-        if sender:
-            contact = conn.execute(
-                "SELECT id, name FROM contacts WHERE LOWER(TRIM(email))=?",
-                (sender.strip().lower(),),
-            ).fetchone()
-            if contact:
-                contact_id = contact["id"]
-                contact_person = contact["name"] or sender
+        recip_list = [r.strip() for r in (email_to or "").split(",") if r.strip()]
+        contact_id, contact_person = _resolve_contact_for_email(
+            conn,
+            sender=sender,
+            recipients=recip_list,
+            direction="received",
+            client_id=inherited_match.get("client_id"),
+        )
+        if not contact_person:
+            contact_person = sender
 
         content_lines = (candidate.get("content") or "").split("\n")
         snippet_lines = [l for l in content_lines[4:] if l.strip()]
@@ -1503,3 +1670,83 @@ def _process_email(
             if _c:
                 _best_client_name = _c["name"]
     _capture_unknown_contacts(conn, email, _best_client_id, _best_client_name)
+
+
+def backfill_email_contacts(conn: sqlite3.Connection) -> dict:
+    """Re-resolve ``contact_id``/``contact_person`` for historical email activities.
+
+    Iterates every ``activity_type='Email'`` row sourced from Outlook
+    (``outlook_sync`` or ``thread_inherit``) where ``contact_id IS NULL``
+    and applies the new direction-aware resolver. Rows with no recoverable
+    sender/recipient data (all three of ``email_from``, ``email_to``, and
+    ``contact_person`` empty) are reported but left untouched — those
+    would need a fresh Outlook re-sync to recover.
+
+    Returns stats dict:
+        {"scanned": N, "linked": K, "created_contacts": C, "unrecoverable": U}
+    """
+    stats = {"scanned": 0, "linked": 0, "created_contacts": 0, "unrecoverable": 0}
+    before_contacts = conn.execute("SELECT COUNT(*) FROM contacts").fetchone()[0]
+
+    rows = conn.execute(
+        """SELECT id, client_id, email_direction, email_from, email_to,
+                  contact_person
+           FROM activity_log
+           WHERE activity_type = 'Email'
+             AND source IN ('outlook_sync', 'thread_inherit')
+             AND contact_id IS NULL
+             AND client_id IS NOT NULL
+             AND client_id > 0"""
+    ).fetchall()
+
+    for row in rows:
+        stats["scanned"] += 1
+        direction = row["email_direction"] or "received"
+
+        sender = (row["email_from"] or "").strip()
+        # contact_person was historically populated from `sender` at insert
+        # time — use it as a fallback when email_from is NULL.
+        if not sender and row["contact_person"] and "@" in (row["contact_person"] or ""):
+            sender = row["contact_person"].strip()
+
+        recipients = [
+            r.strip() for r in (row["email_to"] or "").split(",") if r.strip()
+        ]
+
+        if not sender and not recipients:
+            stats["unrecoverable"] += 1
+            continue
+
+        contact_id, contact_person = _resolve_contact_for_email(
+            conn,
+            sender=sender,
+            recipients=recipients,
+            direction=direction,
+            client_id=row["client_id"],
+        )
+
+        if contact_id:
+            conn.execute(
+                """UPDATE activity_log
+                   SET contact_id = ?,
+                       contact_person = COALESCE(NULLIF(?, ''), contact_person)
+                   WHERE id = ?""",
+                (contact_id, contact_person, row["id"]),
+            )
+            stats["linked"] += 1
+        elif contact_person and not row["contact_person"]:
+            # Even without a contact row, fill in a label so the UI isn't blank.
+            conn.execute(
+                "UPDATE activity_log SET contact_person = ? WHERE id = ?",
+                (contact_person, row["id"]),
+            )
+
+    conn.commit()
+    after_contacts = conn.execute("SELECT COUNT(*) FROM contacts").fetchone()[0]
+    stats["created_contacts"] = max(0, after_contacts - before_contacts)
+
+    logger.info(
+        "backfill_email_contacts: scanned=%d linked=%d created=%d unrecoverable=%d",
+        stats["scanned"], stats["linked"], stats["created_contacts"], stats["unrecoverable"],
+    )
+    return stats


### PR DESCRIPTION
## Summary
- Direction-aware contact resolver — sent emails try recipients first (external → internal), received try sender → recipients, with automated/internal-only candidates filtered out. Fixes the long-standing bug where sent emails always landed with `contact_id = NULL` because the resolver looked up the user (sender) instead of the correspondent.
- Auto-create a `contacts` row + `contact_client_assignments` row when an external non-freemail address has no match and a client context is resolved. Unique-name collisions fall back to `"Name (email)"`. Internal colleagues and freemail senders stay out of the auto-create path (still go to `suggested_contacts` for manual review).
- New `policydb db backfill-email-contacts` CLI to re-resolve `contact_id` / `contact_person` on every historical `outlook_sync` and `thread_inherit` activity where `contact_id IS NULL`.

## Test plan
- [x] Unit-tested resolver across 8 scenarios: received-known, sent-known, sent-empty-sender, received-new-external (auto-create), sent-freemail (no create), sent-with-noreply-and-real-recipient, received-unknown-internal (no create), received-pre-existing-internal (match)
- [x] `policydb db backfill-email-contacts` runs cleanly; existing pre-migration-132 rows correctly reported as unrecoverable
- [ ] Run one live Outlook sync and confirm new rows populate `contact_id` + `contact_person` for both sent and received

🤖 Generated with [Claude Code](https://claude.com/claude-code)