### PR TITLE
fix(today): route issue rows to /issues/*/edit-slideover

### DIFF
--- a/src/policydb/web/templates/action_center/_today.html
+++ b/src/policydb/web/templates/action_center/_today.html
@@ -85,11 +85,14 @@
       }, 400);
     }
 
-    window.openTaskSlideover = async function (id) {
+    window.openTaskSlideover = async function (id, kind) {
       const panel = document.getElementById("fu-edit-content");
       if (!panel) return;
+      const url = kind === "issue"
+        ? `/issues/${id}/edit-slideover`
+        : `/activities/${id}/edit-slideover`;
       try {
-        const r = await fetch(`/activities/${id}/edit-slideover`);
+        const r = await fetch(url);
         if (!r.ok) {
           console.warn(`Failed to load task detail: ${r.status}`);
           return;
@@ -322,7 +325,8 @@
       const target = e.target;
       if (!target) return;
       if (target.closest(".today-check, .actions-btn, a, button")) return;
-      if (window.openTaskSlideover) window.openTaskSlideover(row.getData().id);
+      const data = row.getData();
+      if (window.openTaskSlideover) window.openTaskSlideover(data.id, data.kind);
     });
   })();
 


### PR DESCRIPTION
## Summary
- Today rows with `kind='issue'` now load the issue-specific edit slideover (severity, status, issue UID) instead of the generic activity slideover.
- `openTaskSlideover(id, kind)` branches on `kind === "issue"` to hit `/issues/{id}/edit-slideover`; followup rows continue to hit `/activities/{id}/edit-slideover`.
- Row-click handler in `_today.html` now passes both `data.id` and `data.kind` to the slideover helper.

Closes a gap left open after Phase 2 / PR #283: issue-kind Today rows used to open the wrong slideover template.

## Test plan
- [x] `pytest tests/test_today_routes.py tests/test_today_view.py tests/test_standalone_tasks.py tests/test_paths.py` — 29 passed
- [x] Manual QA with seeded issue row (id=315, severity=High):
  - Clicking the issue row fires `GET /issues/315/edit-slideover` → "Edit Issue" panel with Severity, Status, Subject, Details, Re-check in, issue UID
  - Clicking a Task (followup) row still fires `GET /activities/{id}/edit-slideover` → "Edit Follow-Up" panel (regression check)
  - Direct calls to `openTaskSlideover(id, "issue")` / `("followup")` / `(no kind)` produce expected URLs
- [x] Temp issue row cleaned up from dev DB after QA

🤖 Generated with [Claude Code](https://claude.com/claude-code)