### PR TITLE
fix(renewals): activity-log save now confirms visibly + fix 500 on post-save row render

### DIFF
--- a/src/policydb/web/routes/policies.py
+++ b/src/policydb/web/routes/policies.py
@@ -666,11 +666,13 @@ def policy_row_log_post(
     if not policy:
         return HTMLResponse("", status_code=404)
 
-    return templates.TemplateResponse("policies/_policy_row.html", {
+    resp = templates.TemplateResponse("policies/_policy_row.html", {
         "request": request,
         "p": dict(policy),
         "renewal_statuses": _renewal_statuses(),
     })
+    resp.headers["HX-Trigger"] = '{"activityLogged": "Activity logged"}'
+    return resp
 
 
 @router.get("/{policy_uid}/dash/row", response_class=HTMLResponse)
@@ -739,11 +741,13 @@ def policy_dash_log_post(
     if not policy:
         return HTMLResponse("", status_code=404)
 
-    return templates.TemplateResponse("policies/_policy_dash_row.html", {
+    resp = templates.TemplateResponse("policies/_policy_dash_row.html", {
         "request": request,
         "p": dict(policy),
         "renewal_statuses": _renewal_statuses(),
     })
+    resp.headers["HX-Trigger"] = '{"activityLogged": "Activity logged"}'
+    return resp
 
 
 def _renew_mailto_subject(conn, policy_uid: str) -> str:
@@ -762,9 +766,10 @@ def policy_renew_row(request: Request, policy_uid: str, conn=Depends(get_db)):
         return HTMLResponse("", status_code=404)
     p = dict(policy)
     rows_progress = _attach_milestone_progress(conn, [p])
+    rows_ready = _attach_readiness_score(conn, rows_progress)
     return templates.TemplateResponse("policies/_policy_renew_row.html", {
         "request": request,
-        "p": rows_progress[0],
+        "p": rows_ready[0],
         "mailto_subject": _renew_mailto_subject(conn, uid),
     })
 
@@ -824,11 +829,14 @@ def policy_renew_log_post(
 
     p = dict(policy)
     rows_progress = _attach_milestone_progress(conn, [p])
-    return templates.TemplateResponse("policies/_policy_renew_row.html", {
+    rows_ready = _attach_readiness_score(conn, rows_progress)
+    resp = templates.TemplateResponse("policies/_policy_renew_row.html", {
         "request": request,
-        "p": rows_progress[0],
+        "p": rows_ready[0],
         "mailto_subject": _renew_mailto_subject(conn, uid),
     })
+    resp.headers["HX-Trigger"] = '{"activityLogged": "Activity logged"}'
+    return resp
 
 
 

--- a/src/policydb/web/routes/programs.py
+++ b/src/policydb/web/routes/programs.py
@@ -1531,11 +1531,13 @@ def program_renew_log_save(
     p = _build_program_row_context(conn, program_uid)
     from policydb.queries import attach_renewal_issues
     attach_renewal_issues(conn, [p])
-    return templates.TemplateResponse("policies/_program_renew_row.html", {
+    resp = templates.TemplateResponse("policies/_program_renew_row.html", {
         "request": request,
         "p": p,
         "renewal_statuses": _renewal_statuses(),
     })
+    resp.headers["HX-Trigger"] = '{"activityLogged": "Activity logged"}'
+    return resp
 
 
 @router.get("/programs/{program_uid}/renew/row", response_class=HTMLResponse)

--- a/src/policydb/web/routes/review.py
+++ b/src/policydb/web/routes/review.py
@@ -631,10 +631,12 @@ def policy_row_log_save(
     if not r:
         return HTMLResponse("")
     suggestions = suggest_profile(conn)
-    return templates.TemplateResponse(
+    resp = templates.TemplateResponse(
         "review/_policy_row.html",
         _policy_row_context(request, r, suggestions=suggestions),
     )
+    resp.headers["HX-Trigger"] = '{"activityLogged": "Activity logged"}'
+    return resp
 
 
 # ── Policy Review Slideover ──────────────────────────────────────────────────

--- a/src/policydb/web/templates/policies/_policy_dash_row_log.html
+++ b/src/policydb/web/templates/policies/_policy_dash_row_log.html
@@ -5,6 +5,7 @@
       hx-post="/policies/{{ p.policy_uid }}/dash/log"
       hx-target="#dash-row-{{ p.policy_uid }}"
       hx-swap="outerHTML"
+      hx-disabled-elt="find button[type='submit']"
       class="space-y-3">
 
       <input type="hidden" name="client_id" value="{{ p.client_id }}">

--- a/src/policydb/web/templates/policies/_policy_renew_row_log.html
+++ b/src/policydb/web/templates/policies/_policy_renew_row_log.html
@@ -5,6 +5,7 @@
       hx-post="/policies/{{ p.policy_uid }}/renew/log"
       hx-target="#renew-row-{{ p.policy_uid }}"
       hx-swap="outerHTML"
+      hx-disabled-elt="find button[type='submit']"
       class="space-y-3">
 
       <input type="hidden" name="client_id" value="{{ p.client_id }}">

--- a/src/policydb/web/templates/policies/_policy_row_log.html
+++ b/src/policydb/web/templates/policies/_policy_row_log.html
@@ -5,6 +5,7 @@
       hx-post="/policies/{{ p.policy_uid }}/row/log"
       hx-target="#row-{{ p.policy_uid }}"
       hx-swap="outerHTML"
+      hx-disabled-elt="find button[type='submit']"
       class="space-y-3">
 
       <input type="hidden" name="client_id" value="{{ p.client_id }}">

--- a/src/policydb/web/templates/programs/_program_renew_row_log.html
+++ b/src/policydb/web/templates/programs/_program_renew_row_log.html
@@ -5,6 +5,7 @@
       hx-post="/programs/{{ p.program_uid }}/renew/log"
       hx-target="#pgm-row-{{ p.program_uid }}"
       hx-swap="outerHTML"
+      hx-disabled-elt="find button[type='submit']"
       class="space-y-3">
 
       <!-- Row 1: Type, Subject, Duration, Follow-Up -->

--- a/src/policydb/web/templates/review/_policy_row_log.html
+++ b/src/policydb/web/templates/review/_policy_row_log.html
@@ -4,6 +4,7 @@
     <form hx-post="/review/policies/{{ p.policy_uid }}/row/log"
           hx-target="#review-row-{{ p.policy_uid }}"
           hx-swap="outerHTML"
+          hx-disabled-elt="find button[type='submit']"
           class="space-y-3">
 
       <input type="hidden" name="client_id" value="{{ p.client_id }}">


### PR DESCRIPTION
## Summary
Three related fixes to the inline "Log Activity" flow on the Renewal Pipeline and other row-log variants.

1. **Fix 500 on post-save row render** (root cause). The renewals row template (`_policy_renew_row.html`) reads `p.days_since_touch` but the POST handler built a single-row response without calling `_attach_readiness_score`, so the template crashed with `UndefinedError`. The activity saved (because `conn.commit()` ran first) but HTMX never swapped because the response was a 500. Same fix applied to `GET /policies/{uid}/renew/row` (Cancel button target), which was also broken.
2. **Toast confirmation**. POST endpoints now set `HX-Trigger: {"activityLogged": "Activity logged"}` so the existing `activityLogged` listener in `base.html:1727` fires a "✓ Activity logged" toast.
3. **Double-submit guard**. Forms get `hx-disabled-elt="find button[type='submit']"` so the Save button is disabled during the request.

Applied to all 5 inline log endpoints: `policies row/log`, `policies dash/log`, `policies renew/log`, `programs renew/log`, `review row/log` (and matching templates).

## Test plan
- [x] Manual QA via Playwright on Renewal Pipeline: open log form → submit → `activityLogged` event fires with value "Activity logged", toast shows in green, button is disabled mid-request, row swaps from form to display row.
- [x] `GET /policies/POL-008/renew/row` now returns 200 (was 500 pre-fix).
- [x] `GET /policies/POL-008/dash/row` and `/row` still return 200 (regression check).
- [x] Test activity seeded during QA cleaned up from dev DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)