### PR TITLE
fix(today): register rowClick via table.on() — row drilldown was silently not firing

### DIFF
--- a/src/policydb/web/static/js/tabulator_today.js
+++ b/src/policydb/web/static/js/tabulator_today.js
@@ -134,14 +134,6 @@
         { column: "id", dir: "asc" },
       ],
       tableBuilt: function () { installSortCaret(this); },
-      rowClick: function (e, row) {
-        // Ignore clicks on the check, actions, or any <a>/<button> within the row —
-        // those have their own handlers. Only open slideover for "body" clicks.
-        const target = e.target;
-        if (!target) return;
-        if (target.closest(".today-check, .actions-btn, a, button")) return;
-        if (window.openTaskSlideover) window.openTaskSlideover(row.getData().id);
-      },
       columns: [
         { title: "", field: "_check", width: 40, hozAlign: "center",
           formatter: completeCheckboxFormatter, cellClick: (e, cell) => onCompleted?.(cell.getRow().getData()) },

--- a/src/policydb/web/templates/action_center/_today.html
+++ b/src/policydb/web/templates/action_center/_today.html
@@ -314,6 +314,16 @@
       }
     }
     table.on("dataFiltered", () => refreshEmptyState(table));
+    // Row-click opens the activity edit slideover. Must be registered here
+    // (not in tabulator_today.js options) — Tabulator 6.3's options-dict
+    // `rowClick` doesn't register, and the external event system isn't ready
+    // at `tableBuilt` time either.
+    table.on("rowClick", (e, row) => {
+      const target = e.target;
+      if (!target) return;
+      if (target.closest(".today-check, .actions-btn, a, button")) return;
+      if (window.openTaskSlideover) window.openTaskSlideover(row.getData().id);
+    });
   })();
 
   // Grid-independent wiring — works in both populated and empty states.


### PR DESCRIPTION
## Summary
Follow-up fix to #283. Row-click slideover wasn't opening in the browser despite smoke tests passing.

## Root cause
Tabulator 6.3's `rowClick` callback declared inside the `options` object alongside `tableBuilt` never registered with the external event system. Verified via Playwright:

- `t.externalEvents.events` returned only `dataFiltered` (not `rowClick`) after construction
- `openTaskSlideover(41)` worked perfectly when called directly

## Fix
Register `rowClick` via `table.on("rowClick", ...)` from `_today.html` alongside the already-working `dataFiltered` listener.

## Verified
- `registeredEvents: ["dataFiltered", "rowClick"]` ✓
- Clicking a subject cell opens Edit Follow-Up slideover with populated fields ✓
- ✓ checkbox and ⋯ button still get their own handlers (not the slideover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)