### PR TITLE
feat(today): row-click drilldown + clickable policy refs (post-phase-2 polish)

### DIFF
--- a/src/policydb/web/static/css/today.css
+++ b/src/policydb/web/static/css/today.css
@@ -151,8 +151,11 @@
 
 .tabulator .tabulator-row:nth-child(5n) { border-bottom-color: var(--border); }
 
-.tabulator .tabulator-row:hover { background: #FBFCFF; }
+.tabulator .tabulator-row:hover { background: #FBFCFF; cursor: pointer; }
 .tabulator .tabulator-row:hover .actions-btn { opacity: 1; }
+/* Undo the cursor on non-clickable cells */
+.tabulator .tabulator-row:hover .today-check,
+.tabulator .tabulator-row:hover .actions-btn { cursor: default; }
 .tabulator .tabulator-row:hover .subj {
   text-decoration: underline;
   text-decoration-color: var(--accent);
@@ -216,6 +219,13 @@
   border-radius: 3px;
   font-size: 10px;
   font-family: "JetBrains Mono", Menlo, monospace;
+}
+.ref-pill-link {
+  text-decoration: none;
+}
+.ref-pill-link:hover .ref-pill {
+  background: var(--accent);
+  color: #fff;
 }
 
 .due.red { color: var(--red); font-weight: 500; }

--- a/src/policydb/web/static/js/tabulator_today.js
+++ b/src/policydb/web/static/js/tabulator_today.js
@@ -52,8 +52,10 @@
     if (!row.client_id && !row.policy_uid) {
       return '<em class="muted">Standalone</em>';
     }
-    const policy = row.policy_uid
-      ? `<span class="ref-pill">${escapeHtml(row.policy_uid)}</span> `
+    const policyUid = row.policy_uid;
+    const policy = policyUid
+      ? `<a href="/policies/${encodeURIComponent(policyUid)}/edit" class="ref-pill-link">`
+        + `<span class="ref-pill">${escapeHtml(policyUid)}</span></a> `
       : "";
     const client = row.client_name
       ? `<a href="/clients/${encodeURIComponent(row.client_id)}">${escapeHtml(row.client_name)}</a>`
@@ -132,6 +134,14 @@
         { column: "id", dir: "asc" },
       ],
       tableBuilt: function () { installSortCaret(this); },
+      rowClick: function (e, row) {
+        // Ignore clicks on the check, actions, or any <a>/<button> within the row —
+        // those have their own handlers. Only open slideover for "body" clicks.
+        const target = e.target;
+        if (!target) return;
+        if (target.closest(".today-check, .actions-btn, a, button")) return;
+        if (window.openTaskSlideover) window.openTaskSlideover(row.getData().id);
+      },
       columns: [
         { title: "", field: "_check", width: 40, hozAlign: "center",
           formatter: completeCheckboxFormatter, cellClick: (e, cell) => onCompleted?.(cell.getRow().getData()) },

--- a/src/policydb/web/templates/action_center/_today.html
+++ b/src/policydb/web/templates/action_center/_today.html
@@ -85,6 +85,24 @@
       }, 400);
     }
 
+    window.openTaskSlideover = async function (id) {
+      const panel = document.getElementById("fu-edit-content");
+      if (!panel) return;
+      try {
+        const r = await fetch(`/activities/${id}/edit-slideover`);
+        if (!r.ok) {
+          console.warn(`Failed to load task detail: ${r.status}`);
+          return;
+        }
+        panel.innerHTML = await r.text();
+        if (typeof window.openFollowupEdit === "function") {
+          window.openFollowupEdit();
+        }
+      } catch (err) {
+        console.warn("openTaskSlideover failed", err);
+      }
+    };
+
     function showUndoToast(id, subject) {
       const toast = document.createElement("div");
       toast.className = "undo-toast";


### PR DESCRIPTION
## Summary
Follow-up polish on Phase 2 Today tab.

- Row click anywhere on a task row (except the ✓ checkbox and ⋯ menu) opens the existing activity edit slideover (`/activities/{id}/edit-slideover`)
- `policy_uid` ref-pills now `<a href="/policies/{uid}/edit">` with hover affordance
- Cursor becomes pointer on row hover (except interactive cells)

## Why
User flagged during Phase 2 test-drive: "not able to click anything inline to bring up additional detail." The slideover panel + endpoint exist and are used by Focus Queue / Plan Week / Inbox; this just wires Tabulator's `rowClick` to them.

## Test plan
- [x] Smoke: Today tab + /activities/N/edit-slideover + /policies/UID/edit all return 200
- [ ] Manual: click row body → slideover opens with task fields editable
- [ ] Manual: click ✓ → completes (no slideover)
- [ ] Manual: click ⋯ → snooze menu (no slideover)
- [ ] Manual: click policy ref-pill → navigates to /policies/{uid}/edit
- [ ] Manual: click client name → navigates to /clients/{id}

## Scope held
- No slideover-content changes (reusing existing)
- No schema / route changes
- Single commit, 3 files