### PR TITLE
fix(charts): team chart client picker + tower/layer accuracy + editable titles

### DIFF
--- a/src/policydb/charts.py
+++ b/src/policydb/charts.py
@@ -289,7 +289,10 @@ def get_tower_data(conn: sqlite3.Connection, client_id: int) -> list[dict]:
 
         lp = (r["layer_position"] or "Primary").strip().lower()
         att = r["attachment_point"] or 0
-        is_primary = lp == "primary" or (att == 0 and lp not in ("umbrella",))
+        # Trust attachment_point as the source of truth: a primary by definition
+        # attaches at $0. If att > 0 the policy is a layer regardless of how its
+        # layer_position label was filled in (importers default to "Primary").
+        is_primary = (att == 0) and lp not in ("umbrella", "excess")
 
         # Check if this policy is a package
         pkg_key = (tg, r["policy_type"], r["carrier"], r["policy_number"])
@@ -1053,7 +1056,8 @@ def get_exec_financial_summary_data(
         tg = r["program_name"] or "General"
         lp = (r["layer_position"] or "Primary").strip().lower()
         att = r["attachment_point"] or 0
-        is_primary = lp == "primary" or (att == 0 and lp not in ("umbrella",))
+        # Same rule as get_tower_data — attachment_point is authoritative.
+        is_primary = (att == 0) and lp not in ("umbrella", "excess")
 
         section_label = "Primary" if is_primary else "Excess"
         section_key = f"{tg}|{section_label}"

--- a/src/policydb/db.py
+++ b/src/policydb/db.py
@@ -2155,6 +2155,18 @@ def _init_db_inner(conn: sqlite3.Connection, db_path: Path) -> None:
         conn.commit()
         logger.info("Migration 161: added activity_log.reviewed_at + timesheet_closeouts")
 
+    if 162 not in applied:
+        conn.executescript(
+            (_MIGRATIONS_DIR / "162_repair_misclassified_layers.sql").read_text()
+        )
+        repaired = conn.execute("SELECT changes()").fetchone()[0]
+        conn.execute(
+            "INSERT INTO schema_version (version, description) VALUES (?, ?)",
+            (162, "Repair policies with layer_position='Primary' but attachment_point>0"),
+        )
+        conn.commit()
+        logger.info("Migration 162: repaired %d misclassified excess policies", repaired)
+
     # Data hygiene: fix 'None' string corruption in text fields (runs every startup, fast no-op if clean)
     conn.execute("UPDATE clients SET cn_number = NULL WHERE cn_number = 'None'")
 

--- a/src/policydb/importer.py
+++ b/src/policydb/importer.py
@@ -354,6 +354,17 @@ class PolicyImporter:
             deductible = _parse_money(row.get("deductible", "0"))
             commission_rate = _parse_money(row.get("commission_rate", "0"))
             prior_premium = _parse_money(row.get("prior_premium", "0")) or None
+            attachment_point = _parse_money(row.get("attachment_point", "0")) or None
+
+            # If attachment_point > 0, this row is by definition an excess layer,
+            # not a primary — auto-pick "Excess" when layer_position is blank.
+            raw_lp = (row.get("layer_position") or "").strip()
+            if raw_lp:
+                layer_position = raw_lp
+            elif attachment_point and attachment_point > 0:
+                layer_position = "Excess"
+            else:
+                layer_position = "Primary"
 
             self.conn.execute(
                 """INSERT INTO policies
@@ -362,8 +373,8 @@ class PolicyImporter:
                     description, coverage_form, layer_position, tower_group, is_standalone,
                     underwriter_name, underwriter_contact,
                     renewal_status, commission_rate, prior_premium, account_exec, notes,
-                    access_point)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    access_point, attachment_point)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     uid,
                     client_id,
@@ -377,7 +388,7 @@ class PolicyImporter:
                     deductible or None,
                     description,
                     row.get("coverage_form") or None,
-                    row.get("layer_position") or "Primary",
+                    layer_position,
                     row.get("tower_group") or None,
                     _parse_bool(row.get("is_standalone", "0")),
                     row.get("underwriter_name") or None,
@@ -388,6 +399,7 @@ class PolicyImporter:
                     account_exec,
                     row.get("notes") or None,
                     row.get("access_point") or None,
+                    attachment_point,
                 ),
             )
 

--- a/src/policydb/migrations/162_repair_misclassified_layers.sql
+++ b/src/policydb/migrations/162_repair_misclassified_layers.sql
@@ -1,0 +1,16 @@
+-- Migration 162: repair policies whose layer_position is "Primary" but whose
+-- attachment_point is greater than $0. A primary by definition attaches at $0;
+-- these rows are internally inconsistent (often imported from spreadsheets that
+-- omit the layer_position column, which previously defaulted to "Primary"
+-- regardless of attachment_point).
+--
+-- Fix forward by promoting the misclassified rows to "Excess". The chart
+-- classifier already trusts attachment_point as authoritative, but other
+-- surfaces (renewal pipeline, schedule, exec summary) read layer_position
+-- directly, so the data needs to match reality.
+
+UPDATE policies
+SET layer_position = 'Excess'
+WHERE layer_position = 'Primary'
+  AND attachment_point IS NOT NULL
+  AND attachment_point > 0;

--- a/src/policydb/web/routes/charts.py
+++ b/src/policydb/web/routes/charts.py
@@ -605,18 +605,6 @@ async def deck_view(
             chart_titles[cid] = f"Tower: {tg_name}"
             chart_types[cid] = "d3"
 
-    # Check tower completeness for warning banner
-    tower_incomplete = None
-    tower_missing = []
-    if any(cid.startswith("tower") for cid in selected_charts):
-        from policydb.queries import get_schematic_completeness
-        completeness = get_schematic_completeness(conn, client_id)
-        for c in completeness:
-            if c["pct_complete"] < 80:
-                tower_incomplete = c["tower_group"]
-                tower_missing = c.get("missing_fields", [])[:5]  # show up to 5
-                break
-
     return templates.TemplateResponse(
         "charts/view.html",
         {
@@ -627,8 +615,6 @@ async def deck_view(
             "chart_data": chart_data,
             "chart_titles": chart_titles,
             "chart_types": chart_types,
-            "tower_incomplete": tower_incomplete,
-            "tower_missing": tower_missing,
         },
     )
 

--- a/src/policydb/web/static/charts/charts.css
+++ b/src/policydb/web/static/charts/charts.css
@@ -20,6 +20,12 @@
 .chart-title { font-size: 20px; font-weight: 700; color: #1f2937; margin-bottom: 4px; }
 .chart-subtitle { font-size: 12px; color: #9ca3af; margin-bottom: 16px; }
 
+/* Editable title — invisible affordance until hover/focus */
+.chart-title-editable { outline: none; cursor: text; border-radius: 4px; padding: 0 4px; margin-left: -4px; transition: background-color 0.15s; }
+.chart-title-editable:hover { background-color: #F7F3EE; }
+.chart-title-editable:focus { background-color: #F7F3EE; box-shadow: inset 0 -2px 0 #0B4BFF; }
+@media print { .chart-title-editable:hover, .chart-title-editable:focus { background: transparent; box-shadow: none; } }
+
 /* Chart content area (inside the 16:9 container) */
 .chart-content { padding: 32px; height: 100%; box-sizing: border-box; display: flex; flex-direction: column; }
 

--- a/src/policydb/web/static/charts/charts.js
+++ b/src/policydb/web/static/charts/charts.js
@@ -137,10 +137,76 @@ var ChartNav = {
   bindKeys: function() {
     var self = this;
     document.addEventListener('keydown', function(e) {
-      // Don't navigate when typing in inputs
-      if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.tagName === 'SELECT') return;
+      // Don't navigate when typing in inputs or contenteditable fields
+      var t = e.target;
+      if (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.tagName === 'SELECT') return;
+      if (t.isContentEditable) return;
       if (e.key === 'ArrowLeft') self.prev();
       if (e.key === 'ArrowRight') self.next();
     });
+  }
+};
+
+/**
+ * Editable chart-title persistence.
+ * Storage key: chart_title.<client_id>.<chart_id>
+ * Falls back to "global" when no client scope is present (e.g. manual chart preview).
+ */
+var ChartTitle = {
+  _key: function(chartId) {
+    var area = document.getElementById('chart-display-area');
+    var clientId = area && area.dataset.clientId ? area.dataset.clientId : 'global';
+    return 'chart_title.' + clientId + '.' + chartId;
+  },
+
+  applySaved: function() {
+    document.querySelectorAll('.chart-title-editable').forEach(function(el) {
+      var page = el.closest('.chart-page');
+      if (!page) return;
+      var chartId = page.dataset.chart;
+      try {
+        var saved = localStorage.getItem(ChartTitle._key(chartId));
+        if (saved && saved.trim()) {
+          el.textContent = saved;
+          page.dataset.chartTitle = saved;
+          ChartTitle._updateSidebar(chartId, saved);
+        }
+      } catch (e) { /* localStorage unavailable */ }
+    });
+  },
+
+  _updateSidebar: function(chartId, newTitle) {
+    if (!window.ChartNav || !ChartNav.chartIds) return;
+    var idx = ChartNav.chartIds.indexOf(chartId);
+    if (idx < 0) return;
+    var navItem = document.querySelectorAll('.chart-nav-item')[idx];
+    if (!navItem) return;
+    // Sidebar items have a leading "<n>." span then a trailing text node with the title
+    var labelNode = navItem.lastChild;
+    if (labelNode && labelNode.nodeType === 3) {
+      labelNode.textContent = ' ' + newTitle;
+    }
+  },
+
+  save: function(el) {
+    var page = el.closest('.chart-page');
+    if (!page) return;
+    var chartId = page.dataset.chart;
+    var defaultTitle = el.dataset.defaultTitle || '';
+    var newTitle = (el.textContent || '').replace(/\s+/g, ' ').trim();
+    if (!newTitle) {
+      newTitle = defaultTitle;
+      el.textContent = defaultTitle;
+    }
+    page.dataset.chartTitle = newTitle;
+    try {
+      var key = ChartTitle._key(chartId);
+      if (newTitle === defaultTitle) {
+        localStorage.removeItem(key);
+      } else {
+        localStorage.setItem(key, newTitle);
+      }
+    } catch (e) { /* localStorage unavailable */ }
+    ChartTitle._updateSidebar(chartId, newTitle);
   }
 };

--- a/src/policydb/web/templates/charts/_chart_base.html
+++ b/src/policydb/web/templates/charts/_chart_base.html
@@ -24,7 +24,6 @@
            contenteditable="true"
            spellcheck="false"
            data-default-title="{{ title }}"
-           onfocus="this.dataset.before=this.textContent"
            onblur="ChartTitle.save(this)"
            onkeydown="if(event.key==='Enter'){event.preventDefault();this.blur();}">{{ title }}</div>
       {% if subtitle %}<div class="chart-subtitle">{{ subtitle }}</div>{% endif %}

--- a/src/policydb/web/templates/charts/_chart_base.html
+++ b/src/policydb/web/templates/charts/_chart_base.html
@@ -20,7 +20,13 @@
 <div class="chart-content">
   <div class="flex items-start justify-between mb-4">
     <div>
-      <div class="chart-title">{{ title }}</div>
+      <div class="chart-title chart-title-editable"
+           contenteditable="true"
+           spellcheck="false"
+           data-default-title="{{ title }}"
+           onfocus="this.dataset.before=this.textContent"
+           onblur="ChartTitle.save(this)"
+           onkeydown="if(event.key==='Enter'){event.preventDefault();this.blur();}">{{ title }}</div>
       {% if subtitle %}<div class="chart-subtitle">{{ subtitle }}</div>{% endif %}
     </div>
     <button class="chart-export-btn no-print text-xs bg-gray-100 hover:bg-gray-200 text-gray-600 px-3 py-1.5 rounded-lg transition-colors"

--- a/src/policydb/web/templates/charts/_chart_tower.html
+++ b/src/policydb/web/templates/charts/_chart_tower.html
@@ -7,17 +7,6 @@
              unified Y-axis scale (all blocks positioned by dollar value)
 #}
 {% from "charts/_chart_base.html" import chart_frame %}
-{% if tower_incomplete is defined and tower_incomplete %}
-<div id="tower-incomplete-banner" class="bg-amber-50 border border-amber-200 rounded-lg px-4 py-2 mb-2 flex items-center justify-between no-print">
-  <div class="flex items-center gap-2">
-    <span class="text-xs text-amber-700">Program data is incomplete{% if tower_missing is defined and tower_missing %}: {{ tower_missing | join(', ') }}{% endif %}</span>
-    <a href="/clients/{{ client_id }}/programs/{{ tower_incomplete | urlencode }}" target="_blank"
-       class="text-xs text-marsh hover:underline font-medium">Set up program &rarr;</a>
-  </div>
-  <button type="button" onclick="this.closest('#tower-incomplete-banner').remove()"
-    class="text-amber-400 hover:text-amber-600 text-sm leading-none ml-2">&times;</button>
-</div>
-{% endif %}
 {% call(area_id) chart_frame("Program Structure", "Tower / layer diagram") %}
 <div id="{{ area_id }}" style="width:100%;height:100%"></div>
 <script>
@@ -34,8 +23,28 @@
       return;
     }
 
+    // Compute the natural width vs. the room available — if a tower has many
+    // columns, expand the SVG and let the chart-content scroll horizontally
+    // rather than crushing carrier names below ~70px columns.
+    var MIN_COL_W = 75, MAX_COL_W = 180;
+    var marginH = 65; // left 55 + right 10
+    var availW = (container.clientWidth || 896) - marginH;
+    var _totalCols = 0;
+    data.forEach(function(t) { _totalCols += Math.max((t.underlying || []).length, 1); });
+    var _gaps = Math.max(0, data.length - 1) * 24;
+    var requiredInnerW = _totalCols * MIN_COL_W + _gaps;
+    var fullW = container.clientWidth || 896;
+    if (requiredInnerW > availW) {
+      fullW = requiredInnerW + marginH;
+      container.style.overflowX = 'auto';
+      container.style.overflowY = 'hidden';
+    } else {
+      container.style.overflowX = '';
+      container.style.overflowY = '';
+    }
     var chart = createChartSvg('{{ area_id }}', {
-      margin: {top: 10, right: 10, bottom: 10, left: 55}
+      margin: {top: 10, right: 10, bottom: 10, left: 55},
+      width: fullW
     });
     var g = chart.g, W = chart.width, H = chart.height;
 
@@ -66,6 +75,12 @@
       return '$' + v.toLocaleString();
     }
     function tr(s, m) { return !s ? '' : s.length > m ? s.substring(0,m-1)+'\u2026' : s; }
+    // Width-aware truncate: estimates max chars that fit in pxWidth at the given px-per-char ratio.
+    function trW(s, pxWidth, pxPerChar) {
+      if (!s) return '';
+      var maxChars = Math.max(3, Math.floor((pxWidth - 6) / pxPerChar));
+      return tr(s, maxChars);
+    }
 
     // ── Compute the global maximum dollar value across all tower groups ──
     var globalMaxVal = 0;
@@ -83,12 +98,17 @@
     });
     if (globalMaxVal === 0) globalMaxVal = 1000000; // fallback
 
-    // Round up to a nice number for Y-axis
-    var niceMax;
-    if (globalMaxVal >= 5e6) niceMax = Math.ceil(globalMaxVal / 5e6) * 5e6;
-    else if (globalMaxVal >= 1e6) niceMax = Math.ceil(globalMaxVal / 1e6) * 1e6;
-    else if (globalMaxVal >= 100e3) niceMax = Math.ceil(globalMaxVal / 500e3) * 500e3;
-    else niceMax = Math.ceil(globalMaxVal / 100e3) * 100e3;
+    // Choose tick step first, then round niceMax up to the next step boundary so
+    // every tick lands on a clean dollar amount (no $1.25M ticks).
+    var tickStep;
+    if (globalMaxVal >= 100e6) tickStep = 25e6;
+    else if (globalMaxVal >= 50e6) tickStep = 10e6;
+    else if (globalMaxVal >= 20e6) tickStep = 5e6;
+    else if (globalMaxVal >= 5e6) tickStep = 2e6;
+    else if (globalMaxVal >= 1e6) tickStep = 1e6;
+    else if (globalMaxVal >= 250e3) tickStep = 250e3;
+    else tickStep = 100e3;
+    var niceMax = Math.ceil(globalMaxVal / tickStep) * tickStep;
 
     // ── Unified Y-axis: map dollar values to pixel positions ──
     // The "tower zone" is the area between the title and the label/deductible rows
@@ -102,16 +122,14 @@
       return towerBottom - (dollarVal / niceMax) * towerH;
     }
 
-    // ── Compute column widths ──
-    var totalCols = 0;
-    data.forEach(function(t) { totalCols += Math.max(t.underlying.length, 1); });
-    var totalTwrGaps = Math.max(0, (data.length - 1)) * TWR_GAP;
-    var colW = Math.min(Math.floor((W - totalTwrGaps) / Math.max(totalCols, 1)), 180);
+    // ── Compute column widths (clamped to [MIN_COL_W, MAX_COL_W]) ──
+    var totalCols = _totalCols;
+    var totalTwrGaps = _gaps;
+    var fitColW = Math.floor((W - totalTwrGaps) / Math.max(totalCols, 1));
+    var colW = Math.min(MAX_COL_W, Math.max(MIN_COL_W, fitColW));
 
-    // ── Y-axis reference marks ──
-    var tickCount = 4;
-    for (var ti = 0; ti <= tickCount; ti++) {
-      var tickVal = (niceMax / tickCount) * ti;
+    // ── Y-axis reference marks — every tick lands on a tickStep boundary ──
+    for (var tickVal = 0; tickVal <= niceMax + 0.5; tickVal += tickStep) {
       var tickY = valToY(tickVal);
       if (tickY < towerTop - 5) continue;
       g.append('line')
@@ -123,7 +141,7 @@
         .attr('x', -5).attr('y', tickY + 3)
         .attr('text-anchor', 'end')
         .style('font-size', '8px').attr('fill', '#94a3b8')
-        .text(fmtL(tickVal));
+        .text(tickVal === 0 ? '$0' : fmtL(tickVal));
     }
 
     // ── Render each tower group ──
@@ -135,30 +153,46 @@
       var numCols = Math.max(under.length, 1);
       var towerW = numCols * colW;
 
-      // Title — skip if empty (Ungrouped suppressed)
+      // Title — skip if empty (Ungrouped suppressed). Underline the title with a thin
+      // brand-color rule so each group reads as a section header rather than floating text.
       if (tower.program_name) {
+        var titleW = Math.min(towerW - 12, 160);
+        var titleCx = curX + towerW / 2;
         g.append('text')
-          .attr('x', curX + towerW/2).attr('y', 11)
+          .attr('x', titleCx).attr('y', 11)
           .attr('text-anchor', 'middle')
           .style('font-size', '11px').style('font-weight', '700').style('font-family', 'Noto Serif, serif')
           .attr('fill', C.titleC)
-          .text(tr(tower.program_name, 28));
+          .text(trW(tower.program_name, towerW, 6));
+        g.append('line')
+          .attr('x1', titleCx - titleW / 2).attr('x2', titleCx + titleW / 2)
+          .attr('y1', 14).attr('y2', 14)
+          .attr('stroke', C.titleC).attr('stroke-width', 0.75).attr('opacity', 0.35);
       }
 
       // ── Bottom section: labels + deductibles ──
       var baseY = H;
 
-      // Labels row
+      // Labels row — merge consecutive columns with the same label into one span
       baseY -= LABEL_H;
+      var labelRuns = [];
       under.forEach(function(u, ci) {
-        var cx = curX + ci * colW;
-        g.append('rect').attr('x', cx).attr('y', baseY).attr('width', colW).attr('height', LABEL_H)
+        var lbl = u.label || '';
+        var prev = labelRuns[labelRuns.length - 1];
+        if (prev && prev.label === lbl) {
+          prev.span += 1;
+        } else {
+          labelRuns.push({ label: lbl, startCi: ci, span: 1 });
+        }
+      });
+      labelRuns.forEach(function(run) {
+        var rectX = curX + run.startCi * colW;
+        var rectW = run.span * colW;
+        g.append('rect').attr('x', rectX).attr('y', baseY).attr('width', rectW).attr('height', LABEL_H)
           .attr('fill', C.label).attr('stroke', C.labelBd).attr('stroke-width', 0.5);
-        // Scale label length based on column width
-        var maxChars = Math.max(12, Math.floor(colW / 6));
-        g.append('text').attr('x', cx + colW/2).attr('y', baseY + LABEL_H/2 + 4)
+        g.append('text').attr('x', rectX + rectW / 2).attr('y', baseY + LABEL_H / 2 + 4)
           .attr('text-anchor', 'middle').style('font-size', '8px').style('font-weight', '600')
-          .attr('fill', C.textMut).text(tr(u.label, maxChars));
+          .attr('fill', C.textMut).text(trW(run.label, rectW, 4.8));
       });
 
       // Deductible row
@@ -231,35 +265,23 @@
           });
         }
 
-        // Carrier — centered in block (arrows are now outside)
+        // Carrier — centered in block (width-aware truncate)
         var textY = blockTop + pH/2 - 3;
         g.append('text').attr('x', cx + colW/2).attr('y', textY)
           .attr('text-anchor', 'middle').style('font-size', '9px').style('font-weight', '600')
-          .attr('fill', C.textDk).text(tr(u.carrier, 16));
+          .attr('fill', C.textDk).text(trW(u.carrier, colW, 5.5));
 
-        // Limit or "Statutory"
-        if (u.is_statutory) {
-          g.append('text').attr('x', cx + colW/2).attr('y', textY + 12)
-            .attr('text-anchor', 'middle').style('font-size', '8px').style('font-weight', '600')
-            .attr('fill', C.textDk).attr('opacity', 0.7).text('Statutory');
-        } else {
-          g.append('text').attr('x', cx + colW/2).attr('y', blockTop + pH/2 + 9)
-            .attr('text-anchor', 'middle').style('font-size', '8px')
-            .attr('fill', C.textDk).attr('opacity', 0.8).text(fmtL(u.limit));
-        }
-
-        // Package badge ("via BOP", "via WC")
-        if (u.is_package && u.package_parent_type) {
-          g.append('text').attr('x', cx + colW - 3).attr('y', blockTop + 9)
-            .attr('text-anchor', 'end').style('font-size', '6px').style('font-style', 'italic')
-            .attr('fill', C.pkgBadge).text('via ' + tr(u.package_parent_type, 12));
-        }
-
-        // Premium (skip for package sub-cov columns — they show 0)
-        if (u.premium && !u.is_package) {
-          g.append('text').attr('x', cx + colW - 3).attr('y', blockTop + pH - 3)
-            .attr('text-anchor', 'end').style('font-size', '7px')
-            .attr('fill', C.premC).text(fmtL(u.premium));
+        // Limit or "Statutory" (only when block is tall enough to fit both lines)
+        if (pH >= 22) {
+          if (u.is_statutory) {
+            g.append('text').attr('x', cx + colW/2).attr('y', textY + 12)
+              .attr('text-anchor', 'middle').style('font-size', '8px').style('font-weight', '600')
+              .attr('fill', C.textDk).attr('opacity', 0.7).text('Statutory');
+          } else {
+            g.append('text').attr('x', cx + colW/2).attr('y', blockTop + pH/2 + 9)
+              .attr('text-anchor', 'middle').style('font-size', '8px')
+              .attr('fill', C.textDk).attr('opacity', 0.8).text(fmtL(u.limit));
+          }
         }
       });
 
@@ -295,7 +317,7 @@
           var umbH = umbColBottom - umbTopY;
           if (umbH > 0) {
             g.append('rect').attr('x', cx).attr('y', umbTopY).attr('width', colW).attr('height', umbH)
-              .attr('fill', C.umbrella).attr('stroke', C.split).attr('stroke-width', 0.5);
+              .attr('fill', C.umbrella).attr('stroke', C.umbrella).attr('stroke-width', 0.5);
           }
         });
 
@@ -315,13 +337,25 @@
           }
         }
         var umbMidY = (umbTopY + umbBottomY) / 2;
+        // Estimate the umbrella band's effective width (covered cols × colW)
+        var umbBandW;
+        {
+          var covIs = [];
+          under.forEach(function(u, ci) {
+            if (u.is_statutory) return;
+            if (hasSelective && covTypes.indexOf(u.label) === -1) return;
+            covIs.push(ci);
+          });
+          umbBandW = covIs.length ? (d3.max(covIs) - d3.min(covIs) + 1) * colW : towerW;
+        }
         g.append('text').attr('x', labelCenterX).attr('y', umbMidY - 2)
           .attr('text-anchor', 'middle').style('font-size', '9px').style('font-weight', '700')
-          .attr('fill', C.textLt).text(tr(umbLayer.policy_type, 20));
+          .attr('fill', C.textLt).text(trW(umbLayer.policy_type, umbBandW, 5.5));
+        var umbMeta = (umbLayer.carrier || '') + '  ' + (umbLayer.notation || fmtL(umbLayer.limit));
         g.append('text').attr('x', labelCenterX).attr('y', umbMidY + 9)
           .attr('text-anchor', 'middle').style('font-size', '8px')
           .attr('fill', C.textLt).attr('opacity', 0.9)
-          .text(tr(umbLayer.carrier, 20) + '  ' + (umbLayer.notation || fmtL(umbLayer.limit)));
+          .text(trW(umbMeta, umbBandW, 4.8));
       }
 
       // ── Excess layers — each positioned by its attachment_point and limit ──
@@ -353,14 +387,14 @@
               .attr('fill', bg).attr('stroke', C.split).attr('stroke-width', 1);
             g.append('text').attr('x', px + pW/2).attr('y', layerTop + 11)
               .attr('text-anchor', 'middle').style('font-size', '7px')
-              .attr('fill', fg).attr('opacity', 0.7).text(tr(layer.policy_type, 16));
+              .attr('fill', fg).attr('opacity', 0.7).text(trW(layer.policy_type, pW, 4.4));
             g.append('text').attr('x', px + pW/2).attr('y', layerTop + 21)
               .attr('text-anchor', 'middle').style('font-size', '9px').style('font-weight', '700')
-              .attr('fill', fg).text(tr(p.carrier, 14));
+              .attr('fill', fg).text(trW(p.carrier, pW, 5.5));
             if (p.notation && layerH >= 36) {
               g.append('text').attr('x', px + pW/2).attr('y', layerTop + 31)
                 .attr('text-anchor', 'middle').style('font-size', '7px').style('font-style', 'italic')
-                .attr('fill', fg).attr('opacity', 0.8).text(tr(p.notation, 20));
+                .attr('fill', fg).attr('opacity', 0.8).text(trW(p.notation, pW, 4.4));
             }
           });
         } else {
@@ -368,19 +402,14 @@
             .attr('fill', bg).attr('stroke', C.split).attr('stroke-width', 0.5);
           g.append('text').attr('x', curX + towerW/2).attr('y', layerTop + 11)
             .attr('text-anchor', 'middle').style('font-size', '8px')
-            .attr('fill', fg).attr('opacity', 0.7).text(tr(layer.policy_type, 28));
+            .attr('fill', fg).attr('opacity', 0.7).text(trW(layer.policy_type, towerW, 4.8));
           g.append('text').attr('x', curX + towerW/2).attr('y', layerTop + 22)
             .attr('text-anchor', 'middle').style('font-size', '10px').style('font-weight', '700')
-            .attr('fill', fg).text(tr(layer.carrier || (parts[0]?parts[0].carrier:''), 24));
+            .attr('fill', fg).text(trW(layer.carrier || (parts[0]?parts[0].carrier:''), towerW, 6));
           if (layer.notation && layerH >= 38) {
             g.append('text').attr('x', curX + towerW/2).attr('y', layerTop + 33)
               .attr('text-anchor', 'middle').style('font-size', '8px').style('font-style', 'italic')
-              .attr('fill', fg).attr('opacity', 0.8).text(tr(layer.notation, 30));
-          }
-          if (layer.premium && layerH >= 38) {
-            g.append('text').attr('x', curX + towerW - 4).attr('y', layerTop + layerH - 4)
-              .attr('text-anchor', 'end').style('font-size', '7px')
-              .attr('fill', fg).attr('opacity', 0.6).text(fmtL(layer.premium));
+              .attr('fill', fg).attr('opacity', 0.8).text(trW(layer.notation, towerW, 4.8));
           }
         }
       });

--- a/src/policydb/web/templates/charts/_chart_tower.html
+++ b/src/policydb/web/templates/charts/_chart_tower.html
@@ -30,8 +30,9 @@
     var marginH = 65; // left 55 + right 10
     var availW = (container.clientWidth || 896) - marginH;
     var _totalCols = 0;
+    var TWR_GAP = 24;
     data.forEach(function(t) { _totalCols += Math.max((t.underlying || []).length, 1); });
-    var _gaps = Math.max(0, data.length - 1) * 24;
+    var _gaps = Math.max(0, data.length - 1) * TWR_GAP;
     var requiredInnerW = _totalCols * MIN_COL_W + _gaps;
     var fullW = container.clientWidth || 896;
     if (requiredInnerW > availW) {

--- a/src/policydb/web/templates/charts/manual/_tpl_team_chart.html
+++ b/src/policydb/web/templates/charts/manual/_tpl_team_chart.html
@@ -423,10 +423,15 @@
   <!-- Load from Client -->
   <div style="margin-top:1rem;">
     <div class="section-head midnight">Load from Client</div>
-    <div style="display:flex;align-items:center;gap:0.5rem;">
-      <button type="button" class="tc-btn-load" onclick="loadTeamFromClient(this)">Load Team</button>
-      <span style="font-size:0.72rem;color:#7B7974;">Select a client in the snapshot bar above, then click Load Team</span>
+    <div style="display:flex;align-items:center;gap:0.5rem;flex-wrap:wrap;">
+      <div style="position:relative;flex:1;min-width:220px;">
+        <input type="text" id="team-client" placeholder="Search clients…" autocomplete="off"
+               style="width:100%;border:1px solid var(--mc-border);border-radius:3px;padding:0.38rem 0.55rem;font-family:'Noto Sans',sans-serif;font-size:0.83rem;color:var(--mc-text);background:white;">
+        <input type="hidden" id="team-client-id" value="">
+      </div>
+      <button type="button" class="tc-btn-load" onclick="loadTeamFromClient(this)" id="team-load-btn" disabled>Load Team</button>
     </div>
+    <div style="font-size:0.7rem;color:#7B7974;margin-top:0.35rem;">Pulls internal team contacts assigned to this client.</div>
   </div>
 
   <!-- Team Members -->
@@ -795,14 +800,14 @@
 
   // ── Load from Client ──────────────────────────────────────────────────
   window.loadTeamFromClient = function(btn) {
-    // Find the client ID from the snapshot bar's client combobox
-    var clientInput = document.getElementById('snapshot-client');
-    var clientIdInput = document.getElementById('snapshot-client-id');
-    if (!clientIdInput || !clientIdInput.value) {
-      ManualChart.toast('Select a client in the snapshot bar first', 'error');
+    var clientInput = document.getElementById('team-client');
+    var clientIdInput = document.getElementById('team-client-id');
+    var cid = clientIdInput && clientIdInput.value;
+    if (!cid || cid === '0') {
+      ManualChart.toast('Pick a client first', 'error');
       return;
     }
-    var clientId = clientIdInput.value;
+    var clientId = cid;
     var clientName = clientInput ? clientInput.value : 'this client';
 
     if (members.length > 0) {
@@ -1051,16 +1056,50 @@
     buildCanvas();
   };
 
+  // ── Client picker (dedicated autocomplete, decoupled from snapshot bar) ─
+  function syncLoadBtn() {
+    var idEl = document.getElementById('team-client-id');
+    var btn = document.getElementById('team-load-btn');
+    var v = idEl && idEl.value;
+    btn.disabled = !v || v === '0';
+  }
+
+  if (typeof initClientAutocomplete === 'function') {
+    initClientAutocomplete('team-client', 'team-client-id', {
+      onSelect: function(item) {
+        syncLoadBtn();
+        // Touch-once: tag the snapshot with the same client so Save carries it.
+        var snapName = document.getElementById('snapshot-client');
+        var snapId   = document.getElementById('snapshot-client-id');
+        if (snapName) snapName.value = item.name;
+        if (snapId)   snapId.value   = item.id;
+      }
+    });
+    document.getElementById('team-client').addEventListener('input', syncLoadBtn);
+  }
+
   // ── Init ──────────────────────────────────────────────────────────────
   initLayoutButtons();
   serializeState();
   buildSwatches();
   buildMemberEditor();
   buildCanvas();
+
+  // If a snapshot was restored with a client tag, hydrate the team picker
+  // from it so Load Team is ready immediately.
+  var snapClientName = document.getElementById('snapshot-client');
+  var snapClientId   = document.getElementById('snapshot-client-id');
+  var teamClient     = document.getElementById('team-client');
+  var teamClientId   = document.getElementById('team-client-id');
+  if (teamClient && snapClientId && snapClientId.value && !teamClient.value) {
+    teamClient.value   = snapClientName ? snapClientName.value : '';
+    teamClientId.value = snapClientId.value;
+    syncLoadBtn();
+  }
+
   // Load suggestions if snapshot restored with a client
-  var initClientId = document.getElementById('snapshot-client-id');
-  if (initClientId && initClientId.value) {
-    document.getElementById('team-canvas').dataset.clientId = initClientId.value;
+  if (snapClientId && snapClientId.value) {
+    document.getElementById('team-canvas').dataset.clientId = snapClientId.value;
     loadSuggestions();
   }
 })();

--- a/src/policydb/web/templates/charts/view.html
+++ b/src/policydb/web/templates/charts/view.html
@@ -36,7 +36,7 @@
   {# Chart Display Area #}
   <div class="flex-1 flex flex-col overflow-hidden">
     {# Chart Pages #}
-    <div class="flex-1 flex items-center justify-center overflow-auto p-6" id="chart-display-area">
+    <div class="flex-1 flex items-center justify-center overflow-auto p-6" id="chart-display-area" data-client-id="{{ client.id }}">
       {% for chart_id in selected_charts %}
       <div class="chart-page"
            id="chart-{{ chart_id }}"
@@ -79,5 +79,6 @@
 {# Initialize navigation #}
 <script>
   ChartNav.init({{ selected_charts | tojson }});
+  ChartTitle.applySaved();
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- **Team chart editor:** replace the hidden-by-default snapshot-bar dependency with a dedicated client combobox and Load Team button inside the "Load from Client" section. On select, we also back-fill the snapshot bar (touch-once) so saved snapshots stay client-tagged. Restoring a snapshot with a client tag hydrates the picker so Load Team is ready immediately.
- **Tower/layer accuracy:** trust `attachment_point` as the source of truth in `get_tower_data` and `get_exec_financial_summary_data`; importer auto-picks `layer_position = "Excess"` when `attachment_point > 0` and the row's `layer_position` is blank; migration 162 promotes existing misclassified rows (`layer_position = "Primary"` with `attachment_point > 0`) to `"Excess"` so schedule / renewal pipeline / exec summary readers match reality.
- **Tower chart rendering:** column width clamps to [75, 180] px with horizontal overflow fallback; Y-axis ticks snap to a clean step so no more $1.25M labels; titles get a thin brand-color underline; consecutive columns with the same layer label are merged into a single span; removed the deck-view "tower incomplete" warning banner (noise; completeness audit lives elsewhere).
- **Editable chart titles (deck view):** titles are `contenteditable`; edits persist per `(client_id, chart_id)` in `localStorage` and are reflected in the sidebar nav label; `ChartNav` arrow-key handling ignores `contenteditable` to prevent slide jumps while typing; print-safe.

## Notes
- Branch off `origin/main` via cherry-pick because PR #270's original branch (`fix/email-sync-cc-role-and-review-findings`) was squash-merged, and I needed a clean base.
- Migration renumbered to **162** to avoid a collision with PR #271 (#271's migration 161 = timesheet review), which landed while this work was in flight.

## Test plan
- [ ] `/charts/manual/team_chart` — type 2+ letters in the new client picker, pick a client, click Load Team → team members populate.
- [ ] Same page — Save a snapshot and confirm the snapshot carries the client tag (check `Recent Snapshots` on `/charts/manual`).
- [ ] Reopen a snapshot with a client tag → the team picker hydrates and Load Team is immediately enabled.
- [ ] Import a CSV with `attachment_point > 0` and blank `layer_position` → new row saved as `Excess`.
- [ ] On next server start, observe `Migration 162: repaired N misclassified excess policies` in logs; spot-check that policies with `attachment_point > 0` no longer appear as `Primary`.
- [ ] Deck view (`/charts/{client_id}/deck/view`) — edit a chart title, refresh, confirm it persists; left arrow while editing should NOT change slides.
- [ ] Tower chart with many carriers → columns stay legible and the chart scrolls horizontally rather than crushing labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)