### PR TITLE
fix(clients): enable + Add Location button in overview empty state

### DIFF
--- a/src/policydb/web/templates/clients/_overview_locations.html
+++ b/src/policydb/web/templates/clients/_overview_locations.html
@@ -124,6 +124,7 @@
   </div>
   {% endif %}
 </details>
+{% endif %}
 
 <div id="ov-loc-address-suggestions" class="fixed z-50 bg-white border border-gray-200 rounded-b-lg shadow-lg max-h-48 overflow-y-auto hidden" style="min-width:200px"></div>
 
@@ -286,4 +287,3 @@
   };
 })();
 </script>
-{% endif %}


### PR DESCRIPTION
## Summary
- `window.addLocation` was defined inside the `{% if locations %}` block, so clients with zero locations saw the empty-state button but clicking it threw `ReferenceError`.
- Moved the `<script>` + suggestions div outside the conditional so the handler is always defined.

## Test plan
- [ ] Open a client with zero locations → click "+ Add Location" → inline add row appears, save works.
- [ ] Open a client with existing locations → "+ Add Location" still works (regression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)