### PR TITLE
fix(timeline): profile apply now confirms visibly (select persists + toast)

### DIFF
--- a/src/policydb/views.py
+++ b/src/policydb/views.py
@@ -54,6 +54,7 @@ SELECT
         p.underwriter_contact
     ) AS underwriter_contact,
     p.renewal_status,
+    p.milestone_profile,
     p.commission_rate,
     p.prior_premium,
     p.account_exec,

--- a/src/policydb/web/routes/policies.py
+++ b/src/policydb/web/routes/policies.py
@@ -3439,13 +3439,21 @@ def policy_timeline_set_profile(
     timeline = get_policy_timeline(conn, uid)
     suggestions = suggest_profile(conn, policy_uid=uid) if not timeline else {}
 
-    return templates.TemplateResponse("policies/_timeline.html", {
+    resp = templates.TemplateResponse("policies/_timeline.html", {
         "request": request,
         "policy": policy_dict,
         "timeline": timeline,
         "milestone_profiles": cfg.get("milestone_profiles", []),
         "suggested_profile": suggestions.get(uid, ""),
     })
+    if new_profile:
+        toast_msg = f"Profile '{new_profile}' applied"
+        if not timeline:
+            toast_msg += " — no milestones within horizon"
+    else:
+        toast_msg = "Profile cleared"
+    resp.headers["HX-Trigger"] = json.dumps({"activityLogged": toast_msg})
+    return resp
 
 
 @router.get("/{policy_uid}/edit", response_class=HTMLResponse)


### PR DESCRIPTION
## Summary
Two related fixes so that applying a milestone profile in the Workflow tab produces clear, visible confirmation.

1. **Saved profile now appears as selected on initial render.** `v_policy_status` didn't include the `milestone_profile` column, so `get_policy_by_uid()` returned a row without it. In `_timeline.html`, `policy.milestone_profile` was always Undefined on the initial GET, causing the template to fall through to the *"No timeline milestones configured. Select a profile above and click Apply…"* empty state even when a profile was actually saved. Fix: expose `p.milestone_profile` in the view.

2. **Apply now fires a toast.** The POST response sets `HX-Trigger: {"activityLogged": …}` with a context-aware message — plain "Profile 'X' applied" when milestones generate, or "Profile 'X' applied — no milestones within horizon" when the apply succeeded but the policy is outside the 180-day horizon (so the user isn't confused by an empty timeline on, e.g., an expired policy).

## Test plan
- [x] POL-011 (has saved profile "Standard Renewal") GET `/policies/POL-011/timeline` — select shows *Standard Renewal* with the *Saved* label; no confusing "No timeline configured" message.
- [x] POL-008 (expired, profile cleared) POST apply *Standard Renewal* — response includes `HX-Trigger: activityLogged` with "… — no milestones within horizon"; template shows "Profile Standard Renewal is applied, but no milestones fall within the current horizon window."
- [x] POL-009 (renews 2026-06-01) POST apply *Standard Renewal* — 3 milestones generate (Client Approved, Binder Requested, Policy Received); toast fires with "Profile 'Standard Renewal' applied".
- [x] QA test DB state restored after verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)