### PR TITLE
fix(email-sync): separate TO/CC roles + review findings from PR #269

### DIFF
--- a/src/policydb/cli.py
+++ b/src/policydb/cli.py
@@ -166,6 +166,10 @@ def db_stats():
 def db_backfill_email_contacts():
     """Re-resolve contact_id on historical Outlook-imported email activities."""
     from policydb.email_sync import backfill_email_contacts
+    # Migrations create activity_contacts (160) and other new tables the
+    # backfill writes to — run them first so the CLI works even when the
+    # server hasn't been started since the last upgrade.
+    init_db()
     conn = _get_conn()
     stats = backfill_email_contacts(conn)
     conn.close()

--- a/src/policydb/email_sync.py
+++ b/src/policydb/email_sync.py
@@ -293,7 +293,10 @@ def _resolve_contact_for_email(
         candidates: list[str] = []
         candidates.extend(r for r in recip_addrs if not _is_internal_address(r))
         candidates.extend(r for r in recip_addrs if _is_internal_address(r))
-        if sender_addr:
+        # Sent mail's correspondent is on the recipient side — never the
+        # sender. Only fall back to sender if it's external (e.g. delegated
+        # or shared-mailbox scenarios where the "user" isn't internal).
+        if sender_addr and not _is_internal_address(sender_addr):
             candidates.append(sender_addr)
     else:
         candidates = []
@@ -521,10 +524,11 @@ def _resolve_contacts_for_email(
 ) -> dict:
     """Resolve sender + every recipient to known contacts.
 
-    The AppleScript bridge collapses ``to`` and ``cc`` into one ``recipients``
-    list, so everyone who wasn't the sender is tagged as role ``'to'``. That's
-    good enough for "who was on this email" — we lose the TO/CC distinction
-    but keep the participant set.
+    When the email dict carries ``to_recipients`` / ``cc_recipients`` as
+    separate lists (post-outlook.py update), they're tagged with role
+    ``'to'`` and ``'cc'`` respectively. Legacy callers that only provide
+    the combined ``recipients`` list still work — everything falls into
+    the ``'to'`` role, matching pre-update behavior.
 
     Returns::
 
@@ -555,18 +559,30 @@ def _resolve_contacts_for_email(
         entries.append((from_cid, "from"))
         seen.add((from_cid, "from"))
 
-    for addr in (email.get("recipients") or []):
-        row = lookup(addr)
-        if not row:
-            continue
-        key = (row["id"], "to")
-        if key in seen:
-            continue
-        # Don't re-tag the sender as 'to' if they appear in recipients too
-        if row["id"] == from_cid:
-            continue
-        entries.append(key)
-        seen.add(key)
+    # Prefer the split TO/CC lists when the caller supplies them; fall back
+    # to the combined `recipients` field (legacy code paths).
+    to_addrs = email.get("to_recipients")
+    cc_addrs = email.get("cc_recipients")
+    if to_addrs is None and cc_addrs is None:
+        to_addrs = email.get("recipients") or []
+        cc_addrs = []
+
+    def tag_role(addrs, role):
+        for addr in (addrs or []):
+            row = lookup(addr)
+            if not row:
+                continue
+            # Don't re-tag the sender as to/cc if they appear in recipients too.
+            if row["id"] == from_cid:
+                continue
+            key = (row["id"], role)
+            if key in seen:
+                continue
+            entries.append(key)
+            seen.add(key)
+
+    tag_role(to_addrs, "to")
+    tag_role(cc_addrs, "cc")
 
     return {"from_cid": from_cid, "from_name": from_name, "entries": entries}
 
@@ -1901,6 +1917,13 @@ def backfill_email_contacts(conn: sqlite3.Connection) -> dict:
                    WHERE id = ?""",
                 (contact_id, contact_person, row["id"]),
             )
+            # Mirror the live sync path: also tag every known participant in
+            # the activity_contacts junction so the "who was on this email"
+            # view matches what a freshly-synced activity looks like.
+            participants = _resolve_contacts_for_email(
+                conn, {"sender": sender, "recipients": recipients},
+            )
+            _link_activity_contacts(conn, row["id"], participants["entries"])
             stats["linked"] += 1
         elif contact_person and not row["contact_person"]:
             # Even without a contact row, fill in a label so the UI isn't blank.

--- a/src/policydb/outlook.py
+++ b/src/policydb/outlook.py
@@ -111,6 +111,32 @@ def _escape_for_applescript(text: str) -> str:
     return text.replace("\\", "\\\\").replace('"', '\\"')
 
 
+def _normalize_recipient_fields(email: dict) -> None:
+    """In-place: split comma-joined recipient strings into lists and populate
+    the backward-compatible ``recipients`` field as ``to + cc``.
+
+    AppleScript emits ``to_recipients`` and ``cc_recipients`` as comma-
+    separated strings. Older code paths / fallbacks may still carry a
+    pre-combined ``recipients`` string — we honor it as the TO list in
+    that case.
+    """
+    def _split(s) -> list[str]:
+        if isinstance(s, list):
+            return [x.strip() for x in s if x and str(x).strip()]
+        if isinstance(s, str):
+            return [p.strip() for p in s.split(",") if p.strip()]
+        return []
+
+    to_list = _split(email.get("to_recipients"))
+    cc_list = _split(email.get("cc_recipients"))
+    if not to_list and not cc_list and "recipients" in email:
+        # Legacy combined field — everything lands as TO.
+        to_list = _split(email.get("recipients"))
+    email["to_recipients"] = to_list
+    email["cc_recipients"] = cc_list
+    email["recipients"] = to_list + cc_list
+
+
 def create_draft(
     to: str,
     cc: list[str] | None = None,
@@ -261,10 +287,16 @@ on scanTree(f, folderPath, myDate, capLimit, depth)
                     end try
                     set msgDate to time sent of msg
                     set msgId to id of msg as text
-                    set recipList to ""
+                    set recipTo to ""
                     try
                         repeat with r in to recipients of msg
-                            set recipList to recipList & address of email address of r & ","
+                            set recipTo to recipTo & address of email address of r & ","
+                        end repeat
+                    end try
+                    set recipCc to ""
+                    try
+                        repeat with r in cc recipients of msg
+                            set recipCc to recipCc & address of email address of r & ","
                         end repeat
                     end try
                     set catList to ""
@@ -291,12 +323,13 @@ on scanTree(f, folderPath, myDate, capLimit, depth)
                     set msgSubject to my escJSON(msgSubject)
                     set msgSender to my escJSON(msgSender)
                     set msgContent to my escJSON(msgContent)
-                    set recipList to my escJSON(recipList)
+                    set recipTo to my escJSON(recipTo)
+                    set recipCc to my escJSON(recipCc)
                     set msgId to my escJSON(msgId)
                     set catList to my escJSON(catList)
                     set escFolder to my escJSON(folderPath)
                     set dateStr to (year of msgDate as text) & "-" & my padNum(month of msgDate as integer) & "-" & my padNum(day of msgDate) & "T" & my padNum(hours of msgDate) & ":" & my padNum(minutes of msgDate) & ":00"
-                    set acc's out to (acc's out) & "  {{\\"message_id\\": \\"" & msgId & "\\", \\"subject\\": \\"" & msgSubject & "\\", \\"sender\\": \\"" & msgSender & "\\", \\"recipients\\": \\"" & recipList & "\\", \\"date\\": \\"" & dateStr & "\\", \\"body_snippet\\": \\"" & msgContent & "\\", \\"folder\\": \\"" & escFolder & "\\", \\"categories\\": \\"" & catList & "\\"}},"
+                    set acc's out to (acc's out) & "  {{\\"message_id\\": \\"" & msgId & "\\", \\"subject\\": \\"" & msgSubject & "\\", \\"sender\\": \\"" & msgSender & "\\", \\"to_recipients\\": \\"" & recipTo & "\\", \\"cc_recipients\\": \\"" & recipCc & "\\", \\"date\\": \\"" & dateStr & "\\", \\"body_snippet\\": \\"" & msgContent & "\\", \\"folder\\": \\"" & escFolder & "\\", \\"categories\\": \\"" & catList & "\\"}},"
                 end if
             end repeat
         end try
@@ -357,8 +390,7 @@ end replaceText
         raw = re.sub(r',\s*\]', ']', raw)
         emails = json.loads(raw)
         for email in emails:
-            if isinstance(email.get("recipients"), str):
-                email["recipients"] = [r.strip() for r in email["recipients"].split(",") if r.strip()]
+            _normalize_recipient_fields(email)
             if isinstance(email.get("categories"), str):
                 email["categories"] = [c.strip() for c in email["categories"].split(",") if c.strip()]
             else:
@@ -425,14 +457,18 @@ tell application "Microsoft Outlook"
         end try
         set msgDate to time sent of msg
         set msgId to id of msg as text
-        -- Get recipients
-        set recipList to ""
+        -- Get recipients, keeping TO and CC separate so downstream can
+        -- tag them with distinct roles in activity_contacts.
+        set recipTo to ""
         try
             repeat with r in to recipients of msg
-                set recipList to recipList & address of email address of r & ","
+                set recipTo to recipTo & address of email address of r & ","
             end repeat
+        end try
+        set recipCc to ""
+        try
             repeat with r in cc recipients of msg
-                set recipList to recipList & address of email address of r & ","
+                set recipCc to recipCc & address of email address of r & ","
             end repeat
         end try
         -- Get body as plain text for ref tag matching
@@ -462,11 +498,12 @@ tell application "Microsoft Outlook"
         set msgSubject to my escJSON(msgSubject)
         set msgSender to my escJSON(msgSender)
         set msgContent to my escJSON(msgContent)
-        set recipList to my escJSON(recipList)
+        set recipTo to my escJSON(recipTo)
+        set recipCc to my escJSON(recipCc)
         set msgId to my escJSON(msgId)
         set catList to my escJSON(catList)
         set dateStr to (year of msgDate as text) & "-" & my padNum(month of msgDate as integer) & "-" & my padNum(day of msgDate) & "T" & my padNum(hours of msgDate) & ":" & my padNum(minutes of msgDate) & ":00"
-        set output to output & "  {{\\"message_id\\": \\"" & msgId & "\\", \\"subject\\": \\"" & msgSubject & "\\", \\"sender\\": \\"" & msgSender & "\\", \\"recipients\\": \\"" & recipList & "\\", \\"date\\": \\"" & dateStr & "\\", \\"body_snippet\\": \\"" & msgContent & "\\", \\"folder\\": \\"{esc_folder}\\", \\"categories\\": \\"" & catList & "\\"}},"
+        set output to output & "  {{\\"message_id\\": \\"" & msgId & "\\", \\"subject\\": \\"" & msgSubject & "\\", \\"sender\\": \\"" & msgSender & "\\", \\"to_recipients\\": \\"" & recipTo & "\\", \\"cc_recipients\\": \\"" & recipCc & "\\", \\"date\\": \\"" & dateStr & "\\", \\"body_snippet\\": \\"" & msgContent & "\\", \\"folder\\": \\"{esc_folder}\\", \\"categories\\": \\"" & catList & "\\"}},"
         if i < msgCount then set output to output & return
     end repeat
     set output to output & return & "]"
@@ -507,13 +544,8 @@ end replaceText
         # Clean up trailing commas before closing bracket
         raw = re.sub(r',\s*\]', ']', raw)
         emails = json.loads(raw)
-        # Split comma-separated strings into lists
         for email in emails:
-            if isinstance(email.get("recipients"), str):
-                email["recipients"] = [
-                    r.strip() for r in email["recipients"].split(",")
-                    if r.strip()
-                ]
+            _normalize_recipient_fields(email)
             if isinstance(email.get("categories"), str):
                 email["categories"] = [
                     c.strip() for c in email["categories"].split(",")
@@ -756,13 +788,16 @@ tell application "Microsoft Outlook"
         try
             set internetMsgId to internet message id of msg as text
         end try
-        set recipList to ""
+        set recipTo to ""
         try
             repeat with r in to recipients of msg
-                set recipList to recipList & address of email address of r & ","
+                set recipTo to recipTo & address of email address of r & ","
             end repeat
+        end try
+        set recipCc to ""
+        try
             repeat with r in cc recipients of msg
-                set recipList to recipList & address of email address of r & ","
+                set recipCc to recipCc & address of email address of r & ","
             end repeat
         end try
         set msgContent to ""
@@ -789,14 +824,15 @@ tell application "Microsoft Outlook"
         set msgSubject to my escJSON(msgSubject)
         set msgSender to my escJSON(msgSender)
         set msgContent to my escJSON(msgContent)
-        set recipList to my escJSON(recipList)
+        set recipTo to my escJSON(recipTo)
+        set recipCc to my escJSON(recipCc)
         set msgId to my escJSON(msgId)
         set convId to my escJSON(convId)
         set internetMsgId to my escJSON(internetMsgId)
         set catList to my escJSON(catList)
         set escFolder to my escJSON("{esc_path}")
         set dateStr to (year of msgDate as text) & "-" & my padNum(month of msgDate as integer) & "-" & my padNum(day of msgDate) & "T" & my padNum(hours of msgDate) & ":" & my padNum(minutes of msgDate) & ":00"
-        set output to output & "  {{\\"message_id\\": \\"" & msgId & "\\", \\"conversation_id\\": \\"" & convId & "\\", \\"internet_message_id\\": \\"" & internetMsgId & "\\", \\"subject\\": \\"" & msgSubject & "\\", \\"sender\\": \\"" & msgSender & "\\", \\"recipients\\": \\"" & recipList & "\\", \\"date\\": \\"" & dateStr & "\\", \\"body_snippet\\": \\"" & msgContent & "\\", \\"folder\\": \\"" & escFolder & "\\", \\"categories\\": \\"" & catList & "\\"}},"
+        set output to output & "  {{\\"message_id\\": \\"" & msgId & "\\", \\"conversation_id\\": \\"" & convId & "\\", \\"internet_message_id\\": \\"" & internetMsgId & "\\", \\"subject\\": \\"" & msgSubject & "\\", \\"sender\\": \\"" & msgSender & "\\", \\"to_recipients\\": \\"" & recipTo & "\\", \\"cc_recipients\\": \\"" & recipCc & "\\", \\"date\\": \\"" & dateStr & "\\", \\"body_snippet\\": \\"" & msgContent & "\\", \\"folder\\": \\"" & escFolder & "\\", \\"categories\\": \\"" & catList & "\\"}},"
         if i < msgCount then set output to output & return
     end repeat
     set output to output & return & "]"
@@ -860,11 +896,7 @@ end replaceText
         raw = re.sub(r',\s*\]', ']', raw)
         emails = json.loads(raw)
         for email in emails:
-            if isinstance(email.get("recipients"), str):
-                email["recipients"] = [
-                    r.strip() for r in email["recipients"].split(",")
-                    if r.strip()
-                ]
+            _normalize_recipient_fields(email)
             if isinstance(email.get("categories"), str):
                 email["categories"] = [
                     c.strip() for c in email["categories"].split(",")


### PR DESCRIPTION
Fresh-eyes review of PR #269 (email contact association fix) and the Outlook sync path surfaced several issues. User-facing highlight: the `activity_contacts` junction collapsed TO and CC into a single `to` role because the AppleScript bridge concatenated them end-to-end.

## Summary

- **AppleScript TO/CC split** — `search_emails`, `search_all_folders`, and `search_folder_since` now emit `to_recipients` and `cc_recipients` as separate fields. `search_all_folders` was previously dropping CC recipients entirely.
- **Python normalization** — `outlook._normalize_recipient_fields()` centralises the split and preserves the combined `email["recipients"]` for callers that only need the full participant set (ref-tag matching, domain fallback, suggested contacts).
- **Role tagging** — `_resolve_contacts_for_email` now tags TO with `role='to'` and CC with `role='cc'` in `activity_contacts`. Legacy dicts that still pass the combined `recipients` field continue to behave exactly as before.
- **Sent-email primary contact** — for `direction='sent'`, the sender (user, on an internal domain) is excluded from the primary-contact fallback so a sent-to-colleague email never links the user as the correspondent, even if the user happens to be a manually-created contact.
- **Backfill junction** — `backfill_email_contacts` now also populates `activity_contacts` so backfill-linked activities match freshly-synced ones.
- **Backfill CLI** — `policydb db backfill-email-contacts` now runs `init_db()` first so the command works before the server is restarted after a migration 160 upgrade.

## Review findings not addressed here (follow-ups)

- `get_flagged_emails` AppleScript still emits no recipients — flagged activities land with blank `email_to`. Separate scope.
- `_parse_name_from_email` produces awkward names for unusual local parts (`"Johndoe"` from `johndoe@...`). Cosmetic, user-editable.
- Auto-created contact emails are stored lowercased, which looks inconsistent next to user-entered mixed-case emails. Cosmetic only — lookup is case-insensitive.
- PR #269's three new functions have no pytest coverage yet (verified via ad-hoc harness only).

## Test plan

- [x] `pytest tests/test_email_sync.py -q` — 61/61 pass
- [x] End-to-end harness verified: new-format to/cc split, legacy combined fallback, sender-in-cc not double-tagged, sent-internal-to-internal no longer picks user as primary, backfill populates junction with correct role
- [ ] Run one live Outlook sync and confirm new `activity_contacts` rows are created with the right `to`/`cc` roles for both sent and received mail

🤖 Generated with [Claude Code](https://claude.com/claude-code)