### PR TITLE
feat(copy-table): honor current table sort order in pasted output

### DIFF
--- a/.claude/skills/policydb-copy-table/SKILL.md
+++ b/.claude/skills/policydb-copy-table/SKILL.md
@@ -3,37 +3,51 @@ name: policydb-copy-table
 description: >
   Copy Table Pattern for clipboard rich-paste in PolicyDB. Use when adding a new "Copy Table"
   button, modifying Outlook-safe HTML table rendering, or working on clipboard copy functionality.
-  Covers the backend/frontend architecture, HTML table styling rules for Outlook, and current
-  deployment locations.
+  Covers the backend/frontend architecture, sort-aware row ordering, HTML table styling rules for
+  Outlook, and current deployment locations.
 ---
 
 # Copy Table Pattern (Clipboard Rich-Paste)
 
 Reusable pattern for one-click "Copy Table" buttons that put both HTML (for Outlook/rich paste) and plain text (for plain editors) on the clipboard.
 
+**Rule:** if the source table is sortable, the pasted table must match the user's current sort order. That is the default — not a nice-to-have. Wire every new Copy Table button into the sort-aware plumbing below, even if the initial table has no sort controls (they often get added later).
+
 ## Architecture
 
-1. **Backend function** in `email_templates.py`: `build_policy_table(conn, client_id, project_name, rows)` returns `{"html": ..., "text": ...}`. Also: `_render_policy_table_html(rows)` and `_render_policy_table_text(rows)` for rendering pre-fetched rows.
-2. **API endpoint**: Returns `JSONResponse({"html": ..., "text": ...})` — e.g. `GET /clients/{id}/copy-table?project=...`
-3. **JS function** in `base.html`: `copyPolicyTable(url, btn)` — fetches the endpoint, writes both MIME types via `ClipboardItem`, with `writeText()` fallback.
+1. **Backend function** in `email_templates.py`:
+   - `build_policy_table(conn, client_id, project_name, rows)` and `build_generic_table(rows, columns)` return `{"html": ..., "text": ...}`.
+   - `apply_row_order(rows, order_param, id_key="id")` reorders a list of dicts to match a comma-separated id list. Pass-through when `order_param` is falsy. Unknown ids are dropped silently; rows without a match are appended at end (never lose data).
+2. **API endpoint**: Accepts an `order: str | None = None` query param and returns `JSONResponse({"html": ..., "text": ...})`.
+3. **JS function** in `base.html`: `copyPolicyTable(url, btn, sourceSelector?)`. When the 3rd argument is given, JS reads `[data-row-id]` elements in DOM order under that selector and appends `order=id1,id2,...` to the URL before fetching.
 
 ## Adding a New Copy Table Button
 
-**Template** — add a button that calls `copyPolicyTable(url, btn)`:
+**Template** — pass the source container as the 3rd arg. Use the tbody id or any stable selector that encloses the rendered rows:
+
 ```html
 <button type="button"
-  onclick="copyPolicyTable('/your/endpoint?params=...', this)"
+  onclick="copyPolicyTable('/your/endpoint', this, '#your-tbody-id')"
   class="text-xs text-gray-300 hover:text-marsh" title="Copy table to clipboard">Copy Table</button>
 ```
 
-**Route** — return JSON with both formats:
+Every row inside that container must carry `data-row-id="..."`. Use whatever id your backend looks up by (DB `id`, `policy_uid`, composite `policy:POL-001` — whatever matches the `id_key` you pass to `apply_row_order`).
+
+**Make the source table sortable by default.** Plain tables → add `data-sortable` to the `<table>` and `data-sort-key="..."` to each `<th>`. The generic sort handler in `base.html` (`initTableSort`) picks this up automatically and re-inits after HTMX swaps. Use `data-sort-value="..."` on cells where textContent isn't a clean sort key (currency, dates with badge clutter, etc.).
+
+**Route** — apply the order, then render:
+
 ```python
-from policydb.email_templates import build_policy_table
-result = build_policy_table(conn, client_id, project_name=project)
-return JSONResponse(result)
+from policydb.email_templates import build_generic_table, apply_row_order
+
+@router.get("/your/endpoint")
+def copy_table_foo(..., order: str | None = None, conn=Depends(get_db)):
+    rows = [dict(r) for r in fetch_rows(conn, ...)]
+    rows = apply_row_order(rows, order, id_key="id")  # match data-row-id
+    return JSONResponse(build_generic_table(rows, columns))
 ```
 
-For custom row sources (e.g. renewal pipeline), build row dicts with keys: `policy_type`, `carrier`, `access_point`, `policy_number`, `effective_date`, `expiration_date`, `premium`, `limit_amount`, `description` — then pass as `rows=` parameter.
+For policy tables, use `build_policy_table(conn, client_id, rows=rows)` or the lower-level `_render_policy_table_html/text(rows)` pair. Row dicts need: `policy_type`, `carrier`, `access_point`, `policy_number`, `effective_date`, `expiration_date`, `premium`, `limit_amount`, `description`.
 
 ## HTML Table Styling (Outlook-Safe)
 
@@ -44,11 +58,26 @@ For custom row sources (e.g. renewal pipeline), build row dicts with keys: `poli
 - Currency/limit columns: right-aligned
 - Carrier column: `"Carrier via Access Point"` when access_point exists
 
+## When the source isn't a sortable table
+
+Some Copy Table buttons don't have a visible sortable table behind them (e.g. the all-policies copy on `_tab_policies.html` is grouped across multiple `<tbody>` sections; Copy Schedule on `_summary_bar.html` exports a view that isn't rendered on the page). In those cases, omit the 3rd JS argument — the endpoint returns server-side order, unchanged.
+
 ## Current Deployment Locations
 
-| Location | Endpoint | Template |
-|----------|----------|----------|
-| Project group header | `/clients/{id}/copy-table?project=...` | `_project_header.html` |
-| Client policies section | `/clients/{id}/copy-table` | `_tab_policies.html` |
-| Project detail page | `/clients/{id}/copy-table?project=...` | `project.html` |
-| Renewal pipeline | `/renewals/copy-table?window=...&status=...&client_id=...` | `renewals.html` |
+| Location | Endpoint | Template | id_key | Source selector |
+|----------|----------|----------|--------|-----------------|
+| Client contacts | `/clients/{id}/contacts/copy-table` | `_contacts.html` | `id` | `#client-contacts-tbody-{cid}` |
+| Internal team | `/clients/{id}/team/copy-table` | `_team_contacts.html` | `id` | `#team-contacts-tbody-{cid}` |
+| External stakeholders | `/clients/{id}/external/copy-table` | `_external_contacts.html` | `id` | `#external-contacts-tbody-{cid}` |
+| Placement touchpoints | `/clients/{id}/placement/copy-table` | `_placement_colleagues.html` | `id` | `#placement-list` |
+| Opportunities | `/clients/{id}/copy-table/opportunities` | `_opportunities.html` | `policy_uid` | `#opps-tbody-{cid}` |
+| Project pipeline | `/clients/{id}/projects/pipeline/copy-table` | `_project_pipeline.html` | `id` | `#pp-tbody` |
+| Project locations | `/clients/{id}/projects/locations/copy-table` | `_project_locations.html` | `id` | `#loc-tbody` |
+| Policies per location | `/clients/{id}/copy-table?project=...` | `project.html` | `policy_uid` | `#project-policies-tbody-{pid}` |
+| Renewal pipeline | `/renewals/copy-table?...` | `renewals.html` | `row_id` (`policy:UID` / `program:UID`) | `#renewals-table tbody` |
+| Compliance matrix | `/compliance/client/{id}/copy-table` | `_summary_banner.html` | `row_id` (`{project}:{line}`) | _no sortable source on banner; leave 3rd arg unset_ |
+| Request bundle items | `/clients/{id}/requests/{bid}/copy-table` | `_request_bundle.html` | `id` | _card list, not a table; 3rd arg unset_ |
+| Compose slideover (issue/policy/project) | `/compose/copy-table?...` | `_compose_slideover.html` | `policy_uid` | _slideover; no visible table_ |
+| All client policies (grouped) | `/clients/{id}/copy-table` | `_tab_policies.html` | `policy_uid` | _grouped across multiple tbodies; 3rd arg unset_ |
+| Project group header (per group) | `/clients/{id}/copy-table?project=...` | `_project_header.html` | `policy_uid` | _grouped context; 3rd arg unset_ |
+| Schedule of insurance | `/clients/{id}/copy-table/schedule` | `_summary_bar.html` | — | _whole-client export; no source table_ |

--- a/src/policydb/email_templates.py
+++ b/src/policydb/email_templates.py
@@ -117,8 +117,8 @@ def _fetch_policy_table_rows(
         params.append(project_name)
 
     rows = conn.execute(
-        f"""SELECT p.policy_type, p.carrier, p.access_point, p.policy_number,
-                   p.effective_date, p.expiration_date, p.premium,
+        f"""SELECT p.id, p.policy_uid, p.policy_type, p.carrier, p.access_point,
+                   p.policy_number, p.effective_date, p.expiration_date, p.premium,
                    p.limit_amount, p.description
             FROM policies p
             WHERE p.client_id = ? AND p.archived = 0
@@ -128,6 +128,42 @@ def _fetch_policy_table_rows(
         params,
     ).fetchall()
     return [dict(r) for r in rows]
+
+
+def apply_row_order(
+    rows: list[dict],
+    order_param: str | None,
+    id_key: str = "id",
+) -> list[dict]:
+    """Reorder *rows* to match a comma-separated list of row IDs.
+
+    When *order_param* is falsy or empty, *rows* is returned unchanged.
+    Matching is done by ``str(row[id_key])``. Rows whose id is not in the
+    order list are appended at the end in their original order — this keeps
+    the copy output safe when DOM/DB drift (never drop rows).
+    """
+    if not order_param:
+        return rows
+    order_list = [tok.strip() for tok in order_param.split(",") if tok.strip()]
+    if not order_list:
+        return rows
+    by_id: dict[str, dict] = {}
+    for r in rows:
+        rid = r.get(id_key)
+        if rid is not None and str(rid) not in by_id:
+            by_id[str(rid)] = r
+    ordered: list[dict] = []
+    seen: set[str] = set()
+    for rid in order_list:
+        row = by_id.get(rid)
+        if row is not None and rid not in seen:
+            ordered.append(row)
+            seen.add(rid)
+    for r in rows:
+        rid = r.get(id_key)
+        if rid is None or str(rid) not in seen:
+            ordered.append(r)
+    return ordered
 
 
 def _carrier_display(carrier: str, access_point: str) -> str:

--- a/src/policydb/web/routes/activities.py
+++ b/src/policydb/web/routes/activities.py
@@ -1898,11 +1898,12 @@ def renewals_copy_table(
     urgency: str = "",
     status: str = "",
     client_id: int = 0,
+    order: str | None = None,
     conn=Depends(get_db),
 ):
     """Return HTML + plain-text renewal pipeline table for clipboard copy."""
     from fastapi.responses import JSONResponse
-    from policydb.email_templates import build_policy_table
+    from policydb.email_templates import build_policy_table, apply_row_order
     from policydb.queries import get_renewal_pipeline_merged
     excluded = cfg.get("renewal_statuses_excluded", [])
     filter_client_ids = [client_id] if client_id else None
@@ -1916,16 +1917,19 @@ def renewals_copy_table(
     )
     # Convert merged pipeline rows to the standard table row format.
     # Programs are mapped to program-level rollup rows so they appear
-    # alongside standalone policies in the pasted table.
+    # alongside standalone policies in the pasted table. `row_id` uses the
+    # template's `subject:uid` token so DOM sort order can be honored.
     rows = []
     for r in pipeline:
         if r.get("_is_program"):
             count = r.get("policy_count") or 0
+            pgm_uid = r.get("program_uid") or ""
             rows.append({
+                "row_id": f"program:{pgm_uid}",
                 "policy_type": f"{r.get('program_name') or ''} (Program)",
                 "carrier": r.get("carriers_list") or "",
                 "access_point": "",
-                "policy_number": r.get("program_uid") or "",
+                "policy_number": pgm_uid,
                 "effective_date": "",
                 "expiration_date": r.get("earliest_expiration") or "",
                 "premium": r.get("total_premium"),
@@ -1933,7 +1937,9 @@ def renewals_copy_table(
                 "description": f"{count} polic{'y' if count == 1 else 'ies'}",
             })
         else:
+            pol_uid = r.get("policy_uid") or ""
             rows.append({
+                "row_id": f"policy:{pol_uid}",
                 "policy_type": r.get("policy_type") or "",
                 "carrier": r.get("carrier") or "",
                 "access_point": r.get("access_point") or "",
@@ -1944,6 +1950,7 @@ def renewals_copy_table(
                 "limit_amount": r.get("limit_amount"),
                 "description": r.get("description") or "",
             })
+    rows = apply_row_order(rows, order, id_key="row_id")
     result = build_policy_table(conn, client_id=0, rows=rows)
     return JSONResponse(result)
 

--- a/src/policydb/web/routes/clients.py
+++ b/src/policydb/web/routes/clients.py
@@ -4252,20 +4252,35 @@ def client_policies_json(client_id: int, conn=Depends(get_db)):
 
 
 @router.get("/{client_id}/copy-table")
-def copy_table(client_id: int, project: str | None = None, conn=Depends(get_db)):
+def copy_table(
+    client_id: int,
+    project: str | None = None,
+    order: str | None = None,
+    conn=Depends(get_db),
+):
     """Return HTML + plain-text policy table for clipboard copy."""
     from fastapi.responses import JSONResponse
-    from policydb.email_templates import build_policy_table
-    result = build_policy_table(conn, client_id, project_name=project or None)
-    return JSONResponse(result)
+    from policydb.email_templates import (
+        _fetch_policy_table_rows,
+        _render_policy_table_html,
+        _render_policy_table_text,
+        apply_row_order,
+    )
+    rows = _fetch_policy_table_rows(conn, client_id, project_name=project or None)
+    rows = apply_row_order(rows, order, id_key="policy_uid")
+    return JSONResponse({
+        "html": _render_policy_table_html(rows),
+        "text": _render_policy_table_text(rows),
+    })
 
 
 @router.get("/{client_id}/contacts/copy-table")
-def copy_table_client_contacts(client_id: int, conn=Depends(get_db)):
+def copy_table_client_contacts(client_id: int, order: str | None = None, conn=Depends(get_db)):
     """Return HTML + plain-text contacts table for clipboard copy."""
-    from policydb.email_templates import build_generic_table
+    from policydb.email_templates import build_generic_table, apply_row_order
     rows = [dict(r) for r in get_client_contacts(conn, client_id, contact_type='client')]
     _attach_contact_last_touch(conn, rows, client_id)
+    rows = apply_row_order(rows, order, id_key="id")
     columns = [
         ("name", "Name", False),
         ("title", "Title", False),
@@ -4280,10 +4295,11 @@ def copy_table_client_contacts(client_id: int, conn=Depends(get_db)):
 
 
 @router.get("/{client_id}/team/copy-table")
-def copy_table_team_contacts(client_id: int, conn=Depends(get_db)):
+def copy_table_team_contacts(client_id: int, order: str | None = None, conn=Depends(get_db)):
     """Return HTML + plain-text internal team table for clipboard copy."""
-    from policydb.email_templates import build_generic_table
+    from policydb.email_templates import build_generic_table, apply_row_order
     rows = [dict(r) for r in get_client_contacts(conn, client_id, contact_type='internal')]
+    rows = apply_row_order(rows, order, id_key="id")
     columns = [
         ("name", "Name", False),
         ("title", "Title", False),
@@ -4297,10 +4313,11 @@ def copy_table_team_contacts(client_id: int, conn=Depends(get_db)):
 
 
 @router.get("/{client_id}/external/copy-table")
-def copy_table_external_contacts(client_id: int, conn=Depends(get_db)):
+def copy_table_external_contacts(client_id: int, order: str | None = None, conn=Depends(get_db)):
     """Return HTML + plain-text external stakeholders table for clipboard copy."""
-    from policydb.email_templates import build_generic_table
+    from policydb.email_templates import build_generic_table, apply_row_order
     rows = [dict(r) for r in get_client_contacts(conn, client_id, contact_type='external')]
+    rows = apply_row_order(rows, order, id_key="id")
     columns = [
         ("name", "Name", False),
         ("organization", "Organization", False),
@@ -4314,13 +4331,13 @@ def copy_table_external_contacts(client_id: int, conn=Depends(get_db)):
 
 
 @router.get("/{client_id}/placement/copy-table")
-def copy_table_placement(client_id: int, conn=Depends(get_db)):
+def copy_table_placement(client_id: int, order: str | None = None, conn=Depends(get_db)):
     """Return HTML + plain-text placement touchpoints table for clipboard copy.
 
     One row per placement contact with a rolled-up list of assigned coverages
     (LOB, project, status). Archived/lost policies are included but tagged.
     """
-    from policydb.email_templates import build_generic_table
+    from policydb.email_templates import build_generic_table, apply_row_order
 
     pc_rows = conn.execute(
         """SELECT co.id, co.name, co.email, co.phone, co.organization
@@ -4366,6 +4383,7 @@ def copy_table_placement(client_id: int, conn=Depends(get_db)):
                 label += f" — {p['project_name']}"
             coverage_parts.append(label)
         rows.append({
+            "id": r["id"],
             "name": r["name"] or "",
             "organization": r["organization"] or "",
             "email": r["email"] or "",
@@ -4374,6 +4392,8 @@ def copy_table_placement(client_id: int, conn=Depends(get_db)):
             "active_count": len(active),
             "total_count": len(pols),
         })
+
+    rows = apply_row_order(rows, order, id_key="id")
 
     columns = [
         ("name", "Name", False),
@@ -4388,13 +4408,14 @@ def copy_table_placement(client_id: int, conn=Depends(get_db)):
 
 
 @router.get("/{client_id}/copy-table/opportunities")
-def copy_table_opportunities(client_id: int, conn=Depends(get_db)):
+def copy_table_opportunities(client_id: int, order: str | None = None, conn=Depends(get_db)):
     """Return HTML + plain-text opportunities table for clipboard copy."""
     from fastapi.responses import JSONResponse
-    from policydb.email_templates import build_generic_table
+    from policydb.email_templates import build_generic_table, apply_row_order
     from policydb.queries import get_policies_for_client
     all_policies = [dict(p) for p in get_policies_for_client(conn, client_id)]
     opps = [p for p in all_policies if p.get("is_opportunity")]
+    opps = apply_row_order(opps, order, id_key="policy_uid")
     columns = [
         ("policy_type", "Line of Business", False),
         ("carrier", "Carrier (Target)", False),
@@ -4408,12 +4429,13 @@ def copy_table_opportunities(client_id: int, conn=Depends(get_db)):
 
 
 @router.get("/{client_id}/copy-table/schedule")
-def copy_table_schedule(client_id: int, conn=Depends(get_db)):
+def copy_table_schedule(client_id: int, order: str | None = None, conn=Depends(get_db)):
     """Return HTML + plain-text schedule of insurance for clipboard copy."""
     from fastapi.responses import JSONResponse
-    from policydb.email_templates import build_generic_table
+    from policydb.email_templates import build_generic_table, apply_row_order
     from policydb.exporter import _schedule_rows_for_client
     rows = [dict(r) for r in _schedule_rows_for_client(conn, client_id)]
+    rows = apply_row_order(rows, order, id_key="Policy Number")
     # Strip client_name — already known from context
     for r in rows:
         r.pop("client_name", None)
@@ -4436,14 +4458,15 @@ def copy_table_schedule(client_id: int, conn=Depends(get_db)):
 
 
 @router.get("/{client_id}/requests/{bundle_id}/copy-table")
-def copy_table_request_bundle(client_id: int, bundle_id: int, conn=Depends(get_db)):
+def copy_table_request_bundle(client_id: int, bundle_id: int, order: str | None = None, conn=Depends(get_db)):
     """Return HTML + plain-text request bundle items for clipboard copy."""
     from fastapi.responses import JSONResponse
-    from policydb.email_templates import build_generic_table
+    from policydb.email_templates import build_generic_table, apply_row_order
     items = _enrich_request_items(conn, [dict(r) for r in conn.execute(
         "SELECT * FROM client_request_items WHERE bundle_id=? ORDER BY received ASC, sort_order ASC, id ASC",
         (bundle_id,),
     ).fetchall()])
+    items = apply_row_order(items, order, id_key="id")
     # Build a coverage/location column
     for item in items:
         parts = []
@@ -6623,10 +6646,10 @@ def project_pipeline_export(
 
 
 @router.get("/{client_id}/projects/pipeline/copy-table")
-def project_pipeline_copy_table(client_id: int, conn=Depends(get_db)):
+def project_pipeline_copy_table(client_id: int, order: str | None = None, conn=Depends(get_db)):
     """Return HTML + plain-text pipeline table for clipboard copy."""
     from fastapi.responses import JSONResponse
-    from policydb.email_templates import build_generic_table
+    from policydb.email_templates import build_generic_table, apply_row_order
     projects = _get_project_pipeline(conn, client_id)
     for p in projects:
         pols = conn.execute("""
@@ -6639,6 +6662,7 @@ def project_pipeline_copy_table(client_id: int, conn=Depends(get_db)):
             status = "Opp" if pol["is_opportunity"] else (pol["renewal_status"] or "Placed")
             coverages.append(f"{pol['policy_type']} ({status})")
         p["coverage_list"] = ", ".join(coverages) if coverages else ""
+    projects = apply_row_order(projects, order, id_key="id")
     columns = [
         ("name", "Project", False),
         ("project_type", "Type", False),
@@ -6719,10 +6743,10 @@ def project_locations_export(
 
 
 @router.get("/{client_id}/projects/locations/copy-table")
-def project_locations_copy_table(client_id: int, conn=Depends(get_db)):
+def project_locations_copy_table(client_id: int, order: str | None = None, conn=Depends(get_db)):
     """Return HTML + plain-text locations table for clipboard copy."""
     from fastapi.responses import JSONResponse
-    from policydb.email_templates import build_generic_table
+    from policydb.email_templates import build_generic_table, apply_row_order
     locations = _get_project_locations(conn, client_id)
     for loc in locations:
         pols = conn.execute("""
@@ -6735,6 +6759,7 @@ def project_locations_copy_table(client_id: int, conn=Depends(get_db)):
             status = "Opp" if pol["is_opportunity"] else (pol["renewal_status"] or "Placed")
             coverages.append(f"{pol['policy_type']} ({status})")
         loc["coverage_list"] = ", ".join(coverages) if coverages else ""
+    locations = apply_row_order(locations, order, id_key="id")
     columns = [
         ("name", "Location", False),
         ("address", "Address", False),

--- a/src/policydb/web/routes/compliance.py
+++ b/src/policydb/web/routes/compliance.py
@@ -775,9 +775,9 @@ def compliance_index(client_id: int, request: Request, conn=Depends(get_db)):
 
 
 @router.get("/client/{client_id}/copy-table")
-def compliance_copy_table(client_id: int, conn=Depends(get_db)):
+def compliance_copy_table(client_id: int, order: str | None = None, conn=Depends(get_db)):
     """Return HTML + plain-text compliance matrix for clipboard copy."""
-    from policydb.email_templates import build_generic_table
+    from policydb.email_templates import build_generic_table, apply_row_order
     data = get_client_compliance_data(conn, client_id)
     rows = []
     for loc in data["locations"]:
@@ -787,6 +787,7 @@ def compliance_copy_table(client_id: int, conn=Depends(get_db)):
             # Trim timestamp to date for a cleaner column
             reviewed_date = reviewed_at.split("T")[0] if reviewed_at else ""
             rows.append({
+                "row_id": f"{loc.get('project', {}).get('id', '')}:{line}",
                 "location": loc_name,
                 "coverage_line": gov.get("coverage_line") or line,
                 "required_limit": gov.get("required_limit"),
@@ -797,6 +798,7 @@ def compliance_copy_table(client_id: int, conn=Depends(get_db)):
                 "reviewed": reviewed_date,
                 "reviewer": gov.get("reviewed_by") or "",
             })
+    rows = apply_row_order(rows, order, id_key="row_id")
     columns = [
         ("location", "Location", False),
         ("coverage_line", "Coverage Line", False),

--- a/src/policydb/web/routes/compose.py
+++ b/src/policydb/web/routes/compose.py
@@ -622,9 +622,15 @@ def compose_copy_table(
     policy_uid: str = Query(""),
     client_id: int = Query(0),
     project_name: str = Query(""),
+    order: str = Query(""),
 ):
     """Return {"html": ..., "text": ...} for clipboard copy of linked policies."""
-    from policydb.email_templates import build_policy_table, _render_policy_table_html, _render_policy_table_text
+    from policydb.email_templates import (
+        _fetch_policy_table_rows,
+        _render_policy_table_html,
+        _render_policy_table_text,
+        apply_row_order,
+    )
 
     rows = None
 
@@ -638,25 +644,30 @@ def compose_copy_table(
                 client_id = issue_row["client_id"] or 0
             if issue_row["program_id"]:
                 rows = [dict(r) for r in conn.execute(
-                    """SELECT policy_type, carrier, access_point, policy_number,
+                    """SELECT id, policy_uid, policy_type, carrier, access_point, policy_number,
                               effective_date, expiration_date, premium, limit_amount, description
                        FROM policies WHERE program_id=? AND archived=0 ORDER BY policy_type""",
                     (issue_row["program_id"],),
                 ).fetchall()]
             elif issue_row["policy_id"]:
                 rows = [dict(r) for r in conn.execute(
-                    """SELECT policy_type, carrier, access_point, policy_number,
+                    """SELECT id, policy_uid, policy_type, carrier, access_point, policy_number,
                               effective_date, expiration_date, premium, limit_amount, description
                        FROM policies WHERE id=? AND archived=0""",
                     (issue_row["policy_id"],),
                 ).fetchall()]
 
     if rows is not None:
+        rows = apply_row_order(rows, order or None, id_key="policy_uid")
         return JSONResponse({"html": _render_policy_table_html(rows), "text": _render_policy_table_text(rows)})
 
     if client_id:
-        result = build_policy_table(conn, client_id, project_name or None)
-        return JSONResponse(result)
+        rows = _fetch_policy_table_rows(conn, client_id, project_name or None)
+        rows = apply_row_order(rows, order or None, id_key="policy_uid")
+        return JSONResponse({
+            "html": _render_policy_table_html(rows),
+            "text": _render_policy_table_text(rows),
+        })
 
     return JSONResponse({"html": "", "text": ""}, status_code=400)
 

--- a/src/policydb/web/templates/base.html
+++ b/src/policydb/web/templates/base.html
@@ -895,9 +895,27 @@ function copyRefTag(btn, tag) {
   });
 }
 
-function copyPolicyTable(url, btn) {
+function copyPolicyTable(url, btn, sourceSelector) {
   var orig = btn.textContent;
   btn.textContent = '…';
+
+  /* If a source table/container selector is given, pass the current DOM row order
+     so the pasted table matches the user's client-side sort. The server looks up
+     each id and reorders the rendered rows to match; unknown ids are ignored. */
+  if (sourceSelector) {
+    var src = document.querySelector(sourceSelector);
+    if (src) {
+      var ids = [];
+      src.querySelectorAll('[data-row-id]').forEach(function(el) {
+        var rid = el.getAttribute('data-row-id');
+        if (rid) ids.push(rid);
+      });
+      if (ids.length) {
+        url += (url.indexOf('?') === -1 ? '?' : '&') + 'order=' + encodeURIComponent(ids.join(','));
+      }
+    }
+  }
+
   fetch(url).then(function(r) { return r.json(); }).then(function(data) {
     var htmlBlob = new Blob([data.html], {type: 'text/html'});
     var textBlob = new Blob([data.text], {type: 'text/plain'});

--- a/src/policydb/web/templates/clients/_contacts.html
+++ b/src/policydb/web/templates/clients/_contacts.html
@@ -8,7 +8,7 @@
     <h2 class="font-semibold text-gray-900 text-sm">Contacts</h2>
     <div class="flex items-center gap-3 no-print">
       <button type="button"
-        onclick="copyPolicyTable('/clients/{{ client.id }}/contacts/copy-table', this)"
+        onclick="copyPolicyTable('/clients/{{ client.id }}/contacts/copy-table', this, '#client-contacts-tbody-{{ client.id }}')"
         class="text-xs text-gray-400 hover:text-marsh"
         title="Copy contacts table to clipboard">Copy Table</button>
       <button type="button" class="text-xs text-marsh hover:underline font-medium"

--- a/src/policydb/web/templates/clients/_external_contacts.html
+++ b/src/policydb/web/templates/clients/_external_contacts.html
@@ -5,7 +5,7 @@
     </h2>
     <div class="flex items-center gap-3 no-print">
       <button type="button"
-        onclick="copyPolicyTable('/clients/{{ client.id }}/external/copy-table', this)"
+        onclick="copyPolicyTable('/clients/{{ client.id }}/external/copy-table', this, '#external-contacts-tbody-{{ client.id }}')"
         class="text-xs text-gray-400 hover:text-marsh"
         title="Copy external stakeholders table to clipboard">Copy Table</button>
       <button type="button" class="text-xs text-marsh hover:underline font-medium"

--- a/src/policydb/web/templates/clients/_opportunities.html
+++ b/src/policydb/web/templates/clients/_opportunities.html
@@ -15,25 +15,25 @@
     </div>
     <div class="flex items-center gap-3">
       <button type="button"
-        onclick="copyPolicyTable('/clients/{{ client.id }}/copy-table/opportunities', this)"
+        onclick="copyPolicyTable('/clients/{{ client.id }}/copy-table/opportunities', this, '#opps-tbody-{{ client.id }}')"
         class="text-xs text-gray-300 hover:text-marsh no-print" title="Copy table to clipboard">Copy Table</button>
       <a href="/policies/new?client={{ client.id }}&opp=1" class="text-xs text-marsh hover:underline">+ New Opportunity</a>
     </div>
   </div>
-  <table class="w-full text-sm">
+  <table class="w-full text-sm" data-sortable>
     <thead>
       <tr class="text-left text-xs text-gray-500 uppercase tracking-wide border-b border-gray-100 bg-gray-50">
-        <th class="px-3 py-2">Line of Business</th>
-        <th class="px-3 py-2">Carrier (Target)</th>
-        <th class="px-3 py-2">Status</th>
-        <th class="px-3 py-2">Target Effective</th>
-        <th class="px-3 py-2">Est. Premium</th>
-        <th class="px-3 py-2">Est. Revenue</th>
-        <th class="px-3 py-2">Placement Team</th>
+        <th class="px-3 py-2" data-sort-key="policy_type">Line of Business</th>
+        <th class="px-3 py-2" data-sort-key="carrier">Carrier (Target)</th>
+        <th class="px-3 py-2" data-sort-key="status">Status</th>
+        <th class="px-3 py-2" data-sort-key="target_effective" data-sort-type="date">Target Effective</th>
+        <th class="px-3 py-2" data-sort-key="premium" data-sort-type="numeric">Est. Premium</th>
+        <th class="px-3 py-2" data-sort-key="revenue" data-sort-type="numeric">Est. Revenue</th>
+        <th class="px-3 py-2" data-sort-key="team">Placement Team</th>
         <th class="px-3 py-2"></th>
       </tr>
     </thead>
-    <tbody class="divide-y divide-gray-50">
+    <tbody class="divide-y divide-gray-50" id="opps-tbody-{{ client.id }}">
       {% for o in opportunities %}
       {% include "policies/_opp_client_row.html" %}
       {% endfor %}

--- a/src/policydb/web/templates/clients/_placement_colleagues.html
+++ b/src/policydb/web/templates/clients/_placement_colleagues.html
@@ -12,7 +12,7 @@
         <button type="button" data-pc-sort="coverage" class="px-1.5 py-0.5 rounded hover:bg-gray-100">Coverages</button>
       </div>
       <button type="button"
-        onclick="copyPolicyTable('/clients/{{ client.id }}/placement/copy-table', this)"
+        onclick="copyPolicyTable('/clients/{{ client.id }}/placement/copy-table', this, '#placement-list')"
         class="text-xs text-gray-400 hover:text-marsh"
         title="Copy placement touchpoints table to clipboard">Copy Table</button>
     </div>
@@ -23,6 +23,7 @@
     {% set active_count = c.policies | rejectattr('is_archived') | list | length %}
     {% set total_count = c.policies | length %}
     <div class="placement-row px-5 py-3"
+         data-row-id="{{ c.id }}"
          data-name="{{ (c.name or '') | lower }}"
          data-org="{{ (c.organization or '') | lower }}"
          data-coverage-count="{{ active_count }}">

--- a/src/policydb/web/templates/clients/_project_locations.html
+++ b/src/policydb/web/templates/clients/_project_locations.html
@@ -23,7 +23,7 @@ window.addLocation = function(clientId) {
       <a href="/clients/{{ client.id }}/locations" onclick="event.stopPropagation()"
         class="text-xs bg-indigo-500 text-white px-3 py-1 rounded hover:bg-indigo-600 transition-colors">Organize by Location</a>
       <button type="button"
-         onclick="event.stopPropagation(); copyPolicyTable('/clients/{{ client.id }}/projects/locations/copy-table', this)"
+         onclick="event.stopPropagation(); copyPolicyTable('/clients/{{ client.id }}/projects/locations/copy-table', this, '#loc-tbody')"
          class="text-xs text-marsh hover:underline">Copy Table</button>
       <a href="/clients/{{ client.id }}/projects/locations/export?format=xlsx" class="text-xs text-marsh hover:underline">XLSX</a>
       <a href="/clients/{{ client.id }}/projects/locations/export?format=csv" class="text-xs text-gray-400 hover:underline">CSV</a>
@@ -61,7 +61,7 @@ window.addLocation = function(clientId) {
       </thead>
       <tbody id="loc-tbody">
         {% for loc in location_projects %}
-        <tr id="loc-row-{{ loc.id }}" class="border-b border-gray-50 hover:bg-gray-50 transition-colors">
+        <tr id="loc-row-{{ loc.id }}" data-row-id="{{ loc.id }}" class="border-b border-gray-50 hover:bg-gray-50 transition-colors">
           <td class="px-3 py-2">
             <div class="flex items-center gap-1.5">
               <span contenteditable="true"

--- a/src/policydb/web/templates/clients/_project_pipeline.html
+++ b/src/policydb/web/templates/clients/_project_pipeline.html
@@ -19,7 +19,7 @@
     </span>
     <div class="ml-auto flex items-center gap-3 no-print">
       <button type="button"
-         onclick="event.stopPropagation(); copyPolicyTable('/clients/{{ client.id }}/projects/pipeline/copy-table', this)"
+         onclick="event.stopPropagation(); copyPolicyTable('/clients/{{ client.id }}/projects/pipeline/copy-table', this, '#pp-tbody')"
          class="text-xs text-marsh hover:underline">Copy Table</button>
       <a href="/clients/{{ client.id }}/projects/pipeline/export?format=xlsx"
          onclick="event.stopPropagation()"

--- a/src/policydb/web/templates/clients/_project_pipeline_row.html
+++ b/src/policydb/web/templates/clients/_project_pipeline_row.html
@@ -1,4 +1,4 @@
-<tr id="pp-row-{{ p.id }}" class="pp-row hover:bg-gray-50/60 align-middle border-b border-gray-100">
+<tr id="pp-row-{{ p.id }}" data-row-id="{{ p.id }}" class="pp-row hover:bg-gray-50/60 align-middle border-b border-gray-100">
   {# Type — dropdown #}
   <td class="px-2 py-2">
     {% include "clients/_project_type_badge.html" %}

--- a/src/policydb/web/templates/clients/_team_contacts.html
+++ b/src/policydb/web/templates/clients/_team_contacts.html
@@ -5,7 +5,7 @@
     </h2>
     <div class="flex items-center gap-3 no-print">
       <button type="button"
-        onclick="copyPolicyTable('/clients/{{ client.id }}/team/copy-table', this)"
+        onclick="copyPolicyTable('/clients/{{ client.id }}/team/copy-table', this, '#team-contacts-tbody-{{ client.id }}')"
         class="text-xs text-gray-400 hover:text-marsh"
         title="Copy internal team table to clipboard">Copy Table</button>
       <button type="button" class="text-xs text-marsh hover:underline font-medium"

--- a/src/policydb/web/templates/clients/project.html
+++ b/src/policydb/web/templates/clients/project.html
@@ -28,7 +28,7 @@
           {% if project.updated_at_fmt %}saved {{ project.updated_at_fmt }}{% endif %}
         </span>
         <button type="button"
-           onclick="copyPolicyTable('/clients/{{ client.id }}/copy-table?project={{ project.name | urlencode }}', this)"
+           onclick="copyPolicyTable('/clients/{{ client.id }}/copy-table?project={{ project.name | urlencode }}', this, '#project-policies-tbody-{{ project.id }}')"
            class="text-xs bg-gray-100 hover:bg-gray-200 text-gray-600 px-2.5 py-1 rounded transition-colors no-print">Copy Table</button>
         <a href="/clients/{{ client.id }}/projects/{{ project.id }}/pdf"
            class="text-xs bg-gray-100 hover:bg-gray-200 text-gray-600 px-2.5 py-1 rounded transition-colors no-print">Export PDF ↓</a>
@@ -55,7 +55,7 @@
         </span>
         <div class="flex gap-3 no-print">
           <button type="button"
-            onclick="copyPolicyTable('/clients/{{ client.id }}/copy-table?project={{ project.name | urlencode }}', this)"
+            onclick="copyPolicyTable('/clients/{{ client.id }}/copy-table?project={{ project.name | urlencode }}', this, '#project-policies-tbody-{{ project.id }}')"
             class="text-[11px] text-gray-500 hover:text-marsh">Copy Table</button>
           <a href="/policies/new?client={{ client.id }}&project={{ project.id }}"
              class="text-[11px] text-marsh hover:underline">+ Add Policy</a>
@@ -63,27 +63,27 @@
       </div>
       {% if policies %}
       <div class="overflow-x-auto">
-        <table class="w-full text-sm">
+        <table class="w-full text-sm" data-sortable>
           <thead>
             <tr class="text-left text-[10px] text-gray-400 uppercase tracking-wide bg-gray-50/50 border-b border-gray-100">
-              <th class="px-3 py-2">UID</th>
-              <th class="px-3 py-2">Line of Business</th>
-              <th class="px-3 py-2">Carrier</th>
-              <th class="px-3 py-2">Expires</th>
-              <th class="px-3 py-2 text-right">Premium</th>
-              <th class="px-3 py-2">Status</th>
+              <th class="px-3 py-2" data-sort-key="uid">UID</th>
+              <th class="px-3 py-2" data-sort-key="line">Line of Business</th>
+              <th class="px-3 py-2" data-sort-key="carrier">Carrier</th>
+              <th class="px-3 py-2" data-sort-key="expires" data-sort-type="date">Expires</th>
+              <th class="px-3 py-2 text-right" data-sort-key="premium" data-sort-type="numeric">Premium</th>
+              <th class="px-3 py-2" data-sort-key="status">Status</th>
               <th class="px-3 py-2 w-16"></th>
             </tr>
           </thead>
-          <tbody class="divide-y divide-gray-50">
+          <tbody class="divide-y divide-gray-50" id="project-policies-tbody-{{ project.id }}">
             {% for p in policies %}
-            <tr class="hover:bg-gray-50">
+            <tr class="hover:bg-gray-50" data-row-id="{{ p.policy_uid }}">
               <td class="px-3 py-2 font-mono text-xs text-gray-400">
                 <a href="/policies/{{ p.policy_uid }}/edit" class="hover:text-marsh">{{ p.policy_uid }}</a>
               </td>
               <td class="px-3 py-2 font-medium text-gray-800">{{ p.policy_type or '' }}</td>
               <td class="px-3 py-2 text-gray-600 truncate max-w-[150px]" title="{{ p.carrier or '' }}">{{ p.carrier or '—' }}</td>
-              <td class="px-3 py-2 whitespace-nowrap">
+              <td class="px-3 py-2 whitespace-nowrap" data-sort-value="{{ p.expiration_date or '' }}">
                 {% if p.expiration_date %}
                 <span class="text-xs text-gray-600 tabular-nums">{{ p.expiration_date }}</span>
                 {% if p.days_to_renewal is not none and p.days_to_renewal <= 90 %}
@@ -94,7 +94,7 @@
                 {% endif %}
                 {% else %}—{% endif %}
               </td>
-              <td class="px-3 py-2 text-right tabular-nums text-gray-700">
+              <td class="px-3 py-2 text-right tabular-nums text-gray-700" data-sort-value="{{ p.premium or 0 }}">
                 {{ p.premium | currency if p.premium else '—' }}
               </td>
               <td class="px-3 py-2">

--- a/src/policydb/web/templates/policies/_opp_client_row.html
+++ b/src/policydb/web/templates/policies/_opp_client_row.html
@@ -4,7 +4,7 @@
   'Submitted': 'bg-purple-100 text-purple-700',
   'Pending Bind': 'bg-amber-100 text-amber-700'
 } %}
-<tr id="opp-row-{{ o.policy_uid }}" class="hover:bg-amber-50/40 align-top">
+<tr id="opp-row-{{ o.policy_uid }}" data-row-id="{{ o.policy_uid }}" class="hover:bg-amber-50/40 align-top">
   <td class="px-3 py-2">
     <span class="font-medium text-gray-800">{{ o.policy_type or '—' }}</span>
     {% if o.project_name %}<p class="text-xs text-gray-400 italic">{{ o.project_name }}</p>{% endif %}
@@ -30,10 +30,10 @@
   <td class="px-3 py-2 text-xs text-gray-600 whitespace-nowrap">
     {{ o.target_effective_date or '—' }}
   </td>
-  <td class="px-3 py-2 text-right tabular-nums text-gray-600 text-xs">
+  <td class="px-3 py-2 text-right tabular-nums text-gray-600 text-xs" data-sort-value="{{ o.premium or 0 }}">
     {% if o.premium %}{{ o.premium | currency }}{% else %}—{% endif %}
   </td>
-  <td class="px-3 py-2 text-right tabular-nums text-xs">
+  <td class="px-3 py-2 text-right tabular-nums text-xs" data-sort-value="{{ o.commission_amount or 0 }}">
     {% if o.commission_amount %}
     <span class="text-emerald-600 font-medium">{{ o.commission_amount | currency }}</span>
     {% elif o.premium and not o.commission_rate %}

--- a/src/policydb/web/templates/policies/_policy_renew_row.html
+++ b/src/policydb/web/templates/policies/_policy_renew_row.html
@@ -1,4 +1,4 @@
-<tr id="renew-row-{{ p.policy_uid }}" class="hover:bg-gray-50 text-xs">
+<tr id="renew-row-{{ p.policy_uid }}" data-row-id="policy:{{ p.policy_uid }}" class="hover:bg-gray-50 text-xs">
   <td class="px-2 py-1.5 w-8">
     <input type="checkbox" class="renewal-check rounded border-gray-300" value="{{ p.policy_uid }}"
       onchange="updateRenewalBulkBar()">

--- a/src/policydb/web/templates/policies/_program_renew_row.html
+++ b/src/policydb/web/templates/policies/_program_renew_row.html
@@ -1,5 +1,5 @@
 {# Program row for the renewal pipeline — rendered when p._is_program is True #}
-<tr id="pgm-row-{{ p.program_uid }}" class="hover:bg-indigo-50/30 border-l-2 border-indigo-400 bg-indigo-50/10 text-xs">
+<tr id="pgm-row-{{ p.program_uid }}" data-row-id="program:{{ p.program_uid }}" class="hover:bg-indigo-50/30 border-l-2 border-indigo-400 bg-indigo-50/10 text-xs">
   <td class="px-2 py-1.5 w-8">
     <input type="checkbox" class="renewal-check rounded border-gray-300"
       value="{{ p.program_uid }}" data-subject-type="program"

--- a/src/policydb/web/templates/renewals.html
+++ b/src/policydb/web/templates/renewals.html
@@ -23,7 +23,7 @@
       <span class="border-l border-gray-200 h-6 mx-1"></span>
       {%- set export_qs = 'window=' ~ window ~ '&urgency=' ~ urgency ~ '&status=' ~ (status | urlencode) ~ '&client_id=' ~ (client_id or 0) -%}
       <button type="button"
-        onclick="copyPolicyTable('/renewals/copy-table?{{ export_qs }}', this)"
+        onclick="copyPolicyTable('/renewals/copy-table?{{ export_qs }}', this, '#renewals-table tbody')"
         class="border border-gray-300 hover:border-marsh text-gray-700 hover:text-marsh text-sm font-medium px-3 py-1.5 rounded-lg transition-colors">Copy Table</button>
       <a href="/renewals/export?{{ export_qs }}&fmt=csv" class="border border-gray-300 hover:border-marsh text-gray-700 hover:text-marsh text-sm font-medium px-3 py-1.5 rounded-lg transition-colors">CSV ↓</a>
       <a href="/renewals/export?{{ export_qs }}&fmt=xlsx" class="border border-green-600 hover:bg-green-600 text-green-700 hover:text-white text-sm font-medium px-3 py-1.5 rounded-lg transition-colors">XLSX ↓</a>


### PR DESCRIPTION
## Summary
- New `apply_row_order(rows, order, id_key)` helper in `email_templates.py` reorders rendered rows to match a caller-supplied id list. Unknown ids are ignored; unspecified rows are appended (never lost).
- `copyPolicyTable(url, btn, sourceSelector?)` in `base.html` reads `[data-row-id]` from the source container in DOM order and appends `?order=id1,id2,...` to the request URL. Old 2-arg calls still work (falls back to server order).
- All 13 copy-table endpoints (`clients.py`, `activities.py`, `compose.py`, `compliance.py`) accept `order=` and apply it with the right `id_key` for their data (`id`, `policy_uid`, or composite `policy:UID` / `program:UID` / `{project_id}:{line}` keys for renewals and compliance).
- Source tables marked sortable where they weren't already (opportunities, project location policies) and every row carries `data-row-id`. Contact tables, placement touchpoints, project pipeline, locations, and renewals all wired up.
- `policydb-copy-table` skill doc rewritten: documents the new pattern and lists every deployment with its `id_key` and source selector.

Grouped or non-tabular sources (main `_tab_policies.html` copy, `_project_header.html` per-group copy, `_summary_bar.html` schedule copy, `_request_bundle.html` item cards, compose slideover, compliance banner) keep their existing behavior — the 3rd JS arg is intentionally omitted so the server returns its default order.

## Test plan
- [x] `apply_row_order` unit sanity tests — pass, reverse, unknown ids, missing rows all behave correctly.
- [x] Backend: `GET /clients/2/copy-table?order=POL-049,POL-044,POL-040` reorders policies correctly.
- [x] Backend: `GET /clients/1/external/copy-table?order=19,22` reverses the two external contacts.
- [x] Browser: sorting External Stakeholders by Name desc flips the DOM `data-row-id` values and the outgoing fetch URL flips from `order=22,19` to `order=19,22`.
- [ ] Paste into Outlook after sorting each of: contacts, opportunities, renewals pipeline, project pipeline, locations — confirm order matches the visible sort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)