### PR TITLE
feat(client): sortable contact tables + copy-table + placement rollup

### DIFF
--- a/src/policydb/web/routes/clients.py
+++ b/src/policydb/web/routes/clients.py
@@ -1388,7 +1388,9 @@ def client_tab_contacts(request: Request, client_id: int, add_contact: str = "",
     _attach_contact_last_touch(conn, team_contacts, client_id)
     _attach_contact_last_touch(conn, external_contacts, client_id)
 
-    # Placement colleagues — include archived/lost policies, tagged accordingly
+    # Placement colleagues — include archived/lost policies, tagged accordingly.
+    # Also build a per-colleague policies list so the rollup renders what each
+    # placement contact is assigned to (project, LOB, carrier, expiration).
     _pc_rows = conn.execute(
         """SELECT co.id, co.name, co.email, co.phone, co.mobile,
                   cpa.role, cpa.title, co.organization,
@@ -1402,10 +1404,46 @@ def client_tab_contacts(request: Request, client_id: int, add_contact: str = "",
            GROUP BY co.id ORDER BY LOWER(co.name)""",
         (client_id,),
     ).fetchall()
+
+    _pc_pols = conn.execute(
+        """SELECT co.id AS contact_id, p.policy_uid, p.policy_type, p.carrier,
+                  p.project_name, p.expiration_date, p.archived
+           FROM contact_policy_assignments cpa
+           JOIN contacts co ON cpa.contact_id = co.id
+           JOIN policies p ON cpa.policy_id = p.id
+           WHERE p.client_id = ? AND cpa.is_placement_colleague = 1
+           ORDER BY co.id, p.archived ASC, p.policy_type""",
+        (client_id,),
+    ).fetchall()
+    from policydb.email_templates import render_tokens as _render_tokens_pc
+    _pol_subj_tpl_pc = cfg.get("email_subject_policy", "Re: {{client_name}} \u2014 {{policy_type}}")
+    _pols_by_contact: dict[int, list[dict]] = {}
+    for pr in _pc_pols:
+        _pol_ctx = {
+            "client_name": client["name"],
+            "policy_type": pr["policy_type"] or "",
+            "carrier": pr["carrier"] or "",
+            "policy_uid": pr["policy_uid"] or "",
+            "expiration_date": pr["expiration_date"] or "",
+            "project_name": (pr["project_name"] or "").strip(),
+            "project_name_sep": f" \u2014 {pr['project_name']}" if pr["project_name"] else "",
+        }
+        _pols_by_contact.setdefault(pr["contact_id"], []).append({
+            "policy_uid": pr["policy_uid"],
+            "policy_type": pr["policy_type"],
+            "carrier": pr["carrier"],
+            "project_name": (pr["project_name"] or "").strip(),
+            "expiration_date": pr["expiration_date"] or "",
+            "mailto_subject": _render_tokens_pc(_pol_subj_tpl_pc, _pol_ctx),
+            "is_archived": bool(pr["archived"]),
+        })
+
     placement_colleagues = [
         dict(r) | {
             "organization": r["organization"] or "",
             "is_lost_only": bool(r["all_archived"]),
+            "policies": _pols_by_contact.get(r["id"], []),
+            "coverage_count": len(_pols_by_contact.get(r["id"], [])),
         }
         for r in _pc_rows
     ]
@@ -4220,6 +4258,133 @@ def copy_table(client_id: int, project: str | None = None, conn=Depends(get_db))
     from policydb.email_templates import build_policy_table
     result = build_policy_table(conn, client_id, project_name=project or None)
     return JSONResponse(result)
+
+
+@router.get("/{client_id}/contacts/copy-table")
+def copy_table_client_contacts(client_id: int, conn=Depends(get_db)):
+    """Return HTML + plain-text contacts table for clipboard copy."""
+    from policydb.email_templates import build_generic_table
+    rows = [dict(r) for r in get_client_contacts(conn, client_id, contact_type='client')]
+    _attach_contact_last_touch(conn, rows, client_id)
+    columns = [
+        ("name", "Name", False),
+        ("title", "Title", False),
+        ("role", "Role", False),
+        ("email", "Email", False),
+        ("phone", "Phone", False),
+        ("mobile", "Mobile", False),
+        ("last_touch_ago", "Last Touch", False),
+        ("notes", "Notes", False),
+    ]
+    return JSONResponse(build_generic_table(rows, columns))
+
+
+@router.get("/{client_id}/team/copy-table")
+def copy_table_team_contacts(client_id: int, conn=Depends(get_db)):
+    """Return HTML + plain-text internal team table for clipboard copy."""
+    from policydb.email_templates import build_generic_table
+    rows = [dict(r) for r in get_client_contacts(conn, client_id, contact_type='internal')]
+    columns = [
+        ("name", "Name", False),
+        ("title", "Title", False),
+        ("role", "Role", False),
+        ("assignment", "Assignment", False),
+        ("email", "Email", False),
+        ("phone", "Phone", False),
+        ("mobile", "Mobile", False),
+    ]
+    return JSONResponse(build_generic_table(rows, columns))
+
+
+@router.get("/{client_id}/external/copy-table")
+def copy_table_external_contacts(client_id: int, conn=Depends(get_db)):
+    """Return HTML + plain-text external stakeholders table for clipboard copy."""
+    from policydb.email_templates import build_generic_table
+    rows = [dict(r) for r in get_client_contacts(conn, client_id, contact_type='external')]
+    columns = [
+        ("name", "Name", False),
+        ("organization", "Organization", False),
+        ("role", "Role", False),
+        ("notes", "Notes", False),
+        ("email", "Email", False),
+        ("phone", "Phone", False),
+        ("mobile", "Mobile", False),
+    ]
+    return JSONResponse(build_generic_table(rows, columns))
+
+
+@router.get("/{client_id}/placement/copy-table")
+def copy_table_placement(client_id: int, conn=Depends(get_db)):
+    """Return HTML + plain-text placement touchpoints table for clipboard copy.
+
+    One row per placement contact with a rolled-up list of assigned coverages
+    (LOB, project, status). Archived/lost policies are included but tagged.
+    """
+    from policydb.email_templates import build_generic_table
+
+    pc_rows = conn.execute(
+        """SELECT co.id, co.name, co.email, co.phone, co.organization
+           FROM contact_policy_assignments cpa
+           JOIN contacts co ON cpa.contact_id = co.id
+           JOIN policies p ON cpa.policy_id = p.id
+           WHERE p.client_id = ? AND cpa.is_placement_colleague = 1
+           GROUP BY co.id ORDER BY LOWER(co.organization), LOWER(co.name)""",
+        (client_id,),
+    ).fetchall()
+
+    pol_rows = conn.execute(
+        """SELECT co.id AS contact_id, p.policy_type, p.carrier,
+                  p.project_name, p.archived
+           FROM contact_policy_assignments cpa
+           JOIN contacts co ON cpa.contact_id = co.id
+           JOIN policies p ON cpa.policy_id = p.id
+           WHERE p.client_id = ? AND cpa.is_placement_colleague = 1
+           ORDER BY co.id, p.archived ASC, p.policy_type""",
+        (client_id,),
+    ).fetchall()
+
+    pols_by_contact: dict[int, list[dict]] = {}
+    for r in pol_rows:
+        pols_by_contact.setdefault(r["contact_id"], []).append(dict(r))
+
+    rows = []
+    for r in pc_rows:
+        pols = pols_by_contact.get(r["id"], [])
+        active = [p for p in pols if not p["archived"]]
+        lost = [p for p in pols if p["archived"]]
+        coverage_parts = []
+        for p in active:
+            label = p["policy_type"] or "Unknown"
+            if p["project_name"]:
+                label += f" — {p['project_name']}"
+            if p["carrier"]:
+                label += f" ({p['carrier']})"
+            coverage_parts.append(label)
+        for p in lost:
+            label = (p["policy_type"] or "Unknown") + " [Lost]"
+            if p["project_name"]:
+                label += f" — {p['project_name']}"
+            coverage_parts.append(label)
+        rows.append({
+            "name": r["name"] or "",
+            "organization": r["organization"] or "",
+            "email": r["email"] or "",
+            "phone": r["phone"] or "",
+            "coverages": "; ".join(coverage_parts),
+            "active_count": len(active),
+            "total_count": len(pols),
+        })
+
+    columns = [
+        ("name", "Name", False),
+        ("organization", "Organization", False),
+        ("email", "Email", False),
+        ("phone", "Phone", False),
+        ("coverages", "Coverages Assigned", False),
+        ("active_count", "Active", False),
+        ("total_count", "Total", False),
+    ]
+    return JSONResponse(build_generic_table(rows, columns))
 
 
 @router.get("/{client_id}/copy-table/opportunities")

--- a/src/policydb/web/templates/base.html
+++ b/src/policydb/web/templates/base.html
@@ -921,6 +921,105 @@ function copyPolicyTable(url, btn) {
   });
 }
 
+/* Generic client-side table sort.
+   Call initTableSort(tableEl) once. It looks for <th data-sort-key="col"> elements
+   and adds click handlers. Each <td> in a row may carry data-sort-value="…"
+   to override textContent-based sorting (useful for ISO dates, numeric cells,
+   or rich/badge content). Tri-state cycle: asc → desc → none (reset). */
+function initTableSort(table) {
+  if (!table || table.dataset.sortInit === '1') return;
+  table.dataset.sortInit = '1';
+  var ths = table.querySelectorAll('thead th[data-sort-key]');
+  var tbody = table.querySelector('tbody');
+  if (!tbody) return;
+  var originalOrder = Array.prototype.slice.call(tbody.querySelectorAll('tr'));
+
+  function indicator(dir) {
+    if (dir === 'asc') return ' <span style="color:#0B4BFF;">↑</span>';
+    if (dir === 'desc') return ' <span style="color:#0B4BFF;">↓</span>';
+    return ' <span class="sort-indicator-idle" style="color:#D1D5DB;opacity:0;transition:opacity .15s;">↕</span>';
+  }
+
+  function extract(tr, colIdx, key) {
+    var td = tr.children[colIdx];
+    if (!td) return '';
+    if (td.dataset && td.dataset.sortValue !== undefined) return td.dataset.sortValue;
+    return (td.textContent || '').trim();
+  }
+
+  function compare(a, b, numeric) {
+    if (numeric) {
+      var na = parseFloat(a); var nb = parseFloat(b);
+      if (isNaN(na) && isNaN(nb)) return 0;
+      if (isNaN(na)) return 1; if (isNaN(nb)) return -1;
+      return na - nb;
+    }
+    a = (a || '').toLowerCase(); b = (b || '').toLowerCase();
+    if (!a && b) return 1; if (a && !b) return -1;  // empty values sink
+    if (a < b) return -1; if (a > b) return 1; return 0;
+  }
+
+  ths.forEach(function(th, i) {
+    // Find th's real index in the thead row (in case of leading ths without data-sort-key)
+    var colIdx = Array.prototype.indexOf.call(th.parentElement.children, th);
+    th.style.cursor = 'pointer';
+    th.style.userSelect = 'none';
+    var labelHtml = th.innerHTML;
+    th.innerHTML = '<span class="sort-label">' + labelHtml + '</span><span class="sort-indicator">' + indicator(null) + '</span>';
+    th.addEventListener('mouseenter', function() {
+      var idle = th.querySelector('.sort-indicator-idle');
+      if (idle) idle.style.opacity = '1';
+    });
+    th.addEventListener('mouseleave', function() {
+      var idle = th.querySelector('.sort-indicator-idle');
+      if (idle) idle.style.opacity = '0';
+    });
+
+    th.addEventListener('click', function() {
+      var cur = th.dataset.sortDir || 'none';
+      // Clear indicators on all ths
+      ths.forEach(function(other) {
+        if (other === th) return;
+        other.dataset.sortDir = 'none';
+        var ind = other.querySelector('.sort-indicator');
+        if (ind) ind.innerHTML = indicator(null);
+      });
+      var next = cur === 'none' ? 'asc' : (cur === 'asc' ? 'desc' : 'none');
+      th.dataset.sortDir = next;
+      var ind = th.querySelector('.sort-indicator');
+      if (ind) ind.innerHTML = indicator(next);
+
+      if (next === 'none') {
+        // Restore original order (skip rows that have been removed)
+        originalOrder.forEach(function(row) {
+          if (row.parentElement === tbody) tbody.appendChild(row);
+        });
+        return;
+      }
+      var rows = Array.prototype.slice.call(tbody.querySelectorAll('tr'));
+      // Keep "empty state" rows (e.g. "No contacts yet") pinned at end
+      var emptyRows = rows.filter(function(r) { return r.id && /empty/i.test(r.id); });
+      var dataRows = rows.filter(function(r) { return emptyRows.indexOf(r) === -1; });
+      var numeric = th.dataset.sortType === 'numeric';
+      dataRows.sort(function(ra, rb) {
+        var va = extract(ra, colIdx, th.dataset.sortKey);
+        var vb = extract(rb, colIdx, th.dataset.sortKey);
+        var r = compare(va, vb, numeric);
+        return next === 'asc' ? r : -r;
+      });
+      dataRows.forEach(function(r) { tbody.appendChild(r); });
+      emptyRows.forEach(function(r) { tbody.appendChild(r); });
+    });
+  });
+}
+
+/* Auto-init any table with data-sortable set. Also re-init after HTMX swaps. */
+function initAllSortableTables(root) {
+  (root || document).querySelectorAll('table[data-sortable]').forEach(initTableSort);
+}
+document.addEventListener('DOMContentLoaded', function() { initAllSortableTables(); });
+document.body.addEventListener('htmx:afterSwap', function(e) { initAllSortableTables(e.target); });
+
 /* confirmAction is defined via window.confirmAction in the IIFE above */
 </script>
 

--- a/src/policydb/web/templates/clients/_contact_matrix_row.html
+++ b/src/policydb/web/templates/clients/_contact_matrix_row.html
@@ -16,6 +16,7 @@
   {# Role (combobox) #}
   <td class="matrix-cell-combo px-3 py-2.5 cursor-pointer relative"
       data-field="role"
+      data-sort-value="{{ c.role or '' }}"
       data-options='{{ contact_roles | tojson }}'>
     <span class="cell-display">
       {% if c.role %}
@@ -46,7 +47,9 @@
          data-placeholder="Cell...">{{ c.mobile or '' }}</div>
   </td>
   {# Last Touch — read-only; tap to jump to the activity history tab #}
-  <td class="px-3 py-2.5 whitespace-nowrap text-xs text-gray-500" title="{{ c.last_touch or '' }}">
+  <td class="px-3 py-2.5 whitespace-nowrap text-xs text-gray-500"
+      data-sort-value="{{ c.last_touch or '' }}"
+      title="{{ c.last_touch or '' }}">
     {% if c.last_touch_ago %}
       {{ c.last_touch_ago }}
     {% else %}

--- a/src/policydb/web/templates/clients/_contacts.html
+++ b/src/policydb/web/templates/clients/_contacts.html
@@ -6,12 +6,18 @@
   {% endif %}
   <div class="flex items-center justify-between mb-3">
     <h2 class="font-semibold text-gray-900 text-sm">Contacts</h2>
-    <button type="button" class="text-xs text-marsh hover:underline font-medium no-print"
-      onclick="if(window._clientContactsMatrix)window._clientContactsMatrix.createNewRow()">+ Add</button>
+    <div class="flex items-center gap-3 no-print">
+      <button type="button"
+        onclick="copyPolicyTable('/clients/{{ client.id }}/contacts/copy-table', this)"
+        class="text-xs text-gray-400 hover:text-marsh"
+        title="Copy contacts table to clipboard">Copy Table</button>
+      <button type="button" class="text-xs text-marsh hover:underline font-medium"
+        onclick="if(window._clientContactsMatrix)window._clientContactsMatrix.createNewRow()">+ Add</button>
+    </div>
   </div>
 
   <div class="overflow-x-auto">
-    <table class="w-full text-sm table-fixed">
+    <table class="w-full text-sm table-fixed" data-sortable>
       <colgroup>
         <col style="width:14%"><col style="width:10%"><col style="width:10%">
         <col style="width:17%"><col style="width:12%"><col style="width:12%"><col style="width:9%"><col style="width:18%">
@@ -19,14 +25,14 @@
       </colgroup>
       <thead>
         <tr class="text-left text-xs text-gray-400 uppercase tracking-wide border-b border-gray-100 bg-gray-50">
-          <th class="px-3 py-2">Name</th>
-          <th class="px-3 py-2">Title</th>
-          <th class="px-3 py-2">Role</th>
-          <th class="px-3 py-2">Email</th>
-          <th class="px-3 py-2">Phone</th>
-          <th class="px-3 py-2">Mobile</th>
-          <th class="px-3 py-2" title="Last logged activity with this contact">Last Touch</th>
-          <th class="px-3 py-2">Notes</th>
+          <th class="px-3 py-2" data-sort-key="name">Name</th>
+          <th class="px-3 py-2" data-sort-key="title">Title</th>
+          <th class="px-3 py-2" data-sort-key="role">Role</th>
+          <th class="px-3 py-2" data-sort-key="email">Email</th>
+          <th class="px-3 py-2" data-sort-key="phone">Phone</th>
+          <th class="px-3 py-2" data-sort-key="mobile">Mobile</th>
+          <th class="px-3 py-2" data-sort-key="last_touch" data-sort-type="date" title="Last logged activity with this contact">Last Touch</th>
+          <th class="px-3 py-2" data-sort-key="notes">Notes</th>
           <th class="px-3 py-2"></th>
           <th class="px-3 py-2"></th>
         </tr>

--- a/src/policydb/web/templates/clients/_external_contacts.html
+++ b/src/policydb/web/templates/clients/_external_contacts.html
@@ -3,25 +3,31 @@
     <h2 class="font-semibold text-gray-900 text-sm">External Stakeholders
       <span class="normal-case font-normal text-gray-400 text-xs">— carrier reps, TPAs, outside counsel</span>
     </h2>
-    <button type="button" class="text-xs text-marsh hover:underline font-medium no-print"
-      onclick="if(window._externalContactsMatrix)window._externalContactsMatrix.createNewRow()">+ Add</button>
+    <div class="flex items-center gap-3 no-print">
+      <button type="button"
+        onclick="copyPolicyTable('/clients/{{ client.id }}/external/copy-table', this)"
+        class="text-xs text-gray-400 hover:text-marsh"
+        title="Copy external stakeholders table to clipboard">Copy Table</button>
+      <button type="button" class="text-xs text-marsh hover:underline font-medium"
+        onclick="if(window._externalContactsMatrix)window._externalContactsMatrix.createNewRow()">+ Add</button>
+    </div>
   </div>
 
   <div class="overflow-x-auto">
-    <table class="w-full text-sm table-fixed">
+    <table class="w-full text-sm table-fixed" data-sortable>
       <colgroup>
         <col style="width:15%"><col style="width:12%"><col style="width:12%"><col style="width:14%">
         <col style="width:18%"><col style="width:13%"><col style="width:13%"><col style="width:28px">
       </colgroup>
       <thead>
         <tr class="text-left text-xs text-gray-400 uppercase tracking-wide border-b border-gray-100 bg-gray-50">
-          <th class="px-3 py-2">Name</th>
-          <th class="px-3 py-2">Organization</th>
-          <th class="px-3 py-2">Role</th>
-          <th class="px-3 py-2">Notes</th>
-          <th class="px-3 py-2">Email</th>
-          <th class="px-3 py-2">Phone</th>
-          <th class="px-3 py-2">Mobile</th>
+          <th class="px-3 py-2" data-sort-key="name">Name</th>
+          <th class="px-3 py-2" data-sort-key="organization">Organization</th>
+          <th class="px-3 py-2" data-sort-key="role">Role</th>
+          <th class="px-3 py-2" data-sort-key="notes">Notes</th>
+          <th class="px-3 py-2" data-sort-key="email">Email</th>
+          <th class="px-3 py-2" data-sort-key="phone">Phone</th>
+          <th class="px-3 py-2" data-sort-key="mobile">Mobile</th>
           <th class="px-3 py-2"></th>
         </tr>
       </thead>
@@ -38,11 +44,13 @@
           </td>
           <td class="matrix-cell-combo px-3 py-2.5 cursor-pointer relative"
               data-field="organization"
+              data-sort-value="{{ c.organization or '' }}"
               data-options='{{ all_orgs | tojson }}'>
             <span class="cell-display text-gray-600 text-xs">{{ c.organization or '—' }}</span>
           </td>
           <td class="matrix-cell-combo px-3 py-2.5 cursor-pointer relative"
               data-field="role"
+              data-sort-value="{{ c.role or '' }}"
               data-options='{{ contact_roles | tojson }}'>
             <span class="cell-display">
               {% if c.role %}<span class="text-xs text-indigo-600 bg-indigo-50 px-2 py-0.5 rounded">{{ c.role }}</span>

--- a/src/policydb/web/templates/clients/_placement_colleagues.html
+++ b/src/policydb/web/templates/clients/_placement_colleagues.html
@@ -1,46 +1,124 @@
 {% if placement_colleagues %}
-<div class="card">
-  <div class="px-5 py-3 border-b border-gray-100">
-    <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide">Placement Touchpoints</h3>
-  </div>
-  {% for org_name, group in placement_colleagues | groupby('organization') %}
-  {% set colleagues = group | list %}
-  {% if org_name %}
-  <div class="px-5 pt-3 pb-1">
-    <span class="text-xs font-semibold text-indigo-600 uppercase tracking-wide">{{ org_name }}</span>
-  </div>
-  {% endif %}
-  <div class="divide-y divide-gray-50 {% if not loop.last %}border-b border-gray-100{% endif %}">
-    {% for c in colleagues %}
-    <div class="px-5 py-3 {% if org_name %}pl-7{% endif %}">
-      <div class="flex items-center gap-3 mb-1.5">
-        <span class="text-sm font-medium text-gray-800">{{ c.name }}</span>
-        {% if c.email %}
-        <span class="text-xs text-gray-400">{{ c.email }}</span>
-        {% endif %}
-        <a href="/contacts?q={{ c.name | urlencode }}"
-           class="text-xs text-gray-400 hover:text-marsh ml-auto shrink-0">Edit in Contacts →</a>
+<div id="placement-card" class="card">
+  <div class="px-5 py-3 border-b border-gray-100 flex items-center justify-between">
+    <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide">Placement Touchpoints
+      <span class="normal-case font-normal text-gray-400 text-[11px] ml-1">— who is handling what</span>
+    </h3>
+    <div class="flex items-center gap-3 no-print">
+      <div class="flex items-center gap-1 text-[11px] text-gray-400">
+        <span>Sort:</span>
+        <button type="button" data-pc-sort="org-name" class="px-1.5 py-0.5 rounded hover:bg-gray-100 text-gray-600 font-medium bg-gray-100">Org · Name</button>
+        <button type="button" data-pc-sort="name" class="px-1.5 py-0.5 rounded hover:bg-gray-100">Name</button>
+        <button type="button" data-pc-sort="coverage" class="px-1.5 py-0.5 rounded hover:bg-gray-100">Coverages</button>
       </div>
-      <ul class="space-y-1">
-        {% for p in c.policies %}
-        <li class="flex items-center gap-1.5 text-xs text-gray-500 {% if p.is_archived %}opacity-60{% endif %}">
-          <a href="/policies/{{ p.policy_uid }}/edit" class="font-mono text-gray-400 hover:text-marsh shrink-0">{{ p.policy_uid }}</a>
-          <span class="text-gray-700">{{ p.policy_type }}</span>
-          <span class="text-gray-400">· {{ p.carrier }}</span>
-          {% if p.project_name %}<span class="text-gray-400 italic truncate">· {{ p.project_name }}</span>{% endif %}
-          {% if p.expiration_date %}<span class="text-gray-300 tabular-nums">exp {{ p.expiration_date }}</span>{% endif %}
-          {% if p.is_archived %}<span class="text-[10px] bg-red-50 text-red-500 px-1.5 py-0.5 rounded-full font-medium">Lost</span>{% endif %}
-          {% if c.email %}
-          <a href="mailto:{{ c.email }}?subject={{ p.mailto_subject | urlencode }}"
-             title="Email {{ c.name }} about this policy"
-             class="ml-auto shrink-0 text-gray-300 hover:text-marsh transition-colors">✉</a>
+      <button type="button"
+        onclick="copyPolicyTable('/clients/{{ client.id }}/placement/copy-table', this)"
+        class="text-xs text-gray-400 hover:text-marsh"
+        title="Copy placement touchpoints table to clipboard">Copy Table</button>
+    </div>
+  </div>
+
+  <div id="placement-list" class="divide-y divide-gray-100">
+    {% for c in placement_colleagues %}
+    {% set active_count = c.policies | rejectattr('is_archived') | list | length %}
+    {% set total_count = c.policies | length %}
+    <div class="placement-row px-5 py-3"
+         data-name="{{ (c.name or '') | lower }}"
+         data-org="{{ (c.organization or '') | lower }}"
+         data-coverage-count="{{ active_count }}">
+      <div class="flex items-start gap-3">
+        <div class="flex-1 min-w-0">
+          <div class="flex items-center gap-2 flex-wrap">
+            <span class="text-sm font-medium text-gray-800">{{ c.name }}</span>
+            {% if c.organization %}
+            <span class="text-[11px] text-indigo-600 bg-indigo-50 px-1.5 py-0.5 rounded font-medium">{{ c.organization }}</span>
+            {% endif %}
+            {% if c.email %}
+            <a href="mailto:{{ c.email }}" class="text-xs text-gray-400 hover:text-marsh truncate">{{ c.email }}</a>
+            {% endif %}
+            {% if c.phone %}
+            <span class="text-xs text-gray-300">·</span>
+            <span class="text-xs text-gray-400">{{ c.phone }}</span>
+            {% endif %}
+            <span class="ml-auto text-[11px] text-gray-400">
+              {% if active_count %}{{ active_count }} active{% endif %}
+              {% if total_count > active_count %}
+                {% if active_count %} · {% endif %}{{ total_count - active_count }} lost
+              {% endif %}
+              {% if not total_count %}no assignments{% endif %}
+            </span>
+            <a href="/contacts?q={{ c.name | urlencode }}"
+               class="text-[11px] text-gray-400 hover:text-marsh shrink-0">Edit →</a>
+          </div>
+
+          {# Coverage rollup — what this person is working on / assigned to #}
+          {% if c.policies %}
+          <ul class="mt-1.5 space-y-1">
+            {% for p in c.policies %}
+            <li class="flex items-center gap-1.5 text-xs text-gray-500 {% if p.is_archived %}opacity-60{% endif %}">
+              {% if p.policy_uid %}
+              <a href="/policies/{{ p.policy_uid }}/edit" class="font-mono text-gray-400 hover:text-marsh shrink-0">{{ p.policy_uid }}</a>
+              {% endif %}
+              <span class="text-gray-700 font-medium">{{ p.policy_type or '—' }}</span>
+              {% if p.carrier %}<span class="text-gray-400">· {{ p.carrier }}</span>{% endif %}
+              {% if p.project_name %}<span class="text-gray-400 italic truncate">· {{ p.project_name }}</span>{% endif %}
+              {% if p.expiration_date %}<span class="text-gray-300 tabular-nums">exp {{ p.expiration_date }}</span>{% endif %}
+              {% if p.is_archived %}<span class="text-[10px] bg-red-50 text-red-500 px-1.5 py-0.5 rounded-full font-medium">Lost</span>{% endif %}
+              {% if c.email %}
+              <a href="mailto:{{ c.email }}?subject={{ p.mailto_subject | urlencode }}"
+                 title="Email {{ c.name }} about this policy"
+                 class="ml-auto shrink-0 text-gray-300 hover:text-marsh transition-colors">✉</a>
+              {% endif %}
+            </li>
+            {% endfor %}
+          </ul>
+          {% else %}
+          <div class="mt-1 text-[11px] text-gray-300 italic">No policies linked yet.</div>
           {% endif %}
-        </li>
-        {% endfor %}
-      </ul>
+        </div>
+      </div>
     </div>
     {% endfor %}
   </div>
-  {% endfor %}
 </div>
+
+<script>
+(function() {
+  var list = document.getElementById('placement-list');
+  if (!list) return;
+  var rows = Array.prototype.slice.call(list.querySelectorAll('.placement-row'));
+  var buttons = document.querySelectorAll('[data-pc-sort]');
+  function apply(mode) {
+    var sorted = rows.slice();
+    if (mode === 'name') {
+      sorted.sort(function(a, b) { return a.dataset.name.localeCompare(b.dataset.name); });
+    } else if (mode === 'coverage') {
+      sorted.sort(function(a, b) {
+        var d = parseInt(b.dataset.coverageCount, 10) - parseInt(a.dataset.coverageCount, 10);
+        if (d !== 0) return d;
+        return a.dataset.name.localeCompare(b.dataset.name);
+      });
+    } else {
+      sorted.sort(function(a, b) {
+        var o = a.dataset.org.localeCompare(b.dataset.org);
+        if (o !== 0) {
+          if (!a.dataset.org) return 1;
+          if (!b.dataset.org) return -1;
+          return o;
+        }
+        return a.dataset.name.localeCompare(b.dataset.name);
+      });
+    }
+    sorted.forEach(function(r) { list.appendChild(r); });
+    buttons.forEach(function(b) {
+      b.classList.toggle('bg-gray-100', b.dataset.pcSort === mode);
+      b.classList.toggle('text-gray-600', b.dataset.pcSort === mode);
+      b.classList.toggle('font-medium', b.dataset.pcSort === mode);
+    });
+  }
+  buttons.forEach(function(b) {
+    b.addEventListener('click', function() { apply(b.dataset.pcSort); });
+  });
+})();
+</script>
 {% endif %}

--- a/src/policydb/web/templates/clients/_team_contacts.html
+++ b/src/policydb/web/templates/clients/_team_contacts.html
@@ -3,25 +3,31 @@
     <h2 class="font-semibold text-gray-900 text-sm">Internal Team
       <span class="normal-case font-normal text-gray-400 text-xs">&mdash; account team members</span>
     </h2>
-    <button type="button" class="text-xs text-marsh hover:underline font-medium no-print"
-      onclick="if(window._teamContactsMatrix)window._teamContactsMatrix.createNewRow()">+ Add</button>
+    <div class="flex items-center gap-3 no-print">
+      <button type="button"
+        onclick="copyPolicyTable('/clients/{{ client.id }}/team/copy-table', this)"
+        class="text-xs text-gray-400 hover:text-marsh"
+        title="Copy internal team table to clipboard">Copy Table</button>
+      <button type="button" class="text-xs text-marsh hover:underline font-medium"
+        onclick="if(window._teamContactsMatrix)window._teamContactsMatrix.createNewRow()">+ Add</button>
+    </div>
   </div>
 
   <div class="overflow-x-auto">
-    <table class="w-full text-sm table-fixed">
+    <table class="w-full text-sm table-fixed" data-sortable>
       <colgroup>
         <col style="width:14%"><col style="width:11%"><col style="width:11%"><col style="width:13%">
         <col style="width:17%"><col style="width:13%"><col style="width:13%"><col style="width:28px">
       </colgroup>
       <thead>
         <tr class="text-left text-xs text-gray-400 uppercase tracking-wide border-b border-gray-100 bg-gray-50">
-          <th class="px-3 py-2">Name</th>
-          <th class="px-3 py-2">Title</th>
-          <th class="px-3 py-2">Role</th>
-          <th class="px-3 py-2">Assignment</th>
-          <th class="px-3 py-2">Email</th>
-          <th class="px-3 py-2">Phone</th>
-          <th class="px-3 py-2">Mobile</th>
+          <th class="px-3 py-2" data-sort-key="name">Name</th>
+          <th class="px-3 py-2" data-sort-key="title">Title</th>
+          <th class="px-3 py-2" data-sort-key="role">Role</th>
+          <th class="px-3 py-2" data-sort-key="assignment">Assignment</th>
+          <th class="px-3 py-2" data-sort-key="email">Email</th>
+          <th class="px-3 py-2" data-sort-key="phone">Phone</th>
+          <th class="px-3 py-2" data-sort-key="mobile">Mobile</th>
           <th class="px-3 py-2"></th>
         </tr>
       </thead>

--- a/src/policydb/web/templates/clients/_team_matrix_row.html
+++ b/src/policydb/web/templates/clients/_team_matrix_row.html
@@ -16,6 +16,7 @@
   {# Role (combobox) #}
   <td class="matrix-cell-combo px-3 py-2.5 cursor-pointer relative"
       data-field="role"
+      data-sort-value="{{ c.role or '' }}"
       data-options='{{ contact_roles | tojson }}'>
     <span class="cell-display">
       {% if c.role %}
@@ -26,6 +27,7 @@
   {# Assignment (combobox, amber, client-specific) #}
   <td class="matrix-cell-combo px-3 py-2.5 cursor-pointer relative"
       data-field="assignment"
+      data-sort-value="{{ c.assignment or '' }}"
       data-options='{{ team_assignments | tojson }}'>
     <span class="cell-display">
       {% if c.assignment %}


### PR DESCRIPTION
## Summary
- Click-to-sort headers on the three contact tables (Contacts, Internal Team, External Stakeholders) with tri-state asc/desc/none cycle
- "Copy Table" button on each of the three contact tables and on Placement Touchpoints — outputs Outlook-safe HTML + plain text
- Placement Touchpoints card now rolls up each contact's assigned coverages on the client detail page (policy UID, LOB, carrier, project, expiration), with Org·Name / Name / Coverages sort toggle

## Why
Users asked for sorting on the contact tables and a way to copy them into email. They also needed the Placement Touchpoints section to answer "what is this person working on?" at a glance — the policy list was only populated on the project page, not the client detail page.

## Files
- `src/policydb/web/templates/base.html` — generic `initTableSort()` helper; auto-binds via `data-sortable`, rebinds on `htmx:afterSwap`
- `src/policydb/web/templates/clients/_contacts.html`, `_team_contacts.html`, `_external_contacts.html` — sortable headers + Copy Table button
- `src/policydb/web/templates/clients/_contact_matrix_row.html`, `_team_matrix_row.html` — `data-sort-value` on Role / Assignment / Last Touch cells
- `src/policydb/web/templates/clients/_placement_colleagues.html` — rewrite: coverage rollup per person, sort toggle, copy button
- `src/policydb/web/routes/clients.py` — populate `c.policies` per placement colleague on client detail; four new copy-table GET endpoints

## Test plan
- [x] Sort each contact table by Name asc/desc/reset — works
- [x] Sort Contacts table by Last Touch — ISO dates sort correctly
- [x] Click Copy Table buttons — all four endpoints return 200 with `{html, text}` payload
- [x] Placement Touchpoints shows rolled-up coverages per person (POL-XXX · LOB · carrier · project · exp)
- [x] Placement sort toggle (Org·Name / Name / Coverages) reorders without page reload
- [x] No console errors on contacts tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)